### PR TITLE
[ refactor, cleanup ] drop unneded fromString conversions

### DIFF
--- a/docs/src/Tutorial.md
+++ b/docs/src/Tutorial.md
@@ -80,7 +80,7 @@ prog = do btn <- createElement Button
           textContent btn .= "Click me!"
           Element.id btn .= "the_button"
 
-          txt <- newElement Input [ type =. "text"
+          txt <- newElement Input [ HTMLInputElement.type =. "text"
                                   , placeholder =. "Enter your name here."
                                   ]
 
@@ -573,3 +573,6 @@ types this can be sometimes quite convenient.
 ### Web IDL members
 
 To be added...
+
+<!-- vi: filetype=idris2:syntax=markdown
+-->

--- a/src/Web/Internal/AnimationTypes.idr
+++ b/src/Web/Internal/AnimationTypes.idr
@@ -37,13 +37,6 @@ namespace AnimationPlayState
   read "finished" = Just Finished
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (AnimationPlayState.read s)}
-    -> AnimationPlayState
-  fromString s = fromJust $ read s
-
   export
   ToFFI AnimationPlayState String where
     toFFI = show
@@ -83,10 +76,6 @@ namespace FillMode
   read "auto" = Just Auto
   read _ = Nothing
 
-  public export
-  fromString : (s : String) -> {auto 0 _ : IsJust (FillMode.read s)} -> FillMode
-  fromString s = fromJust $ read s
-
   export
   ToFFI FillMode String where
     toFFI = show
@@ -124,13 +113,6 @@ namespace PlaybackDirection
   read "alternate-reverse" = Just AlternateReverse
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (PlaybackDirection.read s)}
-    -> PlaybackDirection
-  fromString s = fromJust $ read s
-
   export
   ToFFI PlaybackDirection String where
     toFFI = show
@@ -163,13 +145,6 @@ namespace IterationCompositeOperation
   read "replace" = Just Replace
   read "accumulate" = Just Accumulate
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (IterationCompositeOperation.read s)}
-    -> IterationCompositeOperation
-  fromString s = fromJust $ read s
 
   export
   ToFFI IterationCompositeOperation String where
@@ -205,13 +180,6 @@ namespace CompositeOperation
   read "add" = Just Add
   read "accumulate" = Just Accumulate
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CompositeOperation.read s)}
-    -> CompositeOperation
-  fromString s = fromJust $ read s
 
   export
   ToFFI CompositeOperation String where
@@ -249,13 +217,6 @@ namespace CompositeOperationOrAuto
   read "accumulate" = Just Accumulate
   read "auto" = Just Auto
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CompositeOperationOrAuto.read s)}
-    -> CompositeOperationOrAuto
-  fromString s = fromJust $ read s
 
   export
   ToFFI CompositeOperationOrAuto String where

--- a/src/Web/Internal/ClipboardTypes.idr
+++ b/src/Web/Internal/ClipboardTypes.idr
@@ -35,13 +35,6 @@ namespace PresentationStyle
   read "attachment" = Just Attachment
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (PresentationStyle.read s)}
-    -> PresentationStyle
-  fromString s = fromJust $ read s
-
   export
   ToFFI PresentationStyle String where
     toFFI = show

--- a/src/Web/Internal/CssomviewTypes.idr
+++ b/src/Web/Internal/CssomviewTypes.idr
@@ -35,13 +35,6 @@ namespace ScrollBehavior
   read "smooth" = Just Smooth
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ScrollBehavior.read s)}
-    -> ScrollBehavior
-  fromString s = fromJust $ read s
-
   export
   ToFFI ScrollBehavior String where
     toFFI = show
@@ -79,13 +72,6 @@ namespace ScrollLogicalPosition
   read "nearest" = Just Nearest
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ScrollLogicalPosition.read s)}
-    -> ScrollLogicalPosition
-  fromString s = fromJust $ read s
-
   export
   ToFFI ScrollLogicalPosition String where
     toFFI = show
@@ -122,13 +108,6 @@ namespace CSSBoxType
   read "padding" = Just Padding
   read "content" = Just Content
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CSSBoxType.read s)}
-    -> CSSBoxType
-  fromString s = fromJust $ read s
 
   export
   ToFFI CSSBoxType String where

--- a/src/Web/Internal/DomTypes.idr
+++ b/src/Web/Internal/DomTypes.idr
@@ -33,13 +33,6 @@ namespace ShadowRootMode
   read "closed" = Just Closed
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ShadowRootMode.read s)}
-    -> ShadowRootMode
-  fromString s = fromJust $ read s
-
   export
   ToFFI ShadowRootMode String where
     toFFI = show

--- a/src/Web/Internal/FetchTypes.idr
+++ b/src/Web/Internal/FetchTypes.idr
@@ -89,13 +89,6 @@ namespace RequestDestination
   read "xslt" = Just Xslt
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (RequestDestination.read s)}
-    -> RequestDestination
-  fromString s = fromJust $ read s
-
   export
   ToFFI RequestDestination String where
     toFFI = show
@@ -133,13 +126,6 @@ namespace RequestMode
   read "cors" = Just Cors
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (RequestMode.read s)}
-    -> RequestMode
-  fromString s = fromJust $ read s
-
   export
   ToFFI RequestMode String where
     toFFI = show
@@ -174,13 +160,6 @@ namespace RequestCredentials
   read "same-origin" = Just SameOrigin
   read "include" = Just Include
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (RequestCredentials.read s)}
-    -> RequestCredentials
-  fromString s = fromJust $ read s
 
   export
   ToFFI RequestCredentials String where
@@ -229,13 +208,6 @@ namespace RequestCache
   read "only-if-cached" = Just OnlyIfCached
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (RequestCache.read s)}
-    -> RequestCache
-  fromString s = fromJust $ read s
-
   export
   ToFFI RequestCache String where
     toFFI = show
@@ -270,13 +242,6 @@ namespace RequestRedirect
   read "error" = Just Error
   read "manual" = Just Manual
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (RequestRedirect.read s)}
-    -> RequestRedirect
-  fromString s = fromJust $ read s
 
   export
   ToFFI RequestRedirect String where
@@ -318,13 +283,6 @@ namespace ResponseType
   read "opaque" = Just Opaque
   read "opaqueredirect" = Just Opaqueredirect
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ResponseType.read s)}
-    -> ResponseType
-  fromString s = fromJust $ read s
 
   export
   ToFFI ResponseType String where
@@ -381,13 +339,6 @@ namespace ReferrerPolicy
   read "strict-origin-when-cross-origin" = Just StrictOriginWhenCrossOrigin
   read "unsafe-url" = Just UnsafeUrl
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ReferrerPolicy.read s)}
-    -> ReferrerPolicy
-  fromString s = fromJust $ read s
 
   export
   ToFFI ReferrerPolicy String where

--- a/src/Web/Internal/FileTypes.idr
+++ b/src/Web/Internal/FileTypes.idr
@@ -33,13 +33,6 @@ namespace EndingType
   read "native" = Just Native
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (EndingType.read s)}
-    -> EndingType
-  fromString s = fromJust $ read s
-
   export
   ToFFI EndingType String where
     toFFI = show

--- a/src/Web/Internal/HtmlTypes.idr
+++ b/src/Web/Internal/HtmlTypes.idr
@@ -44,13 +44,6 @@ namespace DOMParserSupportedType
   read "image/svg+xml" = Just ImageSvgXml
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (DOMParserSupportedType.read s)}
-    -> DOMParserSupportedType
-  fromString s = fromJust $ read s
-
   export
   ToFFI DOMParserSupportedType String where
     toFFI = show
@@ -85,13 +78,6 @@ namespace DocumentReadyState
   read "interactive" = Just Interactive
   read "complete" = Just Complete
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (DocumentReadyState.read s)}
-    -> DocumentReadyState
-  fromString s = fromJust $ read s
 
   export
   ToFFI DocumentReadyState String where
@@ -128,13 +114,6 @@ namespace CanPlayTypeResult
   read "probably" = Just Probably
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanPlayTypeResult.read s)}
-    -> CanPlayTypeResult
-  fromString s = fromJust $ read s
-
   export
   ToFFI CanPlayTypeResult String where
     toFFI = show
@@ -168,13 +147,6 @@ namespace ScrollRestoration
   read "manual" = Just Manual
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ScrollRestoration.read s)}
-    -> ScrollRestoration
-  fromString s = fromJust $ read s
-
   export
   ToFFI ScrollRestoration String where
     toFFI = show
@@ -207,13 +179,6 @@ namespace ImageOrientation
   read "none" = Just None
   read "flipY" = Just FlipY
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ImageOrientation.read s)}
-    -> ImageOrientation
-  fromString s = fromJust $ read s
 
   export
   ToFFI ImageOrientation String where
@@ -250,13 +215,6 @@ namespace PremultiplyAlpha
   read "default" = Just Default
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (PremultiplyAlpha.read s)}
-    -> PremultiplyAlpha
-  fromString s = fromJust $ read s
-
   export
   ToFFI PremultiplyAlpha String where
     toFFI = show
@@ -289,13 +247,6 @@ namespace ColorSpaceConversion
   read "none" = Just None
   read "default" = Just Default
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ColorSpaceConversion.read s)}
-    -> ColorSpaceConversion
-  fromString s = fromJust $ read s
 
   export
   ToFFI ColorSpaceConversion String where
@@ -334,13 +285,6 @@ namespace ResizeQuality
   read "high" = Just High
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ResizeQuality.read s)}
-    -> ResizeQuality
-  fromString s = fromJust $ read s
-
   export
   ToFFI ResizeQuality String where
     toFFI = show
@@ -373,13 +317,6 @@ namespace CanvasFillRule
   read "nonzero" = Just Nonzero
   read "evenodd" = Just Evenodd
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasFillRule.read s)}
-    -> CanvasFillRule
-  fromString s = fromJust $ read s
 
   export
   ToFFI CanvasFillRule String where
@@ -416,13 +353,6 @@ namespace ImageSmoothingQuality
   read "high" = Just High
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ImageSmoothingQuality.read s)}
-    -> ImageSmoothingQuality
-  fromString s = fromJust $ read s
-
   export
   ToFFI ImageSmoothingQuality String where
     toFFI = show
@@ -458,13 +388,6 @@ namespace CanvasLineCap
   read "square" = Just Square
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasLineCap.read s)}
-    -> CanvasLineCap
-  fromString s = fromJust $ read s
-
   export
   ToFFI CanvasLineCap String where
     toFFI = show
@@ -499,13 +422,6 @@ namespace CanvasLineJoin
   read "bevel" = Just Bevel
   read "miter" = Just Miter
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasLineJoin.read s)}
-    -> CanvasLineJoin
-  fromString s = fromJust $ read s
 
   export
   ToFFI CanvasLineJoin String where
@@ -545,13 +461,6 @@ namespace CanvasTextAlign
   read "right" = Just Right
   read "center" = Just Center
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasTextAlign.read s)}
-    -> CanvasTextAlign
-  fromString s = fromJust $ read s
 
   export
   ToFFI CanvasTextAlign String where
@@ -600,13 +509,6 @@ namespace CanvasTextBaseline
   read "bottom" = Just Bottom
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasTextBaseline.read s)}
-    -> CanvasTextBaseline
-  fromString s = fromJust $ read s
-
   export
   ToFFI CanvasTextBaseline String where
     toFFI = show
@@ -641,13 +543,6 @@ namespace CanvasDirection
   read "rtl" = Just Rtl
   read "inherit" = Just Inherit
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (CanvasDirection.read s)}
-    -> CanvasDirection
-  fromString s = fromJust $ read s
 
   export
   ToFFI CanvasDirection String where
@@ -686,13 +581,6 @@ namespace OffscreenRenderingContextId
   read "webgl2" = Just Webgl2
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (OffscreenRenderingContextId.read s)}
-    -> OffscreenRenderingContextId
-  fromString s = fromJust $ read s
-
   export
   ToFFI OffscreenRenderingContextId String where
     toFFI = show
@@ -727,13 +615,6 @@ namespace TextTrackMode
   read "hidden" = Just Hidden
   read "showing" = Just Showing
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (TextTrackMode.read s)}
-    -> TextTrackMode
-  fromString s = fromJust $ read s
 
   export
   ToFFI TextTrackMode String where
@@ -774,13 +655,6 @@ namespace TextTrackKind
   read "metadata" = Just Metadata
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (TextTrackKind.read s)}
-    -> TextTrackKind
-  fromString s = fromJust $ read s
-
   export
   ToFFI TextTrackKind String where
     toFFI = show
@@ -814,13 +688,6 @@ namespace BinaryType
   read "arraybuffer" = Just Arraybuffer
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (BinaryType.read s)}
-    -> BinaryType
-  fromString s = fromJust $ read s
-
   export
   ToFFI BinaryType String where
     toFFI = show
@@ -853,13 +720,6 @@ namespace WorkerType
   read "classic" = Just Classic
   read "module" = Just Module
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (WorkerType.read s)}
-    -> WorkerType
-  fromString s = fromJust $ read s
 
   export
   ToFFI WorkerType String where
@@ -897,13 +757,6 @@ namespace SelectionMode
   read "end" = Just End
   read "preserve" = Just Preserve
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (SelectionMode.read s)}
-    -> SelectionMode
-  fromString s = fromJust $ read s
 
   export
   ToFFI SelectionMode String where

--- a/src/Web/Internal/IndexedDBTypes.idr
+++ b/src/Web/Internal/IndexedDBTypes.idr
@@ -33,13 +33,6 @@ namespace IDBRequestReadyState
   read "done" = Just Done
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (IDBRequestReadyState.read s)}
-    -> IDBRequestReadyState
-  fromString s = fromJust $ read s
-
   export
   ToFFI IDBRequestReadyState String where
     toFFI = show
@@ -74,13 +67,6 @@ namespace IDBTransactionDurability
   read "strict" = Just Strict
   read "relaxed" = Just Relaxed
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (IDBTransactionDurability.read s)}
-    -> IDBTransactionDurability
-  fromString s = fromJust $ read s
 
   export
   ToFFI IDBTransactionDurability String where
@@ -119,13 +105,6 @@ namespace IDBCursorDirection
   read "prevunique" = Just Prevunique
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (IDBCursorDirection.read s)}
-    -> IDBCursorDirection
-  fromString s = fromJust $ read s
-
   export
   ToFFI IDBCursorDirection String where
     toFFI = show
@@ -160,13 +139,6 @@ namespace IDBTransactionMode
   read "readwrite" = Just Readwrite
   read "versionchange" = Just Versionchange
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (IDBTransactionMode.read s)}
-    -> IDBTransactionMode
-  fromString s = fromJust $ read s
 
   export
   ToFFI IDBTransactionMode String where

--- a/src/Web/Internal/MediasourceTypes.idr
+++ b/src/Web/Internal/MediasourceTypes.idr
@@ -35,13 +35,6 @@ namespace ReadyState
   read "ended" = Just Ended
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ReadyState.read s)}
-    -> ReadyState
-  fromString s = fromJust $ read s
-
   export
   ToFFI ReadyState String where
     toFFI = show
@@ -75,13 +68,6 @@ namespace EndOfStreamError
   read "decode" = Just Decode
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (EndOfStreamError.read s)}
-    -> EndOfStreamError
-  fromString s = fromJust $ read s
-
   export
   ToFFI EndOfStreamError String where
     toFFI = show
@@ -114,13 +100,6 @@ namespace AppendMode
   read "segments" = Just Segments
   read "sequence" = Just Sequence
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (AppendMode.read s)}
-    -> AppendMode
-  fromString s = fromJust $ read s
 
   export
   ToFFI AppendMode String where

--- a/src/Web/Internal/MediastreamTypes.idr
+++ b/src/Web/Internal/MediastreamTypes.idr
@@ -33,13 +33,6 @@ namespace MediaStreamTrackState
   read "ended" = Just Ended
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (MediaStreamTrackState.read s)}
-    -> MediaStreamTrackState
-  fromString s = fromJust $ read s
-
   export
   ToFFI MediaStreamTrackState String where
     toFFI = show
@@ -77,13 +70,6 @@ namespace VideoFacingModeEnum
   read "right" = Just Right
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (VideoFacingModeEnum.read s)}
-    -> VideoFacingModeEnum
-  fromString s = fromJust $ read s
-
   export
   ToFFI VideoFacingModeEnum String where
     toFFI = show
@@ -116,13 +102,6 @@ namespace VideoResizeModeEnum
   read "none" = Just None
   read "crop-and-scale" = Just CropAndScale
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (VideoResizeModeEnum.read s)}
-    -> VideoResizeModeEnum
-  fromString s = fromJust $ read s
 
   export
   ToFFI VideoResizeModeEnum String where
@@ -158,13 +137,6 @@ namespace MediaDeviceKind
   read "audiooutput" = Just Audiooutput
   read "videoinput" = Just Videoinput
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (MediaDeviceKind.read s)}
-    -> MediaDeviceKind
-  fromString s = fromJust $ read s
 
   export
   ToFFI MediaDeviceKind String where

--- a/src/Web/Internal/PermissionsTypes.idr
+++ b/src/Web/Internal/PermissionsTypes.idr
@@ -35,13 +35,6 @@ namespace PermissionState
   read "prompt" = Just Prompt
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (PermissionState.read s)}
-    -> PermissionState
-  fromString s = fromJust $ read s
-
   export
   ToFFI PermissionState String where
     toFFI = show
@@ -130,13 +123,6 @@ namespace PermissionName
   read "display-capture" = Just DisplayCapture
   read "nfc" = Just Nfc
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (PermissionName.read s)}
-    -> PermissionName
-  fromString s = fromJust $ read s
 
   export
   ToFFI PermissionName String where

--- a/src/Web/Internal/ServiceworkerTypes.idr
+++ b/src/Web/Internal/ServiceworkerTypes.idr
@@ -47,13 +47,6 @@ namespace ServiceWorkerState
   read "redundant" = Just Redundant
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ServiceWorkerState.read s)}
-    -> ServiceWorkerState
-  fromString s = fromJust $ read s
-
   export
   ToFFI ServiceWorkerState String where
     toFFI = show
@@ -88,13 +81,6 @@ namespace ServiceWorkerUpdateViaCache
   read "all" = Just All
   read "none" = Just None
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ServiceWorkerUpdateViaCache.read s)}
-    -> ServiceWorkerUpdateViaCache
-  fromString s = fromJust $ read s
 
   export
   ToFFI ServiceWorkerUpdateViaCache String where
@@ -133,13 +119,6 @@ namespace FrameType
   read "none" = Just None
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (FrameType.read s)}
-    -> FrameType
-  fromString s = fromJust $ read s
-
   export
   ToFFI FrameType String where
     toFFI = show
@@ -176,13 +155,6 @@ namespace ClientType
   read "sharedworker" = Just Sharedworker
   read "all" = Just All
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ClientType.read s)}
-    -> ClientType
-  fromString s = fromJust $ read s
 
   export
   ToFFI ClientType String where

--- a/src/Web/Internal/StreamsTypes.idr
+++ b/src/Web/Internal/StreamsTypes.idr
@@ -31,13 +31,6 @@ namespace ReadableStreamReaderMode
   read "byob" = Just Byob
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ReadableStreamReaderMode.read s)}
-    -> ReadableStreamReaderMode
-  fromString s = fromJust $ read s
-
   export
   ToFFI ReadableStreamReaderMode String where
     toFFI = show
@@ -68,13 +61,6 @@ namespace ReadableStreamType
   read : String -> Maybe ReadableStreamType
   read "bytes" = Just Bytes
   read _ = Nothing
-
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (ReadableStreamType.read s)}
-    -> ReadableStreamType
-  fromString s = fromJust $ read s
 
   export
   ToFFI ReadableStreamType String where

--- a/src/Web/Internal/VisibilityTypes.idr
+++ b/src/Web/Internal/VisibilityTypes.idr
@@ -33,13 +33,6 @@ namespace VisibilityState
   read "visible" = Just Visible
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (VisibilityState.read s)}
-    -> VisibilityState
-  fromString s = fromJust $ read s
-
   export
   ToFFI VisibilityState String where
     toFFI = show

--- a/src/Web/Internal/WebglTypes.idr
+++ b/src/Web/Internal/WebglTypes.idr
@@ -35,13 +35,6 @@ namespace WebGLPowerPreference
   read "high-performance" = Just HighPerformance
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (WebGLPowerPreference.read s)}
-    -> WebGLPowerPreference
-  fromString s = fromJust $ read s
-
   export
   ToFFI WebGLPowerPreference String where
     toFFI = show

--- a/src/Web/Internal/XhrTypes.idr
+++ b/src/Web/Internal/XhrTypes.idr
@@ -47,13 +47,6 @@ namespace XMLHttpRequestResponseType
   read "text" = Just Text
   read _ = Nothing
 
-  public export
-  fromString :
-       (s : String)
-    -> {auto 0 _ : IsJust (XMLHttpRequestResponseType.read s)}
-    -> XMLHttpRequestResponseType
-  fromString s = fromJust $ read s
-
   export
   ToFFI XMLHttpRequestResponseType String where
     toFFI = show


### PR DESCRIPTION
These can potentially slow down compilation times in other modules due to extensive time being used for ambiguity resolution. Since they don't add any real value, I decided to just drop them.