### PR TITLE
Make Control.Monad.Either a public import in JS.Util.

### DIFF
--- a/src/JS/Util.idr
+++ b/src/JS/Util.idr
@@ -3,7 +3,7 @@
 ||| own package.
 module JS.Util
 
-import Control.Monad.Either
+import public Control.Monad.Either
 import Data.Maybe
 
 export


### PR DESCRIPTION
@stefan-hoeck's idea from https://github.com/idris-lang/Idris2/issues/1856.

This fixes
`Error: Control.Monad.Error.Either.EitherT not a data type`
when compiling `JS.Callback`.

