### PR TITLE
[ refactor, breaking ] deprecate JSType and use Cast instead

### DIFF
--- a/docs/src/Tutorial.md
+++ b/docs/src/Tutorial.md
@@ -493,7 +493,7 @@ of an unfamiliar function much easier.
 
 #### Subtyping
 
-Subtyping relations as described for interfaces, mixins, and dictionaries,
+~~Subtyping relations as described for interfaces, mixins, and dictionaries,
 are handled by interface `JS.Inheritance.JSType`. Implementations of
 this interface list associated parent types and mixins for an
 external Idris type. Function `up` and operator `(:>)` can be
@@ -517,7 +517,12 @@ additional gain in flexibility.
 Two examples: `Web.Dom.Node.firstChild` abstracts over the
 parent node's type, while `Web.Html.HTMLButtonElement.checkValidity`
 uses concrete types, since there are no child interfaces for
-`HTMLButtonElement` in the spec.
+`HTMLButtonElement` in the spec.~~
+
+The above no longer applies. Subtyping is handle simply by implementing
+`Cast a b`, where `b` is a parent type or mixin of `a`. Since
+types `a` and `b` are usually external types, such `Cast` implementations
+use `believe_me` internally.
 
 ### Web IDL types
 
@@ -558,9 +563,9 @@ nodes to the body like so:
 ```idris
 addNodes : HTMLButtonElement -> HTMLDivElement -> HTMLDivElement -> JSIO ()
 addNodes btn txtDiv outDiv =
-  ignore $ (!body `append` [ Here $ btn :> Node
-                           , Here $ txtDiv :> Node
-                           , Here $ outDiv :> Node
+  ignore $ (!body `append` [ Here $ cast btn
+                           , Here $ cast txtDiv
+                           , Here $ cast outDiv
                            ])
 ```
 

--- a/js/src/JS/Inheritance.idr
+++ b/js/src/JS/Inheritance.idr
@@ -15,6 +15,8 @@ import Data.String
 ||| mixins. It is used to safely and conveniently cast a value to a
 ||| less specific type mentioned either in the list of
 ||| mixins or parent types by means of funciton `up` and operator `:>`.
+|||
+||| Deprecated: Use `Cast` and `cast` instead
 public export
 interface JSType a where
 
@@ -22,6 +24,7 @@ interface JSType a where
   ||| (starting at the direct supertype). At runtime, such an inheritance
   ||| chain can be inspected by recursively calling the Javascript
   ||| function `Object.getPrototypeOf`.
+  %deprecate
   parents : List Type
 
   ||| A Mixin is a concept from WebIDL: It is as programming interface
@@ -31,11 +34,13 @@ interface JSType a where
   ||| a value's prototype chain. It is therefore much harder
   ||| (and right now not supported in this library) to at runtime
   ||| check, whether a value implements a given mixin.
+  %deprecate
   mixins : List Type
 
 ||| Convenience alias for `parents`, which takes an explicit
 ||| erased type argument.
-public export
+||| Deprecated: Use `Cast` and `cast` instead
+public export %deprecate
 0 Types : (0 a : Type) -> JSType a => List Type
 Types a = a :: parents {a} ++ mixins {a}
 
@@ -43,14 +48,16 @@ Types a = a :: parents {a} ++ mixins {a}
 ||| therefore of course only safe, if the `JSType` implementation
 ||| is correct according to some specification and the backend
 ||| properly adhere to this specification.
-public export %inline
+||| Deprecated: Use `Cast` and `cast` instead
+public export %inline %deprecate
 up : (0 _ : JSType a) => a -> {auto 0 _ : Elem b (Types a)} -> b
 up v = believe_me v
 
 infixl 1 :>
 
 ||| Operator version of `up`.
-public export %inline
+||| Deprecated: Use `Cast` and `cast` instead
+public export %inline %deprecate
 (:>) : (0 _ : JSType a) => a -> (0 b : Type) -> {auto 0 _ : Elem b (Types a)} -> b
 a :> _ = up a
 

--- a/js/src/JS/Nullable.idr
+++ b/js/src/JS/Nullable.idr
@@ -13,16 +13,16 @@ data Nullable : Type -> Type where [external]
 %foreign "javascript:lambda:()=>null"
 prim__null : AnyPtr
 
-export
+export %inline
 null : Nullable a
 null = believe_me prim__null
 
-export
+export %inline
 nonNull : a -> Nullable a
 nonNull = believe_me
 
 ||| Tests, whether a value of questionable origin is null
-export
+export %inline
 isNull : a -> Bool
 isNull = eqv prim__null
 
@@ -31,8 +31,8 @@ maybeToNullable : Maybe a -> Nullable a
 maybeToNullable = maybe null nonNull
 
 export
-mayUp : (0 _ : JSType a) => Maybe a -> {auto 0 _ : Elem b (Types a)} -> Nullable b
-mayUp x = maybe null (\v => nonNull $ up v) x
+mayUp : Cast a b => Maybe a -> Nullable b
+mayUp x = maybe null (\v => nonNull $ cast v) x
 
 export
 nullableToMaybe : Nullable a -> Maybe a

--- a/js/src/JS/Undefined.idr
+++ b/js/src/JS/Undefined.idr
@@ -149,14 +149,11 @@ optionalToUndefOr : Optional a -> UndefOr a
 optionalToUndefOr = optional undef def
 
 export
-optUp : (0 _ : JSType a) => Optional a -> {auto 0 _ : Elem b (Types a)} -> UndefOr b
-optUp x = optional undef (\v => def $ up v) x
+optUp : Cast a b => Optional a -> UndefOr b
+optUp x = optional undef (\v => def $ cast v) x
 
 export
-omyUp :  (0 _ : JSType a)
-      => Optional (Maybe a)
-      -> {auto 0 _ : Elem b (Types a)}
-      -> UndefOr (Nullable b)
+omyUp : Cast a b => Optional (Maybe a) -> UndefOr (Nullable b)
 omyUp x = optionalToUndefOr $ map (\m => mayUp m) x
 
 public export

--- a/src/Web/Internal/AnimationPrim.idr
+++ b/src/Web/Internal/AnimationPrim.idr
@@ -11,148 +11,148 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Animation
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTime"
   prim__currentTime : Animation -> PrimIO (Nullable Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentTime = v}"
   prim__setCurrentTime : Animation -> Nullable Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.effect"
   prim__effect : Animation -> PrimIO (Nullable AnimationEffect)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.effect = v}"
   prim__setEffect : Animation -> Nullable AnimationEffect -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.finished"
   prim__finished : Animation -> PrimIO (Promise Animation)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : Animation -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.id = v}"
   prim__setId : Animation -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncancel"
   prim__oncancel : Animation -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncancel = v}"
   prim__setOncancel : Animation -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onfinish"
   prim__onfinish : Animation -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onfinish = v}"
   prim__setOnfinish : Animation -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pending"
   prim__pending : Animation -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.playState"
   prim__playState : Animation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.playbackRate"
   prim__playbackRate : Animation -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.playbackRate = v}"
   prim__setPlaybackRate : Animation -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ready"
   prim__ready : Animation -> PrimIO (Promise Animation)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startTime"
   prim__startTime : Animation -> PrimIO (Nullable Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.startTime = v}"
   prim__setStartTime : Animation -> Nullable Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timeline"
   prim__timeline : Animation -> PrimIO (Nullable AnimationTimeline)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.timeline = v}"
   prim__setTimeline : Animation -> Nullable AnimationTimeline -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cancel()"
   prim__cancel : Animation -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.finish()"
   prim__finish : Animation -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pause()"
   prim__pause : Animation -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.play()"
   prim__play : Animation -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reverse()"
   prim__reverse : Animation -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.updatePlaybackRate(a)"
   prim__updatePlaybackRate : Animation -> Double -> PrimIO ()
@@ -160,17 +160,17 @@ namespace Animation
 
 
 namespace AnimationEffect
-
+  
   export
   %foreign "browser:lambda:x=>x.getComputedTiming()"
   prim__getComputedTiming : AnimationEffect -> PrimIO ComputedEffectTiming
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getTiming()"
   prim__getTiming : AnimationEffect -> PrimIO EffectTiming
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.updateTiming(a)"
   prim__updateTiming :
@@ -181,12 +181,12 @@ namespace AnimationEffect
 
 
 namespace AnimationPlaybackEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTime"
   prim__currentTime : AnimationPlaybackEvent -> PrimIO (Nullable Double)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timelineTime"
   prim__timelineTime : AnimationPlaybackEvent -> PrimIO (Nullable Double)
@@ -194,7 +194,7 @@ namespace AnimationPlaybackEvent
 
 
 namespace AnimationTimeline
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTime"
   prim__currentTime : AnimationTimeline -> PrimIO (Nullable Double)
@@ -203,31 +203,31 @@ namespace AnimationTimeline
 
 
 namespace KeyframeEffect
-
+  
   export
   %foreign "browser:lambda:x=>x.composite"
   prim__composite : KeyframeEffect -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composite = v}"
   prim__setComposite : KeyframeEffect -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterationComposite"
   prim__iterationComposite : KeyframeEffect -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterationComposite = v}"
   prim__setIterationComposite : KeyframeEffect -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target :
@@ -235,7 +235,7 @@ namespace KeyframeEffect
     -> PrimIO (Nullable (Union2 Element CSSPseudoElement))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget :
@@ -244,12 +244,12 @@ namespace KeyframeEffect
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getKeyframes()"
   prim__getKeyframes : KeyframeEffect -> PrimIO (Array Object)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setKeyframes(a)"
   prim__setKeyframes : KeyframeEffect -> Nullable Object -> PrimIO ()
@@ -262,7 +262,7 @@ namespace KeyframeEffect
 --------------------------------------------------------------------------------
 
 namespace Animatable
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.animate(a,b)"
   prim__animate :
@@ -271,7 +271,7 @@ namespace Animatable
     -> UndefOr (Union2 Double KeyframeAnimationOptions)
     -> PrimIO Animation
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAnimations()"
   prim__getAnimations : Animatable -> PrimIO (Array Animation)
@@ -284,7 +284,7 @@ namespace Animatable
 --------------------------------------------------------------------------------
 
 namespace AnimationPlaybackEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({currentTime: a,timelineTime: b})"
   prim__new :
@@ -292,7 +292,7 @@ namespace AnimationPlaybackEventInit
     -> UndefOr (Nullable Double)
     -> PrimIO AnimationPlaybackEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTime"
   prim__currentTime :
@@ -300,7 +300,7 @@ namespace AnimationPlaybackEventInit
     -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentTime = v}"
   prim__setCurrentTime :
@@ -309,7 +309,7 @@ namespace AnimationPlaybackEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timelineTime"
   prim__timelineTime :
@@ -317,7 +317,7 @@ namespace AnimationPlaybackEventInit
     -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.timelineTime = v}"
   prim__setTimelineTime :
@@ -329,7 +329,7 @@ namespace AnimationPlaybackEventInit
 
 
 namespace BaseComputedKeyframe
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({offset: a,computedOffset: b,easing: c,composite: d})"
   prim__new :
@@ -339,49 +339,49 @@ namespace BaseComputedKeyframe
     -> UndefOr String
     -> PrimIO BaseComputedKeyframe
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composite"
   prim__composite : BaseComputedKeyframe -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composite = v}"
   prim__setComposite : BaseComputedKeyframe -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.computedOffset"
   prim__computedOffset : BaseComputedKeyframe -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.computedOffset = v}"
   prim__setComputedOffset : BaseComputedKeyframe -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.easing"
   prim__easing : BaseComputedKeyframe -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.easing = v}"
   prim__setEasing : BaseComputedKeyframe -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offset"
   prim__offset : BaseComputedKeyframe -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.offset = v}"
   prim__setOffset :
@@ -393,7 +393,7 @@ namespace BaseComputedKeyframe
 
 
 namespace BaseKeyframe
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({offset: a,easing: b,composite: c})"
   prim__new :
@@ -402,37 +402,37 @@ namespace BaseKeyframe
     -> UndefOr String
     -> PrimIO BaseKeyframe
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composite"
   prim__composite : BaseKeyframe -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composite = v}"
   prim__setComposite : BaseKeyframe -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.easing"
   prim__easing : BaseKeyframe -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.easing = v}"
   prim__setEasing : BaseKeyframe -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offset"
   prim__offset : BaseKeyframe -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.offset = v}"
   prim__setOffset : BaseKeyframe -> UndefOr (Nullable Double) -> PrimIO ()
@@ -441,7 +441,7 @@ namespace BaseKeyframe
 
 
 namespace BasePropertyIndexedKeyframe
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({offset: a,easing: b,composite: c})"
   prim__new :
@@ -450,7 +450,7 @@ namespace BasePropertyIndexedKeyframe
     -> UndefOr (Union2 String (Array String))
     -> PrimIO BasePropertyIndexedKeyframe
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composite"
   prim__composite :
@@ -458,7 +458,7 @@ namespace BasePropertyIndexedKeyframe
     -> PrimIO (UndefOr (Union2 String (Array String)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composite = v}"
   prim__setComposite :
@@ -467,7 +467,7 @@ namespace BasePropertyIndexedKeyframe
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.easing"
   prim__easing :
@@ -475,7 +475,7 @@ namespace BasePropertyIndexedKeyframe
     -> PrimIO (UndefOr (Union2 String (Array String)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.easing = v}"
   prim__setEasing :
@@ -484,7 +484,7 @@ namespace BasePropertyIndexedKeyframe
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offset"
   prim__offset :
@@ -492,7 +492,7 @@ namespace BasePropertyIndexedKeyframe
     -> PrimIO (UndefOr (Nullable (Union2 Double (Array (Nullable Double)))))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.offset = v}"
   prim__setOffset :
@@ -504,7 +504,7 @@ namespace BasePropertyIndexedKeyframe
 
 
 namespace ComputedEffectTiming
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({endTime: a,activeDuration: b,localTime: c,progress: d,currentIteration: e})"
   prim__new :
@@ -515,19 +515,19 @@ namespace ComputedEffectTiming
     -> UndefOr (Nullable Double)
     -> PrimIO ComputedEffectTiming
 
-
+  
   export
   %foreign "browser:lambda:x=>x.activeDuration"
   prim__activeDuration : ComputedEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.activeDuration = v}"
   prim__setActiveDuration : ComputedEffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentIteration"
   prim__currentIteration :
@@ -535,7 +535,7 @@ namespace ComputedEffectTiming
     -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentIteration = v}"
   prim__setCurrentIteration :
@@ -544,25 +544,25 @@ namespace ComputedEffectTiming
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endTime"
   prim__endTime : ComputedEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endTime = v}"
   prim__setEndTime : ComputedEffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.localTime"
   prim__localTime : ComputedEffectTiming -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.localTime = v}"
   prim__setLocalTime :
@@ -571,13 +571,13 @@ namespace ComputedEffectTiming
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.progress"
   prim__progress : ComputedEffectTiming -> PrimIO (UndefOr (Nullable Double))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.progress = v}"
   prim__setProgress :
@@ -589,18 +589,18 @@ namespace ComputedEffectTiming
 
 
 namespace DocumentTimelineOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({originTime: a})"
   prim__new : UndefOr Double -> PrimIO DocumentTimelineOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.originTime"
   prim__originTime : DocumentTimelineOptions -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.originTime = v}"
   prim__setOriginTime : DocumentTimelineOptions -> UndefOr Double -> PrimIO ()
@@ -609,7 +609,7 @@ namespace DocumentTimelineOptions
 
 
 namespace EffectTiming
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h)=> ({delay: a,endDelay: b,fill: c,iterationStart: d,iterations: e,duration: f,direction: g,easing: h})"
   prim__new :
@@ -623,37 +623,37 @@ namespace EffectTiming
     -> UndefOr String
     -> PrimIO EffectTiming
 
-
+  
   export
   %foreign "browser:lambda:x=>x.delay"
   prim__delay : EffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.delay = v}"
   prim__setDelay : EffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.direction"
   prim__direction : EffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.direction = v}"
   prim__setDirection : EffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.duration"
   prim__duration : EffectTiming -> PrimIO (UndefOr (Union2 Double String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.duration = v}"
   prim__setDuration :
@@ -662,61 +662,61 @@ namespace EffectTiming
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.easing"
   prim__easing : EffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.easing = v}"
   prim__setEasing : EffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endDelay"
   prim__endDelay : EffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endDelay = v}"
   prim__setEndDelay : EffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fill"
   prim__fill : EffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fill = v}"
   prim__setFill : EffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterationStart"
   prim__iterationStart : EffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterationStart = v}"
   prim__setIterationStart : EffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterations"
   prim__iterations : EffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterations = v}"
   prim__setIterations : EffectTiming -> UndefOr Double -> PrimIO ()
@@ -725,18 +725,18 @@ namespace EffectTiming
 
 
 namespace KeyframeAnimationOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({id: a})"
   prim__new : UndefOr String -> PrimIO KeyframeAnimationOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : KeyframeAnimationOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.id = v}"
   prim__setId : KeyframeAnimationOptions -> UndefOr String -> PrimIO ()
@@ -745,30 +745,30 @@ namespace KeyframeAnimationOptions
 
 
 namespace KeyframeEffectOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({iterationComposite: a,composite: b})"
   prim__new : UndefOr String -> UndefOr String -> PrimIO KeyframeEffectOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composite"
   prim__composite : KeyframeEffectOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composite = v}"
   prim__setComposite : KeyframeEffectOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterationComposite"
   prim__iterationComposite : KeyframeEffectOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterationComposite = v}"
   prim__setIterationComposite :
@@ -780,7 +780,7 @@ namespace KeyframeEffectOptions
 
 
 namespace OptionalEffectTiming
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h)=> ({delay: a,endDelay: b,fill: c,iterationStart: d,iterations: e,duration: f,direction: g,easing: h})"
   prim__new :
@@ -794,31 +794,31 @@ namespace OptionalEffectTiming
     -> UndefOr String
     -> PrimIO OptionalEffectTiming
 
-
+  
   export
   %foreign "browser:lambda:x=>x.delay"
   prim__delay : OptionalEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.delay = v}"
   prim__setDelay : OptionalEffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.direction"
   prim__direction : OptionalEffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.direction = v}"
   prim__setDirection : OptionalEffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.duration"
   prim__duration :
@@ -826,7 +826,7 @@ namespace OptionalEffectTiming
     -> PrimIO (UndefOr (Union2 Double String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.duration = v}"
   prim__setDuration :
@@ -835,61 +835,65 @@ namespace OptionalEffectTiming
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.easing"
   prim__easing : OptionalEffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.easing = v}"
   prim__setEasing : OptionalEffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endDelay"
   prim__endDelay : OptionalEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endDelay = v}"
   prim__setEndDelay : OptionalEffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fill"
   prim__fill : OptionalEffectTiming -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fill = v}"
   prim__setFill : OptionalEffectTiming -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterationStart"
   prim__iterationStart : OptionalEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterationStart = v}"
   prim__setIterationStart : OptionalEffectTiming -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterations"
   prim__iterations : OptionalEffectTiming -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.iterations = v}"
   prim__setIterations : OptionalEffectTiming -> UndefOr Double -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/AnimationTypes.idr
+++ b/src/Web/Internal/AnimationTypes.idr
@@ -10,64 +10,64 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace AnimationPlayState
-
+  
   public export
   data AnimationPlayState = Idle | Running | Paused | Finished
-
-  public export
+  
+  export
   Show AnimationPlayState where
     show Idle = "idle"
     show Running = "running"
     show Paused = "paused"
     show Finished = "finished"
-
-  public export
+  
+  export
   Eq AnimationPlayState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord AnimationPlayState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe AnimationPlayState
   read "idle" = Just Idle
   read "running" = Just Running
   read "paused" = Just Paused
   read "finished" = Just Finished
   read _ = Nothing
-
+  
   export
   ToFFI AnimationPlayState String where
     toFFI = show
-
+  
   export
   FromFFI AnimationPlayState String where
     fromFFI = read
 
 
 namespace FillMode
-
+  
   public export
   data FillMode = None | Forwards | Backwards | Both | Auto
-
-  public export
+  
+  export
   Show FillMode where
     show None = "none"
     show Forwards = "forwards"
     show Backwards = "backwards"
     show Both = "both"
     show Auto = "auto"
-
-  public export
+  
+  export
   Eq FillMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord FillMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe FillMode
   read "none" = Just None
   read "forwards" = Just Forwards
@@ -75,153 +75,153 @@ namespace FillMode
   read "both" = Just Both
   read "auto" = Just Auto
   read _ = Nothing
-
+  
   export
   ToFFI FillMode String where
     toFFI = show
-
+  
   export
   FromFFI FillMode String where
     fromFFI = read
 
 
 namespace PlaybackDirection
-
+  
   public export
   data PlaybackDirection = Normal | Reverse | Alternate | AlternateReverse
-
-  public export
+  
+  export
   Show PlaybackDirection where
     show Normal = "normal"
     show Reverse = "reverse"
     show Alternate = "alternate"
     show AlternateReverse = "alternate-reverse"
-
-  public export
+  
+  export
   Eq PlaybackDirection where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord PlaybackDirection where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe PlaybackDirection
   read "normal" = Just Normal
   read "reverse" = Just Reverse
   read "alternate" = Just Alternate
   read "alternate-reverse" = Just AlternateReverse
   read _ = Nothing
-
+  
   export
   ToFFI PlaybackDirection String where
     toFFI = show
-
+  
   export
   FromFFI PlaybackDirection String where
     fromFFI = read
 
 
 namespace IterationCompositeOperation
-
+  
   public export
   data IterationCompositeOperation = Replace | Accumulate
-
-  public export
+  
+  export
   Show IterationCompositeOperation where
     show Replace = "replace"
     show Accumulate = "accumulate"
-
-  public export
+  
+  export
   Eq IterationCompositeOperation where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord IterationCompositeOperation where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe IterationCompositeOperation
   read "replace" = Just Replace
   read "accumulate" = Just Accumulate
   read _ = Nothing
-
+  
   export
   ToFFI IterationCompositeOperation String where
     toFFI = show
-
+  
   export
   FromFFI IterationCompositeOperation String where
     fromFFI = read
 
 
 namespace CompositeOperation
-
+  
   public export
   data CompositeOperation = Replace | Add | Accumulate
-
-  public export
+  
+  export
   Show CompositeOperation where
     show Replace = "replace"
     show Add = "add"
     show Accumulate = "accumulate"
-
-  public export
+  
+  export
   Eq CompositeOperation where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CompositeOperation where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CompositeOperation
   read "replace" = Just Replace
   read "add" = Just Add
   read "accumulate" = Just Accumulate
   read _ = Nothing
-
+  
   export
   ToFFI CompositeOperation String where
     toFFI = show
-
+  
   export
   FromFFI CompositeOperation String where
     fromFFI = read
 
 
 namespace CompositeOperationOrAuto
-
+  
   public export
   data CompositeOperationOrAuto = Replace | Add | Accumulate | Auto
-
-  public export
+  
+  export
   Show CompositeOperationOrAuto where
     show Replace = "replace"
     show Add = "add"
     show Accumulate = "accumulate"
     show Auto = "auto"
-
-  public export
+  
+  export
   Eq CompositeOperationOrAuto where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CompositeOperationOrAuto where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CompositeOperationOrAuto
   read "replace" = Just Replace
   read "add" = Just Add
   read "accumulate" = Just Accumulate
   read "auto" = Just Auto
   read _ = Nothing
-
+  
   export
   ToFFI CompositeOperationOrAuto String where
     toFFI = show
-
+  
   export
   FromFFI CompositeOperationOrAuto String where
     fromFFI = read
@@ -401,3 +401,5 @@ ToFFI Animatable Animatable where toFFI = id
 
 export
 FromFFI Animatable Animatable where fromFFI = Just
+
+

--- a/src/Web/Internal/ClipboardPrim.idr
+++ b/src/Web/Internal/ClipboardPrim.idr
@@ -11,22 +11,22 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Clipboard
-
+  
   export
   %foreign "browser:lambda:x=>x.read()"
   prim__read : Clipboard -> PrimIO (Promise (Array ClipboardItem))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readText()"
   prim__readText : Clipboard -> PrimIO (Promise String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.write(a)"
   prim__write : Clipboard -> Array ClipboardItem -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.writeText(a)"
   prim__writeText : Clipboard -> String -> PrimIO (Promise Undefined)
@@ -34,12 +34,12 @@ namespace Clipboard
 
 
 namespace ClipboardEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ClipboardEvent(a,b)"
   prim__new : String -> UndefOr ClipboardEventInit -> PrimIO ClipboardEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clipboardData"
   prim__clipboardData : ClipboardEvent -> PrimIO (Nullable DataTransfer)
@@ -47,7 +47,7 @@ namespace ClipboardEvent
 
 
 namespace ClipboardItem
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ClipboardItem(a,b)"
   prim__new :
@@ -55,7 +55,7 @@ namespace ClipboardItem
     -> UndefOr ClipboardItemOptions
     -> PrimIO ClipboardItem
 
-
+  
   export
   %foreign "browser:lambda:(a,b)=>ClipboardItem.createDelayed(a,b)"
   prim__createDelayed :
@@ -63,27 +63,27 @@ namespace ClipboardItem
     -> UndefOr ClipboardItemOptions
     -> PrimIO ClipboardItem
 
-
+  
   export
   %foreign "browser:lambda:x=>x.delayed"
   prim__delayed : ClipboardItem -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastModified"
   prim__lastModified : ClipboardItem -> PrimIO JSInt64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.presentationStyle"
   prim__presentationStyle : ClipboardItem -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.types"
   prim__types : ClipboardItem -> PrimIO (Array String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getType(a)"
   prim__getType : ClipboardItem -> String -> PrimIO (Promise Blob)
@@ -97,12 +97,12 @@ namespace ClipboardItem
 --------------------------------------------------------------------------------
 
 namespace ClipboardEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({clipboardData: a})"
   prim__new : UndefOr (Nullable DataTransfer) -> PrimIO ClipboardEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clipboardData"
   prim__clipboardData :
@@ -110,7 +110,7 @@ namespace ClipboardEventInit
     -> PrimIO (UndefOr (Nullable DataTransfer))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clipboardData = v}"
   prim__setClipboardData :
@@ -122,18 +122,18 @@ namespace ClipboardEventInit
 
 
 namespace ClipboardItemOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({presentationStyle: a})"
   prim__new : UndefOr String -> PrimIO ClipboardItemOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.presentationStyle"
   prim__presentationStyle : ClipboardItemOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.presentationStyle = v}"
   prim__setPresentationStyle :
@@ -145,12 +145,12 @@ namespace ClipboardItemOptions
 
 
 namespace ClipboardPermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({allowWithoutGesture: a})"
   prim__new : UndefOr Boolean -> PrimIO ClipboardPermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.allowWithoutGesture"
   prim__allowWithoutGesture :
@@ -158,7 +158,7 @@ namespace ClipboardPermissionDescriptor
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.allowWithoutGesture = v}"
   prim__setAllowWithoutGesture :
@@ -175,9 +175,11 @@ namespace ClipboardPermissionDescriptor
 --------------------------------------------------------------------------------
 
 namespace ClipboardItemDelayedCallback
-
+  
   export
   %foreign "browser:lambda:x=>()=>x()()"
   prim__toClipboardItemDelayedCallback :
        (() -> IO (Promise (Union2 String Blob)))
     -> PrimIO ClipboardItemDelayedCallback
+
+

--- a/src/Web/Internal/ClipboardTypes.idr
+++ b/src/Web/Internal/ClipboardTypes.idr
@@ -10,35 +10,35 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace PresentationStyle
-
+  
   public export
   data PresentationStyle = Unspecified | Inline | Attachment
-
-  public export
+  
+  export
   Show PresentationStyle where
     show Unspecified = "unspecified"
     show Inline = "inline"
     show Attachment = "attachment"
-
-  public export
+  
+  export
   Eq PresentationStyle where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord PresentationStyle where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe PresentationStyle
   read "unspecified" = Just Unspecified
   read "inline" = Just Inline
   read "attachment" = Just Attachment
   read _ = Nothing
-
+  
   export
   ToFFI PresentationStyle String where
     toFFI = show
-
+  
   export
   FromFFI PresentationStyle String where
     fromFFI = read
@@ -127,3 +127,4 @@ ToFFI ClipboardItemDelayedCallback ClipboardItemDelayedCallback where toFFI = id
 
 export
 FromFFI ClipboardItemDelayedCallback ClipboardItemDelayedCallback where fromFFI = Just
+

--- a/src/Web/Internal/CssPrim.idr
+++ b/src/Web/Internal/CssPrim.idr
@@ -11,17 +11,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CSSGroupingRule
-
+  
   export
   %foreign "browser:lambda:x=>x.cssRules"
   prim__cssRules : CSSGroupingRule -> PrimIO CSSRuleList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteRule(a)"
   prim__deleteRule : CSSGroupingRule -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertRule(a,b)"
   prim__insertRule :
@@ -33,17 +33,17 @@ namespace CSSGroupingRule
 
 
 namespace CSSImportRule
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : CSSImportRule -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : CSSImportRule -> PrimIO MediaList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.styleSheet"
   prim__styleSheet : CSSImportRule -> PrimIO CSSStyleSheet
@@ -51,12 +51,12 @@ namespace CSSImportRule
 
 
 namespace CSSMarginRule
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : CSSMarginRule -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.style"
   prim__style : CSSMarginRule -> PrimIO CSSStyleDeclaration
@@ -64,12 +64,12 @@ namespace CSSMarginRule
 
 
 namespace CSSNamespaceRule
-
+  
   export
   %foreign "browser:lambda:x=>x.namespaceURI"
   prim__namespaceURI : CSSNamespaceRule -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.prefix"
   prim__prefix : CSSNamespaceRule -> PrimIO String
@@ -77,19 +77,19 @@ namespace CSSNamespaceRule
 
 
 namespace CSSPageRule
-
+  
   export
   %foreign "browser:lambda:x=>x.selectorText"
   prim__selectorText : CSSPageRule -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectorText = v}"
   prim__setSelectorText : CSSPageRule -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.style"
   prim__style : CSSPageRule -> PrimIO CSSStyleDeclaration
@@ -97,12 +97,12 @@ namespace CSSPageRule
 
 
 namespace CSSPseudoElement
-
+  
   export
   %foreign "browser:lambda:x=>x.element"
   prim__element : CSSPseudoElement -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : CSSPseudoElement -> PrimIO String
@@ -110,29 +110,29 @@ namespace CSSPseudoElement
 
 
 namespace CSSRule
-
+  
   export
   %foreign "browser:lambda:x=>x.cssText"
   prim__cssText : CSSRule -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cssText = v}"
   prim__setCssText : CSSRule -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentRule"
   prim__parentRule : CSSRule -> PrimIO (Nullable CSSRule)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentStyleSheet"
   prim__parentStyleSheet : CSSRule -> PrimIO (Nullable CSSStyleSheet)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : CSSRule -> PrimIO Bits16
@@ -140,12 +140,12 @@ namespace CSSRule
 
 
 namespace CSSRuleList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : CSSRuleList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : CSSRuleList -> Bits32 -> PrimIO (Nullable CSSRule)
@@ -153,61 +153,61 @@ namespace CSSRuleList
 
 
 namespace CSSStyleDeclaration
-
+  
   export
   %foreign "browser:lambda:x=>x.cssFloat"
   prim__cssFloat : CSSStyleDeclaration -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cssFloat = v}"
   prim__setCssFloat : CSSStyleDeclaration -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cssText"
   prim__cssText : CSSStyleDeclaration -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cssText = v}"
   prim__setCssText : CSSStyleDeclaration -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : CSSStyleDeclaration -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentRule"
   prim__parentRule : CSSStyleDeclaration -> PrimIO (Nullable CSSRule)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getPropertyPriority(a)"
   prim__getPropertyPriority : CSSStyleDeclaration -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getPropertyValue(a)"
   prim__getPropertyValue : CSSStyleDeclaration -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : CSSStyleDeclaration -> Bits32 -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeProperty(a)"
   prim__removeProperty : CSSStyleDeclaration -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setProperty(a,b,c)"
   prim__setProperty :
@@ -220,19 +220,19 @@ namespace CSSStyleDeclaration
 
 
 namespace CSSStyleRule
-
+  
   export
   %foreign "browser:lambda:x=>x.selectorText"
   prim__selectorText : CSSStyleRule -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectorText = v}"
   prim__setSelectorText : CSSStyleRule -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.style"
   prim__style : CSSStyleRule -> PrimIO CSSStyleDeclaration
@@ -240,22 +240,22 @@ namespace CSSStyleRule
 
 
 namespace CSSStyleSheet
-
+  
   export
   %foreign "browser:lambda:x=>x.cssRules"
   prim__cssRules : CSSStyleSheet -> PrimIO CSSRuleList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ownerRule"
   prim__ownerRule : CSSStyleSheet -> PrimIO (Nullable CSSRule)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rules"
   prim__rules : CSSStyleSheet -> PrimIO CSSRuleList
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.addRule(a,b,c)"
   prim__addRule :
@@ -265,17 +265,17 @@ namespace CSSStyleSheet
     -> UndefOr Bits32
     -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteRule(a)"
   prim__deleteRule : CSSStyleSheet -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertRule(a,b)"
   prim__insertRule : CSSStyleSheet -> String -> UndefOr Bits32 -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeRule(a)"
   prim__removeRule : CSSStyleSheet -> UndefOr Bits32 -> PrimIO ()
@@ -283,34 +283,34 @@ namespace CSSStyleSheet
 
 
 namespace MediaList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : MediaList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mediaText"
   prim__mediaText : MediaList -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mediaText = v}"
   prim__setMediaText : MediaList -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendMedium(a)"
   prim__appendMedium : MediaList -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteMedium(a)"
   prim__deleteMedium : MediaList -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : MediaList -> Bits32 -> PrimIO (Nullable String)
@@ -318,46 +318,46 @@ namespace MediaList
 
 
 namespace StyleSheet
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : StyleSheet -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : StyleSheet -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : StyleSheet -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : StyleSheet -> PrimIO MediaList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ownerNode"
   prim__ownerNode :
        StyleSheet
     -> PrimIO (Nullable (Union2 Element ProcessingInstruction))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentStyleSheet"
   prim__parentStyleSheet : StyleSheet -> PrimIO (Nullable CSSStyleSheet)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.title"
   prim__title : StyleSheet -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : StyleSheet -> PrimIO String
@@ -365,12 +365,12 @@ namespace StyleSheet
 
 
 namespace StyleSheetList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : StyleSheetList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : StyleSheetList -> Bits32 -> PrimIO (Nullable CSSStyleSheet)
@@ -383,7 +383,7 @@ namespace StyleSheetList
 --------------------------------------------------------------------------------
 
 namespace ElementCSSInlineStyle
-
+  
   export
   %foreign "browser:lambda:x=>x.style"
   prim__style : ElementCSSInlineStyle -> PrimIO CSSStyleDeclaration
@@ -391,7 +391,11 @@ namespace ElementCSSInlineStyle
 
 
 namespace LinkStyle
-
+  
   export
   %foreign "browser:lambda:x=>x.sheet"
   prim__sheet : LinkStyle -> PrimIO (Nullable CSSStyleSheet)
+
+
+
+

--- a/src/Web/Internal/CssTypes.idr
+++ b/src/Web/Internal/CssTypes.idr
@@ -199,3 +199,5 @@ ToFFI LinkStyle LinkStyle where toFFI = id
 
 export
 FromFFI LinkStyle LinkStyle where fromFFI = Just
+
+

--- a/src/Web/Internal/CssomviewPrim.idr
+++ b/src/Web/Internal/CssomviewPrim.idr
@@ -11,17 +11,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CaretPosition
-
+  
   export
   %foreign "browser:lambda:x=>x.offset"
   prim__offset : CaretPosition -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetNode"
   prim__offsetNode : CaretPosition -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getClientRect()"
   prim__getClientRect : CaretPosition -> PrimIO (Nullable DOMRect)
@@ -29,23 +29,23 @@ namespace CaretPosition
 
 
 namespace MediaQueryList
-
+  
   export
   %foreign "browser:lambda:x=>x.matches"
   prim__matches : MediaQueryList -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : MediaQueryList -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : MediaQueryList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange :
@@ -54,12 +54,12 @@ namespace MediaQueryList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.addListener(a)"
   prim__addListener : MediaQueryList -> Nullable EventListener -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeListener(a)"
   prim__removeListener : MediaQueryList -> Nullable EventListener -> PrimIO ()
@@ -67,7 +67,7 @@ namespace MediaQueryList
 
 
 namespace MediaQueryListEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new MediaQueryListEvent(a,b)"
   prim__new :
@@ -75,12 +75,12 @@ namespace MediaQueryListEvent
     -> UndefOr MediaQueryListEventInit
     -> PrimIO MediaQueryListEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.matches"
   prim__matches : MediaQueryListEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : MediaQueryListEvent -> PrimIO String
@@ -88,32 +88,32 @@ namespace MediaQueryListEvent
 
 
 namespace Screen
-
+  
   export
   %foreign "browser:lambda:x=>x.availHeight"
   prim__availHeight : Screen -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.availWidth"
   prim__availWidth : Screen -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.colorDepth"
   prim__colorDepth : Screen -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : Screen -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pixelDepth"
   prim__pixelDepth : Screen -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : Screen -> PrimIO Int32
@@ -121,28 +121,28 @@ namespace Screen
 
 
 namespace VisualViewport
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetLeft"
   prim__offsetLeft : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetTop"
   prim__offsetTop : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onresize"
   prim__onresize : VisualViewport -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onresize = v}"
   prim__setOnresize :
@@ -151,13 +151,13 @@ namespace VisualViewport
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onscroll"
   prim__onscroll : VisualViewport -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onscroll = v}"
   prim__setOnscroll :
@@ -166,13 +166,13 @@ namespace VisualViewport
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onscrollend"
   prim__onscrollend : VisualViewport -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onscrollend = v}"
   prim__setOnscrollend :
@@ -181,22 +181,22 @@ namespace VisualViewport
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageLeft"
   prim__pageLeft : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageTop"
   prim__pageTop : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scale"
   prim__scale : VisualViewport -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : VisualViewport -> PrimIO Double
@@ -209,7 +209,7 @@ namespace VisualViewport
 --------------------------------------------------------------------------------
 
 namespace GeometryUtils
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.convertPointFromNode(a,b,c)"
   prim__convertPointFromNode :
@@ -219,7 +219,7 @@ namespace GeometryUtils
     -> UndefOr ConvertCoordinateOptions
     -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.convertQuadFromNode(a,b,c)"
   prim__convertQuadFromNode :
@@ -229,7 +229,7 @@ namespace GeometryUtils
     -> UndefOr ConvertCoordinateOptions
     -> PrimIO DOMQuad
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.convertRectFromNode(a,b,c)"
   prim__convertRectFromNode :
@@ -239,7 +239,7 @@ namespace GeometryUtils
     -> UndefOr ConvertCoordinateOptions
     -> PrimIO DOMQuad
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getBoxQuads(a)"
   prim__getBoxQuads :
@@ -255,7 +255,7 @@ namespace GeometryUtils
 --------------------------------------------------------------------------------
 
 namespace BoxQuadOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({box: a,relativeTo: b})"
   prim__new :
@@ -263,19 +263,19 @@ namespace BoxQuadOptions
     -> UndefOr (Union4 Text Element CSSPseudoElement Document)
     -> PrimIO BoxQuadOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.box"
   prim__box : BoxQuadOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.box = v}"
   prim__setBox : BoxQuadOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relativeTo"
   prim__relativeTo :
@@ -283,7 +283,7 @@ namespace BoxQuadOptions
     -> PrimIO (UndefOr (Union4 Text Element CSSPseudoElement Document))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.relativeTo = v}"
   prim__setRelativeTo :
@@ -295,7 +295,7 @@ namespace BoxQuadOptions
 
 
 namespace CheckVisibilityOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({checkOpacity: a,checkVisibilityCSS: b})"
   prim__new :
@@ -303,25 +303,25 @@ namespace CheckVisibilityOptions
     -> UndefOr Boolean
     -> PrimIO CheckVisibilityOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkOpacity"
   prim__checkOpacity : CheckVisibilityOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.checkOpacity = v}"
   prim__setCheckOpacity : CheckVisibilityOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkVisibilityCSS"
   prim__checkVisibilityCSS : CheckVisibilityOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.checkVisibilityCSS = v}"
   prim__setCheckVisibilityCSS :
@@ -333,7 +333,7 @@ namespace CheckVisibilityOptions
 
 
 namespace ConvertCoordinateOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({fromBox: a,toBox: b})"
   prim__new :
@@ -341,25 +341,25 @@ namespace ConvertCoordinateOptions
     -> UndefOr String
     -> PrimIO ConvertCoordinateOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fromBox"
   prim__fromBox : ConvertCoordinateOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fromBox = v}"
   prim__setFromBox : ConvertCoordinateOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toBox"
   prim__toBox : ConvertCoordinateOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.toBox = v}"
   prim__setToBox : ConvertCoordinateOptions -> UndefOr String -> PrimIO ()
@@ -368,7 +368,7 @@ namespace ConvertCoordinateOptions
 
 
 namespace MediaQueryListEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({media: a,matches: b})"
   prim__new :
@@ -376,25 +376,25 @@ namespace MediaQueryListEventInit
     -> UndefOr Boolean
     -> PrimIO MediaQueryListEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.matches"
   prim__matches : MediaQueryListEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.matches = v}"
   prim__setMatches : MediaQueryListEventInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : MediaQueryListEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.media = v}"
   prim__setMedia : MediaQueryListEventInit -> UndefOr String -> PrimIO ()
@@ -403,30 +403,30 @@ namespace MediaQueryListEventInit
 
 
 namespace ScrollIntoViewOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({block: a,inline: b})"
   prim__new : UndefOr String -> UndefOr String -> PrimIO ScrollIntoViewOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.block"
   prim__block : ScrollIntoViewOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.block = v}"
   prim__setBlock : ScrollIntoViewOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inline"
   prim__inline : ScrollIntoViewOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.inline = v}"
   prim__setInline : ScrollIntoViewOptions -> UndefOr String -> PrimIO ()
@@ -435,18 +435,18 @@ namespace ScrollIntoViewOptions
 
 
 namespace ScrollOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({behavior: a})"
   prim__new : UndefOr String -> PrimIO ScrollOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.behavior"
   prim__behavior : ScrollOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.behavior = v}"
   prim__setBehavior : ScrollOptions -> UndefOr String -> PrimIO ()
@@ -455,30 +455,34 @@ namespace ScrollOptions
 
 
 namespace ScrollToOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({left: a,top: b})"
   prim__new : UndefOr Double -> UndefOr Double -> PrimIO ScrollToOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.left"
   prim__left : ScrollToOptions -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.left = v}"
   prim__setLeft : ScrollToOptions -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.top"
   prim__top : ScrollToOptions -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.top = v}"
   prim__setTop : ScrollToOptions -> UndefOr Double -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/CssomviewTypes.idr
+++ b/src/Web/Internal/CssomviewTypes.idr
@@ -10,109 +10,109 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace ScrollBehavior
-
+  
   public export
   data ScrollBehavior = Auto | Instant | Smooth
-
-  public export
+  
+  export
   Show ScrollBehavior where
     show Auto = "auto"
     show Instant = "instant"
     show Smooth = "smooth"
-
-  public export
+  
+  export
   Eq ScrollBehavior where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ScrollBehavior where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ScrollBehavior
   read "auto" = Just Auto
   read "instant" = Just Instant
   read "smooth" = Just Smooth
   read _ = Nothing
-
+  
   export
   ToFFI ScrollBehavior String where
     toFFI = show
-
+  
   export
   FromFFI ScrollBehavior String where
     fromFFI = read
 
 
 namespace ScrollLogicalPosition
-
+  
   public export
   data ScrollLogicalPosition = Start | Center | End | Nearest
-
-  public export
+  
+  export
   Show ScrollLogicalPosition where
     show Start = "start"
     show Center = "center"
     show End = "end"
     show Nearest = "nearest"
-
-  public export
+  
+  export
   Eq ScrollLogicalPosition where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ScrollLogicalPosition where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ScrollLogicalPosition
   read "start" = Just Start
   read "center" = Just Center
   read "end" = Just End
   read "nearest" = Just Nearest
   read _ = Nothing
-
+  
   export
   ToFFI ScrollLogicalPosition String where
     toFFI = show
-
+  
   export
   FromFFI ScrollLogicalPosition String where
     fromFFI = read
 
 
 namespace CSSBoxType
-
+  
   public export
   data CSSBoxType = Margin | Border | Padding | Content
-
-  public export
+  
+  export
   Show CSSBoxType where
     show Margin = "margin"
     show Border = "border"
     show Padding = "padding"
     show Content = "content"
-
-  public export
+  
+  export
   Eq CSSBoxType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CSSBoxType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CSSBoxType
   read "margin" = Just Margin
   read "border" = Just Border
   read "padding" = Just Padding
   read "content" = Just Content
   read _ = Nothing
-
+  
   export
   ToFFI CSSBoxType String where
     toFFI = show
-
+  
   export
   FromFFI CSSBoxType String where
     fromFFI = read
@@ -256,3 +256,5 @@ ToFFI GeometryUtils GeometryUtils where toFFI = id
 
 export
 FromFFI GeometryUtils GeometryUtils where fromFFI = Just
+
+

--- a/src/Web/Internal/DomPrim.idr
+++ b/src/Web/Internal/DomPrim.idr
@@ -11,17 +11,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace AbortController
-
+  
   export
   %foreign "browser:lambda:()=> new AbortController()"
   prim__new : PrimIO AbortController
 
-
+  
   export
   %foreign "browser:lambda:x=>x.signal"
   prim__signal : AbortController -> PrimIO AbortSignal
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : AbortController -> PrimIO ()
@@ -29,23 +29,23 @@ namespace AbortController
 
 
 namespace AbortSignal
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : PrimIO AbortSignal
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aborted"
   prim__aborted : AbortSignal -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : AbortSignal -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : AbortSignal -> Nullable EventHandlerNonNull -> PrimIO ()
@@ -54,27 +54,27 @@ namespace AbortSignal
 
 
 namespace AbstractRange
-
+  
   export
   %foreign "browser:lambda:x=>x.collapsed"
   prim__collapsed : AbstractRange -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endContainer"
   prim__endContainer : AbstractRange -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endOffset"
   prim__endOffset : AbstractRange -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startContainer"
   prim__startContainer : AbstractRange -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startOffset"
   prim__startOffset : AbstractRange -> PrimIO Bits32
@@ -82,43 +82,43 @@ namespace AbstractRange
 
 
 namespace Attr
-
+  
   export
   %foreign "browser:lambda:x=>x.localName"
   prim__localName : Attr -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : Attr -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.namespaceURI"
   prim__namespaceURI : Attr -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ownerElement"
   prim__ownerElement : Attr -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.prefix"
   prim__prefix : Attr -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.specified"
   prim__specified : Attr -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : Attr -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : Attr -> String -> PrimIO ()
@@ -128,44 +128,44 @@ namespace Attr
 
 
 namespace CharacterData
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : CharacterData -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : CharacterData -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : CharacterData -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendData(a)"
   prim__appendData : CharacterData -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.deleteData(a,b)"
   prim__deleteData : CharacterData -> Bits32 -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertData(a,b)"
   prim__insertData : CharacterData -> Bits32 -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.replaceData(a,b,c)"
   prim__replaceData : CharacterData -> Bits32 -> Bits32 -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.substringData(a,b)"
   prim__substringData : CharacterData -> Bits32 -> Bits32 -> PrimIO String
@@ -173,7 +173,7 @@ namespace CharacterData
 
 
 namespace Comment
-
+  
   export
   %foreign "browser:lambda:(a)=> new Comment(a)"
   prim__new : UndefOr String -> PrimIO Comment
@@ -181,17 +181,17 @@ namespace Comment
 
 
 namespace CustomEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new CustomEvent(a,b)"
   prim__new : String -> UndefOr CustomEventInit -> PrimIO CustomEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.detail"
   prim__detail : CustomEvent -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.initCustomEvent(a,b,c,d)"
   prim__initCustomEvent :
@@ -205,7 +205,7 @@ namespace CustomEvent
 
 
 namespace DOMImplementation
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createDocument(a,b,c)"
   prim__createDocument :
@@ -215,7 +215,7 @@ namespace DOMImplementation
     -> UndefOr (Nullable DocumentType)
     -> PrimIO XMLDocument
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createDocumentType(a,b,c)"
   prim__createDocumentType :
@@ -225,7 +225,7 @@ namespace DOMImplementation
     -> String
     -> PrimIO DocumentType
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createHTMLDocument(a)"
   prim__createHTMLDocument :
@@ -233,7 +233,7 @@ namespace DOMImplementation
     -> UndefOr String
     -> PrimIO Document
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hasFeature()"
   prim__hasFeature : DOMImplementation -> PrimIO Boolean
@@ -241,54 +241,54 @@ namespace DOMImplementation
 
 
 namespace DOMTokenList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : DOMTokenList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : DOMTokenList -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : DOMTokenList -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.add(...va())"
   prim__add : DOMTokenList -> IO (Array String) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.contains(a)"
   prim__contains : DOMTokenList -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : DOMTokenList -> Bits32 -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.remove(...va())"
   prim__remove : DOMTokenList -> IO (Array String) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replace(a,b)"
   prim__replace : DOMTokenList -> String -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.supports(a)"
   prim__supports : DOMTokenList -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.toggle(a,b)"
   prim__toggle : DOMTokenList -> String -> UndefOr Boolean -> PrimIO Boolean
@@ -296,248 +296,248 @@ namespace DOMTokenList
 
 
 namespace Document
-
+  
   export
   %foreign "browser:lambda:()=> new Document()"
   prim__new : PrimIO Document
 
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : Document -> String -> PrimIO Object
 
-
+  
   export
   %foreign "browser:lambda:x=>x.URL"
   prim__URL : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alinkColor"
   prim__alinkColor : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alinkColor = v}"
   prim__setAlinkColor : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.all"
   prim__all : Document -> PrimIO HTMLAllCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.anchors"
   prim__anchors : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.applets"
   prim__applets : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.body"
   prim__body : Document -> PrimIO (Nullable HTMLElement)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.body = v}"
   prim__setBody : Document -> Nullable HTMLElement -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.characterSet"
   prim__characterSet : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.charset"
   prim__charset : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compatMode"
   prim__compatMode : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentType"
   prim__contentType : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cookie"
   prim__cookie : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cookie = v}"
   prim__setCookie : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentScript"
   prim__currentScript :
        Document
     -> PrimIO (Nullable (Union2 HTMLScriptElement SVGScriptElement))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultView"
   prim__defaultView : Document -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.designMode"
   prim__designMode : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.designMode = v}"
   prim__setDesignMode : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dir"
   prim__dir : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dir = v}"
   prim__setDir : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.doctype"
   prim__doctype : Document -> PrimIO (Nullable DocumentType)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.documentElement"
   prim__documentElement : Document -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.documentURI"
   prim__documentURI : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.domain"
   prim__domain : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.domain = v}"
   prim__setDomain : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.embeds"
   prim__embeds : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fgColor"
   prim__fgColor : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fgColor = v}"
   prim__setFgColor : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.forms"
   prim__forms : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.head"
   prim__head : Document -> PrimIO (Nullable HTMLHeadElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hidden"
   prim__hidden : Document -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.images"
   prim__images : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.implementation"
   prim__implementation : Document -> PrimIO DOMImplementation
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inputEncoding"
   prim__inputEncoding : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastModified"
   prim__lastModified : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.linkColor"
   prim__linkColor : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.linkColor = v}"
   prim__setLinkColor : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.links"
   prim__links : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.location"
   prim__location : Document -> PrimIO (Nullable Location)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onreadystatechange"
   prim__onreadystatechange : Document -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onreadystatechange = v}"
   prim__setOnreadystatechange :
@@ -546,13 +546,13 @@ namespace Document
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onvisibilitychange"
   prim__onvisibilitychange : Document -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onvisibilitychange = v}"
   prim__setOnvisibilitychange :
@@ -561,81 +561,81 @@ namespace Document
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.plugins"
   prim__plugins : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrer"
   prim__referrer : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rootElement"
   prim__rootElement : Document -> PrimIO (Nullable SVGSVGElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scripts"
   prim__scripts : Document -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollingElement"
   prim__scrollingElement : Document -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timeline"
   prim__timeline : Document -> PrimIO DocumentTimeline
 
-
+  
   export
   %foreign "browser:lambda:x=>x.title"
   prim__title : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.title = v}"
   prim__setTitle : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.visibilityState"
   prim__visibilityState : Document -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vlinkColor"
   prim__vlinkColor : Document -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vlinkColor = v}"
   prim__setVlinkColor : Document -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.adoptNode(a)"
   prim__adoptNode : Document -> Node -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.captureEvents()"
   prim__captureEvents : Document -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.caretPositionFromPoint(a,b)"
   prim__caretPositionFromPoint :
@@ -644,42 +644,42 @@ namespace Document
     -> Double
     -> PrimIO (Nullable CaretPosition)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : Document -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : Document -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createAttribute(a)"
   prim__createAttribute : Document -> String -> PrimIO Attr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createAttributeNS(a,b)"
   prim__createAttributeNS : Document -> Nullable String -> String -> PrimIO Attr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createCDATASection(a)"
   prim__createCDATASection : Document -> String -> PrimIO CDATASection
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createComment(a)"
   prim__createComment : Document -> String -> PrimIO Comment
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createDocumentFragment()"
   prim__createDocumentFragment : Document -> PrimIO DocumentFragment
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createElement(a,b)"
   prim__createElement :
@@ -688,7 +688,7 @@ namespace Document
     -> UndefOr (Union2 String ElementCreationOptions)
     -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createElementNS(a,b,c)"
   prim__createElementNS :
@@ -698,12 +698,12 @@ namespace Document
     -> UndefOr (Union2 String ElementCreationOptions)
     -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createEvent(a)"
   prim__createEvent : Document -> String -> PrimIO Event
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createNodeIterator(a,b,c)"
   prim__createNodeIterator :
@@ -713,7 +713,7 @@ namespace Document
     -> UndefOr (Nullable NodeFilter)
     -> PrimIO NodeIterator
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createProcessingInstruction(a,b)"
   prim__createProcessingInstruction :
@@ -722,17 +722,17 @@ namespace Document
     -> String
     -> PrimIO ProcessingInstruction
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createRange()"
   prim__createRange : Document -> PrimIO Range
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createTextNode(a)"
   prim__createTextNode : Document -> String -> PrimIO Text
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createTreeWalker(a,b,c)"
   prim__createTreeWalker :
@@ -742,7 +742,7 @@ namespace Document
     -> UndefOr (Nullable NodeFilter)
     -> PrimIO TreeWalker
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.elementFromPoint(a,b)"
   prim__elementFromPoint :
@@ -751,7 +751,7 @@ namespace Document
     -> Double
     -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.elementsFromPoint(a,b)"
   prim__elementsFromPoint :
@@ -760,7 +760,7 @@ namespace Document
     -> Double
     -> PrimIO (Array Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.execCommand(a,b,c)"
   prim__execCommand :
@@ -770,27 +770,27 @@ namespace Document
     -> UndefOr String
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAnimations()"
   prim__getAnimations : Document -> PrimIO (Array Animation)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementsByClassName(a)"
   prim__getElementsByClassName : Document -> String -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementsByName(a)"
   prim__getElementsByName : Document -> String -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementsByTagName(a)"
   prim__getElementsByTagName : Document -> String -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getElementsByTagNameNS(a,b)"
   prim__getElementsByTagNameNS :
@@ -799,22 +799,22 @@ namespace Document
     -> String
     -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hasFocus()"
   prim__hasFocus : Document -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.importNode(a,b)"
   prim__importNode : Document -> Node -> UndefOr Boolean -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.open(a,b)"
   prim__open : Document -> UndefOr String -> UndefOr String -> PrimIO Document
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.open(a,b,c)"
   prim__open1 :
@@ -824,42 +824,42 @@ namespace Document
     -> String
     -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queryCommandEnabled(a)"
   prim__queryCommandEnabled : Document -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queryCommandIndeterm(a)"
   prim__queryCommandIndeterm : Document -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queryCommandState(a)"
   prim__queryCommandState : Document -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queryCommandSupported(a)"
   prim__queryCommandSupported : Document -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queryCommandValue(a)"
   prim__queryCommandValue : Document -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.releaseEvents()"
   prim__releaseEvents : Document -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.write(...va())"
   prim__write : Document -> IO (Array String) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.writeln(...va())"
   prim__writeln : Document -> IO (Array String) -> PrimIO ()
@@ -867,7 +867,7 @@ namespace Document
 
 
 namespace DocumentFragment
-
+  
   export
   %foreign "browser:lambda:()=> new DocumentFragment()"
   prim__new : PrimIO DocumentFragment
@@ -875,17 +875,17 @@ namespace DocumentFragment
 
 
 namespace DocumentType
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : DocumentType -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.publicId"
   prim__publicId : DocumentType -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.systemId"
   prim__systemId : DocumentType -> PrimIO String
@@ -893,149 +893,149 @@ namespace DocumentType
 
 
 namespace Element
-
+  
   export
   %foreign "browser:lambda:x=>x.attributes"
   prim__attributes : Element -> PrimIO NamedNodeMap
 
-
+  
   export
   %foreign "browser:lambda:x=>x.classList"
   prim__classList : Element -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.className"
   prim__className : Element -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.className = v}"
   prim__setClassName : Element -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientHeight"
   prim__clientHeight : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientLeft"
   prim__clientLeft : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientTop"
   prim__clientTop : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientWidth"
   prim__clientWidth : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : Element -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.id = v}"
   prim__setId : Element -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.localName"
   prim__localName : Element -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.namespaceURI"
   prim__namespaceURI : Element -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.outerHTML"
   prim__outerHTML : Element -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.outerHTML = v}"
   prim__setOuterHTML : Element -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.prefix"
   prim__prefix : Element -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollHeight"
   prim__scrollHeight : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollLeft"
   prim__scrollLeft : Element -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrollLeft = v}"
   prim__setScrollLeft : Element -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollTop"
   prim__scrollTop : Element -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrollTop = v}"
   prim__setScrollTop : Element -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollWidth"
   prim__scrollWidth : Element -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowRoot"
   prim__shadowRoot : Element -> PrimIO (Nullable ShadowRoot)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.slot"
   prim__slot : Element -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.slot = v}"
   prim__setSlot : Element -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tagName"
   prim__tagName : Element -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.attachShadow(a)"
   prim__attachShadow : Element -> ShadowRootInit -> PrimIO ShadowRoot
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.checkVisibility(a)"
   prim__checkVisibility :
@@ -1043,17 +1043,17 @@ namespace Element
     -> UndefOr CheckVisibilityOptions
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.closest(a)"
   prim__closest : Element -> String -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAttribute(a)"
   prim__getAttribute : Element -> String -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAttributeNS(a,b)"
   prim__getAttributeNS :
@@ -1062,17 +1062,17 @@ namespace Element
     -> String
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAttributeNames()"
   prim__getAttributeNames : Element -> PrimIO (Array String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAttributeNode(a)"
   prim__getAttributeNode : Element -> String -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAttributeNodeNS(a,b)"
   prim__getAttributeNodeNS :
@@ -1081,27 +1081,27 @@ namespace Element
     -> String
     -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getBoundingClientRect()"
   prim__getBoundingClientRect : Element -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getClientRects()"
   prim__getClientRects : Element -> PrimIO DOMRectList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementsByClassName(a)"
   prim__getElementsByClassName : Element -> String -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementsByTagName(a)"
   prim__getElementsByTagName : Element -> String -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getElementsByTagNameNS(a,b)"
   prim__getElementsByTagNameNS :
@@ -1110,22 +1110,22 @@ namespace Element
     -> String
     -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.hasAttribute(a)"
   prim__hasAttribute : Element -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.hasAttributeNS(a,b)"
   prim__hasAttributeNS : Element -> Nullable String -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hasAttributes()"
   prim__hasAttributes : Element -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertAdjacentElement(a,b)"
   prim__insertAdjacentElement :
@@ -1134,62 +1134,62 @@ namespace Element
     -> Element
     -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertAdjacentHTML(a,b)"
   prim__insertAdjacentHTML : Element -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertAdjacentText(a,b)"
   prim__insertAdjacentText : Element -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.matches(a)"
   prim__matches : Element -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.pseudo(a)"
   prim__pseudo : Element -> String -> PrimIO (Nullable CSSPseudoElement)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeAttribute(a)"
   prim__removeAttribute : Element -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.removeAttributeNS(a,b)"
   prim__removeAttributeNS : Element -> Nullable String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeAttributeNode(a)"
   prim__removeAttributeNode : Element -> Attr -> PrimIO Attr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollBy(a)"
   prim__scrollBy : Element -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scrollBy(a,b)"
   prim__scrollBy1 : Element -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scroll(a)"
   prim__scroll : Element -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scroll(a,b)"
   prim__scroll1 : Element -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollIntoView(a)"
   prim__scrollIntoView :
@@ -1197,22 +1197,22 @@ namespace Element
     -> UndefOr (Union2 Boolean ScrollIntoViewOptions)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollTo(a)"
   prim__scrollTo : Element -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scrollTo(a,b)"
   prim__scrollTo1 : Element -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setAttribute(a,b)"
   prim__setAttribute : Element -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setAttributeNS(a,b,c)"
   prim__setAttributeNS :
@@ -1222,22 +1222,22 @@ namespace Element
     -> String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setAttributeNode(a)"
   prim__setAttributeNode : Element -> Attr -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setAttributeNodeNS(a)"
   prim__setAttributeNodeNS : Element -> Attr -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.toggleAttribute(a,b)"
   prim__toggleAttribute : Element -> String -> UndefOr Boolean -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.webkitMatchesSelector(a)"
   prim__webkitMatchesSelector : Element -> String -> PrimIO Boolean
@@ -1245,96 +1245,96 @@ namespace Element
 
 
 namespace Event
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new Event(a,b)"
   prim__new : String -> UndefOr EventInit -> PrimIO Event
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bubbles"
   prim__bubbles : Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cancelBubble"
   prim__cancelBubble : Event -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cancelBubble = v}"
   prim__setCancelBubble : Event -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cancelable"
   prim__cancelable : Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composed"
   prim__composed : Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTarget"
   prim__currentTarget : Event -> PrimIO (Nullable EventTarget)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultPrevented"
   prim__defaultPrevented : Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.eventPhase"
   prim__eventPhase : Event -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isTrusted"
   prim__isTrusted : Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.returnValue"
   prim__returnValue : Event -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.returnValue = v}"
   prim__setReturnValue : Event -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srcElement"
   prim__srcElement : Event -> PrimIO (Nullable EventTarget)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : Event -> PrimIO (Nullable EventTarget)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timeStamp"
   prim__timeStamp : Event -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : Event -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composedPath()"
   prim__composedPath : Event -> PrimIO (Array EventTarget)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.initEvent(a,b,c)"
   prim__initEvent :
@@ -1344,17 +1344,17 @@ namespace Event
     -> UndefOr Boolean
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventDefault()"
   prim__preventDefault : Event -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stopImmediatePropagation()"
   prim__stopImmediatePropagation : Event -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stopPropagation()"
   prim__stopPropagation : Event -> PrimIO ()
@@ -1362,12 +1362,12 @@ namespace Event
 
 
 namespace EventTarget
-
+  
   export
   %foreign "browser:lambda:()=> new EventTarget()"
   prim__new : PrimIO EventTarget
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.addEventListener(a,b,c)"
   prim__addEventListener :
@@ -1377,12 +1377,12 @@ namespace EventTarget
     -> UndefOr (Union2 AddEventListenerOptions Boolean)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.dispatchEvent(a)"
   prim__dispatchEvent : EventTarget -> Event -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.removeEventListener(a,b,c)"
   prim__removeEventListener :
@@ -1395,17 +1395,17 @@ namespace EventTarget
 
 
 namespace HTMLCollection
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : HTMLCollection -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : HTMLCollection -> Bits32 -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem : HTMLCollection -> String -> PrimIO (Nullable Element)
@@ -1413,17 +1413,17 @@ namespace HTMLCollection
 
 
 namespace MutationObserver
-
+  
   export
   %foreign "browser:lambda:(a)=> new MutationObserver(a)"
   prim__new : MutationCallback -> PrimIO MutationObserver
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disconnect()"
   prim__disconnect : MutationObserver -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.observe(a,b)"
   prim__observe :
@@ -1432,7 +1432,7 @@ namespace MutationObserver
     -> UndefOr MutationObserverInit
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.takeRecords()"
   prim__takeRecords : MutationObserver -> PrimIO (Array MutationRecord)
@@ -1440,47 +1440,47 @@ namespace MutationObserver
 
 
 namespace MutationRecord
-
+  
   export
   %foreign "browser:lambda:x=>x.addedNodes"
   prim__addedNodes : MutationRecord -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attributeName"
   prim__attributeName : MutationRecord -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attributeNamespace"
   prim__attributeNamespace : MutationRecord -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nextSibling"
   prim__nextSibling : MutationRecord -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldValue"
   prim__oldValue : MutationRecord -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousSibling"
   prim__previousSibling : MutationRecord -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.removedNodes"
   prim__removedNodes : MutationRecord -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : MutationRecord -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : MutationRecord -> PrimIO String
@@ -1488,12 +1488,12 @@ namespace MutationRecord
 
 
 namespace NamedNodeMap
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : NamedNodeMap -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getNamedItemNS(a,b)"
   prim__getNamedItemNS :
@@ -1502,17 +1502,17 @@ namespace NamedNodeMap
     -> String
     -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getNamedItem(a)"
   prim__getNamedItem : NamedNodeMap -> String -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : NamedNodeMap -> Bits32 -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.removeNamedItemNS(a,b)"
   prim__removeNamedItemNS :
@@ -1521,17 +1521,17 @@ namespace NamedNodeMap
     -> String
     -> PrimIO Attr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeNamedItem(a)"
   prim__removeNamedItem : NamedNodeMap -> String -> PrimIO Attr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setNamedItemNS(a)"
   prim__setNamedItemNS : NamedNodeMap -> Attr -> PrimIO (Nullable Attr)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setNamedItem(a)"
   prim__setNamedItem : NamedNodeMap -> Attr -> PrimIO (Nullable Attr)
@@ -1539,161 +1539,161 @@ namespace NamedNodeMap
 
 
 namespace Node
-
+  
   export
   %foreign "browser:lambda:x=>x.baseURI"
   prim__baseURI : Node -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.childNodes"
   prim__childNodes : Node -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.firstChild"
   prim__firstChild : Node -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isConnected"
   prim__isConnected : Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastChild"
   prim__lastChild : Node -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nextSibling"
   prim__nextSibling : Node -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nodeName"
   prim__nodeName : Node -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nodeType"
   prim__nodeType : Node -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nodeValue"
   prim__nodeValue : Node -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.nodeValue = v}"
   prim__setNodeValue : Node -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ownerDocument"
   prim__ownerDocument : Node -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentElement"
   prim__parentElement : Node -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentNode"
   prim__parentNode : Node -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousSibling"
   prim__previousSibling : Node -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textContent"
   prim__textContent : Node -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.textContent = v}"
   prim__setTextContent : Node -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendChild(a)"
   prim__appendChild : Node -> Node -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.cloneNode(a)"
   prim__cloneNode : Node -> UndefOr Boolean -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.compareDocumentPosition(a)"
   prim__compareDocumentPosition : Node -> Node -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.contains(a)"
   prim__contains : Node -> Nullable Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getRootNode(a)"
   prim__getRootNode : Node -> UndefOr GetRootNodeOptions -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hasChildNodes()"
   prim__hasChildNodes : Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertBefore(a,b)"
   prim__insertBefore : Node -> Node -> Nullable Node -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isDefaultNamespace(a)"
   prim__isDefaultNamespace : Node -> Nullable String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isEqualNode(a)"
   prim__isEqualNode : Node -> Nullable Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isSameNode(a)"
   prim__isSameNode : Node -> Nullable Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.lookupNamespaceURI(a)"
   prim__lookupNamespaceURI : Node -> Nullable String -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.lookupPrefix(a)"
   prim__lookupPrefix : Node -> Nullable String -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.normalize()"
   prim__normalize : Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeChild(a)"
   prim__removeChild : Node -> Node -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceChild(a,b)"
   prim__replaceChild : Node -> Node -> Node -> PrimIO Node
@@ -1701,42 +1701,42 @@ namespace Node
 
 
 namespace NodeIterator
-
+  
   export
   %foreign "browser:lambda:x=>x.filter"
   prim__filter : NodeIterator -> PrimIO (Nullable NodeFilter)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pointerBeforeReferenceNode"
   prim__pointerBeforeReferenceNode : NodeIterator -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referenceNode"
   prim__referenceNode : NodeIterator -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.root"
   prim__root : NodeIterator -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.whatToShow"
   prim__whatToShow : NodeIterator -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.detach()"
   prim__detach : NodeIterator -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nextNode()"
   prim__nextNode : NodeIterator -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousNode()"
   prim__previousNode : NodeIterator -> PrimIO (Nullable Node)
@@ -1744,12 +1744,12 @@ namespace NodeIterator
 
 
 namespace NodeList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : NodeList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : NodeList -> Bits32 -> PrimIO (Nullable Node)
@@ -1757,17 +1757,17 @@ namespace NodeList
 
 
 namespace Performance
-
+  
   export
   %foreign "browser:lambda:x=>x.timeOrigin"
   prim__timeOrigin : Performance -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.now()"
   prim__now : Performance -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : Performance -> PrimIO Object
@@ -1775,7 +1775,7 @@ namespace Performance
 
 
 namespace ProcessingInstruction
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : ProcessingInstruction -> PrimIO String
@@ -1783,132 +1783,132 @@ namespace ProcessingInstruction
 
 
 namespace Range
-
+  
   export
   %foreign "browser:lambda:()=> new Range()"
   prim__new : PrimIO Range
 
-
+  
   export
   %foreign "browser:lambda:x=>x.commonAncestorContainer"
   prim__commonAncestorContainer : Range -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cloneContents()"
   prim__cloneContents : Range -> PrimIO DocumentFragment
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cloneRange()"
   prim__cloneRange : Range -> PrimIO Range
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.collapse(a)"
   prim__collapse : Range -> UndefOr Boolean -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.compareBoundaryPoints(a,b)"
   prim__compareBoundaryPoints : Range -> Bits16 -> Range -> PrimIO Int16
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.comparePoint(a,b)"
   prim__comparePoint : Range -> Node -> Bits32 -> PrimIO Int16
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createContextualFragment(a)"
   prim__createContextualFragment : Range -> String -> PrimIO DocumentFragment
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deleteContents()"
   prim__deleteContents : Range -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.detach()"
   prim__detach : Range -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.extractContents()"
   prim__extractContents : Range -> PrimIO DocumentFragment
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getBoundingClientRect()"
   prim__getBoundingClientRect : Range -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getClientRects()"
   prim__getClientRects : Range -> PrimIO DOMRectList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.insertNode(a)"
   prim__insertNode : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.intersectsNode(a)"
   prim__intersectsNode : Range -> Node -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.isPointInRange(a,b)"
   prim__isPointInRange : Range -> Node -> Bits32 -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.selectNodeContents(a)"
   prim__selectNodeContents : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.selectNode(a)"
   prim__selectNode : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setEndAfter(a)"
   prim__setEndAfter : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setEndBefore(a)"
   prim__setEndBefore : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setEnd(a,b)"
   prim__setEnd : Range -> Node -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setStartAfter(a)"
   prim__setStartAfter : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setStartBefore(a)"
   prim__setStartBefore : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setStart(a,b)"
   prim__setStart : Range -> Node -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.surroundContents(a)"
   prim__surroundContents : Range -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toString()"
   prim__toString : Range -> PrimIO String
@@ -1916,23 +1916,23 @@ namespace Range
 
 
 namespace ShadowRoot
-
+  
   export
   %foreign "browser:lambda:x=>x.host"
   prim__host : ShadowRoot -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : ShadowRoot -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onslotchange"
   prim__onslotchange : ShadowRoot -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onslotchange = v}"
   prim__setOnslotchange :
@@ -1944,7 +1944,7 @@ namespace ShadowRoot
 
 
 namespace StaticRange
-
+  
   export
   %foreign "browser:lambda:(a)=> new StaticRange(a)"
   prim__new : StaticRangeInit -> PrimIO StaticRange
@@ -1952,17 +1952,17 @@ namespace StaticRange
 
 
 namespace Text
-
+  
   export
   %foreign "browser:lambda:(a)=> new Text(a)"
   prim__new : UndefOr String -> PrimIO Text
 
-
+  
   export
   %foreign "browser:lambda:x=>x.wholeText"
   prim__wholeText : Text -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.splitText(a)"
   prim__splitText : Text -> Bits32 -> PrimIO Text
@@ -1970,64 +1970,64 @@ namespace Text
 
 
 namespace TreeWalker
-
+  
   export
   %foreign "browser:lambda:x=>x.currentNode"
   prim__currentNode : TreeWalker -> PrimIO Node
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentNode = v}"
   prim__setCurrentNode : TreeWalker -> Node -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.filter"
   prim__filter : TreeWalker -> PrimIO (Nullable NodeFilter)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.root"
   prim__root : TreeWalker -> PrimIO Node
 
-
+  
   export
   %foreign "browser:lambda:x=>x.whatToShow"
   prim__whatToShow : TreeWalker -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.firstChild()"
   prim__firstChild : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastChild()"
   prim__lastChild : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nextNode()"
   prim__nextNode : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nextSibling()"
   prim__nextSibling : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parentNode()"
   prim__parentNode : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousNode()"
   prim__previousNode : TreeWalker -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousSibling()"
   prim__previousSibling : TreeWalker -> PrimIO (Nullable Node)
@@ -2036,12 +2036,12 @@ namespace TreeWalker
 
 
 namespace XMLSerializer
-
+  
   export
   %foreign "browser:lambda:()=> new XMLSerializer()"
   prim__new : PrimIO XMLSerializer
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.serializeToString(a)"
   prim__serializeToString : XMLSerializer -> Node -> PrimIO String
@@ -2049,7 +2049,7 @@ namespace XMLSerializer
 
 
 namespace XPathEvaluator
-
+  
   export
   %foreign "browser:lambda:()=> new XPathEvaluator()"
   prim__new : PrimIO XPathEvaluator
@@ -2057,7 +2057,7 @@ namespace XPathEvaluator
 
 
 namespace XPathExpression
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.evaluate(a,b,c)"
   prim__evaluate :
@@ -2070,47 +2070,47 @@ namespace XPathExpression
 
 
 namespace XPathResult
-
+  
   export
   %foreign "browser:lambda:x=>x.booleanValue"
   prim__booleanValue : XPathResult -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.invalidIteratorState"
   prim__invalidIteratorState : XPathResult -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberValue"
   prim__numberValue : XPathResult -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resultType"
   prim__resultType : XPathResult -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.singleNodeValue"
   prim__singleNodeValue : XPathResult -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.snapshotLength"
   prim__snapshotLength : XPathResult -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stringValue"
   prim__stringValue : XPathResult -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.iterateNext()"
   prim__iterateNext : XPathResult -> PrimIO (Nullable Node)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.snapshotItem(a)"
   prim__snapshotItem : XPathResult -> Bits32 -> PrimIO (Nullable Node)
@@ -2123,22 +2123,22 @@ namespace XPathResult
 --------------------------------------------------------------------------------
 
 namespace ChildNode
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.after(...va())"
   prim__after : ChildNode -> IO (Array (Union2 Node String)) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.before(...va())"
   prim__before : ChildNode -> IO (Array (Union2 Node String)) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.remove()"
   prim__remove : ChildNode -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.replaceWith(...va())"
   prim__replaceWith : ChildNode -> IO (Array (Union2 Node String)) -> PrimIO ()
@@ -2146,7 +2146,7 @@ namespace ChildNode
 
 
 namespace DocumentOrShadowRoot
-
+  
   export
   %foreign "browser:lambda:x=>x.styleSheets"
   prim__styleSheets : DocumentOrShadowRoot -> PrimIO StyleSheetList
@@ -2154,13 +2154,13 @@ namespace DocumentOrShadowRoot
 
 
 namespace InnerHTML
-
+  
   export
   %foreign "browser:lambda:x=>x.innerHTML"
   prim__innerHTML : InnerHTML -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.innerHTML = v}"
   prim__setInnerHTML : InnerHTML -> String -> PrimIO ()
@@ -2169,14 +2169,14 @@ namespace InnerHTML
 
 
 namespace NonDocumentTypeChildNode
-
+  
   export
   %foreign "browser:lambda:x=>x.nextElementSibling"
   prim__nextElementSibling :
        NonDocumentTypeChildNode
     -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.previousElementSibling"
   prim__previousElementSibling :
@@ -2186,7 +2186,7 @@ namespace NonDocumentTypeChildNode
 
 
 namespace NonElementParentNode
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementById(a)"
   prim__getElementById :
@@ -2197,47 +2197,47 @@ namespace NonElementParentNode
 
 
 namespace ParentNode
-
+  
   export
   %foreign "browser:lambda:x=>x.childElementCount"
   prim__childElementCount : ParentNode -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.children"
   prim__children : ParentNode -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.firstElementChild"
   prim__firstElementChild : ParentNode -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastElementChild"
   prim__lastElementChild : ParentNode -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.append(...va())"
   prim__append : ParentNode -> IO (Array (Union2 Node String)) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.prepend(...va())"
   prim__prepend : ParentNode -> IO (Array (Union2 Node String)) -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.querySelectorAll(a)"
   prim__querySelectorAll : ParentNode -> String -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.querySelector(a)"
   prim__querySelector : ParentNode -> String -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.replaceChildren(...va())"
   prim__replaceChildren :
@@ -2248,7 +2248,7 @@ namespace ParentNode
 
 
 namespace Slottable
-
+  
   export
   %foreign "browser:lambda:x=>x.assignedSlot"
   prim__assignedSlot : Slottable -> PrimIO (Nullable HTMLSlotElement)
@@ -2256,7 +2256,7 @@ namespace Slottable
 
 
 namespace XPathEvaluatorBase
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createExpression(a,b)"
   prim__createExpression :
@@ -2265,12 +2265,12 @@ namespace XPathEvaluatorBase
     -> UndefOr (Nullable XPathNSResolver)
     -> PrimIO XPathExpression
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createNSResolver(a)"
   prim__createNSResolver : XPathEvaluatorBase -> Node -> PrimIO XPathNSResolver
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.evaluate(a,b,c,d,e)"
   prim__evaluate :
@@ -2290,7 +2290,7 @@ namespace XPathEvaluatorBase
 --------------------------------------------------------------------------------
 
 namespace AddEventListenerOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({passive: a,once: b,signal: c})"
   prim__new :
@@ -2299,37 +2299,37 @@ namespace AddEventListenerOptions
     -> UndefOr AbortSignal
     -> PrimIO AddEventListenerOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.once"
   prim__once : AddEventListenerOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.once = v}"
   prim__setOnce : AddEventListenerOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.passive"
   prim__passive : AddEventListenerOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.passive = v}"
   prim__setPassive : AddEventListenerOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.signal"
   prim__signal : AddEventListenerOptions -> PrimIO (UndefOr AbortSignal)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.signal = v}"
   prim__setSignal : AddEventListenerOptions -> UndefOr AbortSignal -> PrimIO ()
@@ -2338,18 +2338,18 @@ namespace AddEventListenerOptions
 
 
 namespace CustomEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({detail: a})"
   prim__new : UndefOr AnyPtr -> PrimIO CustomEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.detail"
   prim__detail : CustomEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.detail = v}"
   prim__setDetail : CustomEventInit -> UndefOr AnyPtr -> PrimIO ()
@@ -2358,18 +2358,18 @@ namespace CustomEventInit
 
 
 namespace ElementCreationOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({is: a})"
   prim__new : UndefOr String -> PrimIO ElementCreationOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.is"
   prim__is : ElementCreationOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.is = v}"
   prim__setIs : ElementCreationOptions -> UndefOr String -> PrimIO ()
@@ -2378,7 +2378,7 @@ namespace ElementCreationOptions
 
 
 namespace EventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({bubbles: a,cancelable: b,composed: c})"
   prim__new :
@@ -2387,37 +2387,37 @@ namespace EventInit
     -> UndefOr Boolean
     -> PrimIO EventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bubbles"
   prim__bubbles : EventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bubbles = v}"
   prim__setBubbles : EventInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cancelable"
   prim__cancelable : EventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cancelable = v}"
   prim__setCancelable : EventInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composed"
   prim__composed : EventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composed = v}"
   prim__setComposed : EventInit -> UndefOr Boolean -> PrimIO ()
@@ -2426,18 +2426,18 @@ namespace EventInit
 
 
 namespace EventListenerOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({capture: a})"
   prim__new : UndefOr Boolean -> PrimIO EventListenerOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.capture"
   prim__capture : EventListenerOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.capture = v}"
   prim__setCapture : EventListenerOptions -> UndefOr Boolean -> PrimIO ()
@@ -2446,18 +2446,18 @@ namespace EventListenerOptions
 
 
 namespace GetRootNodeOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({composed: a})"
   prim__new : UndefOr Boolean -> PrimIO GetRootNodeOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.composed"
   prim__composed : GetRootNodeOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.composed = v}"
   prim__setComposed : GetRootNodeOptions -> UndefOr Boolean -> PrimIO ()
@@ -2466,7 +2466,7 @@ namespace GetRootNodeOptions
 
 
 namespace MutationObserverInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g)=> ({childList: a,attributes: b,characterData: c,subtree: d,attributeOldValue: e,characterDataOldValue: f,attributeFilter: g})"
   prim__new :
@@ -2479,7 +2479,7 @@ namespace MutationObserverInit
     -> UndefOr (Array String)
     -> PrimIO MutationObserverInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attributeFilter"
   prim__attributeFilter :
@@ -2487,7 +2487,7 @@ namespace MutationObserverInit
     -> PrimIO (UndefOr (Array String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.attributeFilter = v}"
   prim__setAttributeFilter :
@@ -2496,13 +2496,13 @@ namespace MutationObserverInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attributeOldValue"
   prim__attributeOldValue : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.attributeOldValue = v}"
   prim__setAttributeOldValue :
@@ -2511,37 +2511,37 @@ namespace MutationObserverInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attributes"
   prim__attributes : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.attributes = v}"
   prim__setAttributes : MutationObserverInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.characterData"
   prim__characterData : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.characterData = v}"
   prim__setCharacterData : MutationObserverInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.characterDataOldValue"
   prim__characterDataOldValue : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.characterDataOldValue = v}"
   prim__setCharacterDataOldValue :
@@ -2550,25 +2550,25 @@ namespace MutationObserverInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.childList"
   prim__childList : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.childList = v}"
   prim__setChildList : MutationObserverInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.subtree"
   prim__subtree : MutationObserverInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.subtree = v}"
   prim__setSubtree : MutationObserverInit -> UndefOr Boolean -> PrimIO ()
@@ -2577,30 +2577,30 @@ namespace MutationObserverInit
 
 
 namespace ShadowRootInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({mode: a,delegatesFocus: b})"
   prim__new : String -> UndefOr Boolean -> PrimIO ShadowRootInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.delegatesFocus"
   prim__delegatesFocus : ShadowRootInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.delegatesFocus = v}"
   prim__setDelegatesFocus : ShadowRootInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : ShadowRootInit -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mode = v}"
   prim__setMode : ShadowRootInit -> String -> PrimIO ()
@@ -2609,54 +2609,54 @@ namespace ShadowRootInit
 
 
 namespace StaticRangeInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({startContainer: a,startOffset: b,endContainer: c,endOffset: d})"
   prim__new : Node -> Bits32 -> Node -> Bits32 -> PrimIO StaticRangeInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endContainer"
   prim__endContainer : StaticRangeInit -> PrimIO Node
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endContainer = v}"
   prim__setEndContainer : StaticRangeInit -> Node -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endOffset"
   prim__endOffset : StaticRangeInit -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endOffset = v}"
   prim__setEndOffset : StaticRangeInit -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startContainer"
   prim__startContainer : StaticRangeInit -> PrimIO Node
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.startContainer = v}"
   prim__setStartContainer : StaticRangeInit -> Node -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startOffset"
   prim__startOffset : StaticRangeInit -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.startOffset = v}"
   prim__setStartOffset : StaticRangeInit -> Bits32 -> PrimIO ()
@@ -2670,7 +2670,7 @@ namespace StaticRangeInit
 --------------------------------------------------------------------------------
 
 namespace EventListener
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toEventListener : (Event -> IO ()) -> PrimIO EventListener
@@ -2678,7 +2678,7 @@ namespace EventListener
 
 
 namespace MutationCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a,b)=>x(a,b)()"
   prim__toMutationCallback :
@@ -2688,7 +2688,7 @@ namespace MutationCallback
 
 
 namespace NodeFilter
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toNodeFilter : (Node -> IO Bits16) -> PrimIO NodeFilter
@@ -2696,9 +2696,11 @@ namespace NodeFilter
 
 
 namespace XPathNSResolver
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toXPathNSResolver :
        (Nullable String -> IO (Nullable String))
     -> PrimIO XPathNSResolver
+
+

--- a/src/Web/Internal/DomTypes.idr
+++ b/src/Web/Internal/DomTypes.idr
@@ -10,33 +10,33 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace ShadowRootMode
-
+  
   public export
   data ShadowRootMode = Open | Closed
-
-  public export
+  
+  export
   Show ShadowRootMode where
     show Open = "open"
     show Closed = "closed"
-
-  public export
+  
+  export
   Eq ShadowRootMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ShadowRootMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ShadowRootMode
   read "open" = Just Open
   read "closed" = Just Closed
   read _ = Nothing
-
+  
   export
   ToFFI ShadowRootMode String where
     toFFI = show
-
+  
   export
   FromFFI ShadowRootMode String where
     fromFFI = read
@@ -649,3 +649,4 @@ ToFFI XPathNSResolver XPathNSResolver where toFFI = id
 
 export
 FromFFI XPathNSResolver XPathNSResolver where fromFFI = Just
+

--- a/src/Web/Internal/FetchPrim.idr
+++ b/src/Web/Internal/FetchPrim.idr
@@ -11,7 +11,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Headers
-
+  
   export
   %foreign "browser:lambda:(a)=> new Headers(a)"
   prim__new :
@@ -19,27 +19,27 @@ namespace Headers
          (Union2 (Array (Array ByteString)) (Record ByteString ByteString))
     -> PrimIO Headers
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.append(a,b)"
   prim__append : Headers -> ByteString -> ByteString -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.delete(a)"
   prim__delete : Headers -> ByteString -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : Headers -> ByteString -> PrimIO (Nullable ByteString)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.has(a)"
   prim__has : Headers -> ByteString -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.set(a,b)"
   prim__set : Headers -> ByteString -> ByteString -> PrimIO ()
@@ -47,87 +47,87 @@ namespace Headers
 
 
 namespace Request
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new Request(a,b)"
   prim__new : Union2 Request String -> UndefOr RequestInit -> PrimIO Request
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cache"
   prim__cache : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.credentials"
   prim__credentials : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.destination"
   prim__destination : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headers"
   prim__headers : Request -> PrimIO Headers
 
-
+  
   export
   %foreign "browser:lambda:x=>x.integrity"
   prim__integrity : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isHistoryNavigation"
   prim__isHistoryNavigation : Request -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isReloadNavigation"
   prim__isReloadNavigation : Request -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keepalive"
   prim__keepalive : Request -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.method"
   prim__method : Request -> PrimIO ByteString
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.redirect"
   prim__redirect : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrer"
   prim__referrer : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.signal"
   prim__signal : Request -> PrimIO AbortSignal
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : Request -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clone()"
   prim__clone : Request -> PrimIO Request
@@ -135,7 +135,7 @@ namespace Request
 
 
 namespace Response
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new Response(a,b)"
   prim__new :
@@ -161,52 +161,52 @@ namespace Response
     -> UndefOr ResponseInit
     -> PrimIO Response
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error()"
   prim__error : PrimIO Response
 
-
+  
   export
   %foreign "browser:lambda:(a,b)=>Response.redirect(a,b)"
   prim__redirect : String -> UndefOr Bits16 -> PrimIO Response
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headers"
   prim__headers : Response -> PrimIO Headers
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ok"
   prim__ok : Response -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.redirected"
   prim__redirected : Response -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.status"
   prim__status : Response -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.statusText"
   prim__statusText : Response -> PrimIO ByteString
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : Response -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : Response -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clone()"
   prim__clone : Response -> PrimIO Response
@@ -219,37 +219,37 @@ namespace Response
 --------------------------------------------------------------------------------
 
 namespace Body
-
+  
   export
   %foreign "browser:lambda:x=>x.body"
   prim__body : Body -> PrimIO (Nullable ReadableStream)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bodyUsed"
   prim__bodyUsed : Body -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.arrayBuffer()"
   prim__arrayBuffer : Body -> PrimIO (Promise ArrayBuffer)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.blob()"
   prim__blob : Body -> PrimIO (Promise Blob)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formData()"
   prim__formData : Body -> PrimIO (Promise FormData)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.json()"
   prim__json : Body -> PrimIO (Promise AnyPtr)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text()"
   prim__text : Body -> PrimIO (Promise String)
@@ -262,7 +262,7 @@ namespace Body
 --------------------------------------------------------------------------------
 
 namespace RequestInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m)=> ({method: a,headers: b,body: c,referrer: d,referrerPolicy: e,mode: f,credentials: g,cache: h,redirect: i,integrity: j,keepalive: k,signal: l,window: m})"
   prim__new :
@@ -299,7 +299,7 @@ namespace RequestInit
     -> UndefOr AnyPtr
     -> PrimIO RequestInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.body"
   prim__body :
@@ -326,7 +326,7 @@ namespace RequestInit
                   String)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.body = v}"
   prim__setBody :
@@ -353,31 +353,31 @@ namespace RequestInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cache"
   prim__cache : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cache = v}"
   prim__setCache : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.credentials"
   prim__credentials : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.credentials = v}"
   prim__setCredentials : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headers"
   prim__headers :
@@ -387,7 +387,7 @@ namespace RequestInit
             (Union2 (Array (Array ByteString)) (Record ByteString ByteString)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.headers = v}"
   prim__setHeaders :
@@ -397,109 +397,109 @@ namespace RequestInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.integrity"
   prim__integrity : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.integrity = v}"
   prim__setIntegrity : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keepalive"
   prim__keepalive : RequestInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.keepalive = v}"
   prim__setKeepalive : RequestInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.method"
   prim__method : RequestInit -> PrimIO (UndefOr ByteString)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.method = v}"
   prim__setMethod : RequestInit -> UndefOr ByteString -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mode = v}"
   prim__setMode : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.redirect"
   prim__redirect : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.redirect = v}"
   prim__setRedirect : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrer"
   prim__referrer : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrer = v}"
   prim__setReferrer : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : RequestInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : RequestInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.signal"
   prim__signal : RequestInit -> PrimIO (UndefOr (Nullable AbortSignal))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.signal = v}"
   prim__setSignal : RequestInit -> UndefOr (Nullable AbortSignal) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.window"
   prim__window : RequestInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.window = v}"
   prim__setWindow : RequestInit -> UndefOr AnyPtr -> PrimIO ()
@@ -508,7 +508,7 @@ namespace RequestInit
 
 
 namespace ResponseInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({status: a,statusText: b,headers: c})"
   prim__new :
@@ -518,7 +518,7 @@ namespace ResponseInit
          (Union2 (Array (Array ByteString)) (Record ByteString ByteString))
     -> PrimIO ResponseInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headers"
   prim__headers :
@@ -528,7 +528,7 @@ namespace ResponseInit
             (Union2 (Array (Array ByteString)) (Record ByteString ByteString)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.headers = v}"
   prim__setHeaders :
@@ -538,25 +538,29 @@ namespace ResponseInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.status"
   prim__status : ResponseInit -> PrimIO (UndefOr Bits16)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.status = v}"
   prim__setStatus : ResponseInit -> UndefOr Bits16 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.statusText"
   prim__statusText : ResponseInit -> PrimIO (UndefOr ByteString)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.statusText = v}"
   prim__setStatusText : ResponseInit -> UndefOr ByteString -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/FetchTypes.idr
+++ b/src/Web/Internal/FetchTypes.idr
@@ -10,7 +10,7 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace RequestDestination
-
+  
   public export
   data RequestDestination =
       Empty
@@ -33,8 +33,8 @@ namespace RequestDestination
     | Video
     | Worker
     | Xslt
-
-  public export
+  
+  export
   Show RequestDestination where
     show Empty = ""
     show Audio = "audio"
@@ -56,16 +56,16 @@ namespace RequestDestination
     show Video = "video"
     show Worker = "worker"
     show Xslt = "xslt"
-
-  public export
+  
+  export
   Eq RequestDestination where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord RequestDestination where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe RequestDestination
   read "" = Just Empty
   read "audio" = Just Audio
@@ -88,90 +88,90 @@ namespace RequestDestination
   read "worker" = Just Worker
   read "xslt" = Just Xslt
   read _ = Nothing
-
+  
   export
   ToFFI RequestDestination String where
     toFFI = show
-
+  
   export
   FromFFI RequestDestination String where
     fromFFI = read
 
 
 namespace RequestMode
-
+  
   public export
   data RequestMode = Navigate | SameOrigin | NoCors | Cors
-
-  public export
+  
+  export
   Show RequestMode where
     show Navigate = "navigate"
     show SameOrigin = "same-origin"
     show NoCors = "no-cors"
     show Cors = "cors"
-
-  public export
+  
+  export
   Eq RequestMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord RequestMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe RequestMode
   read "navigate" = Just Navigate
   read "same-origin" = Just SameOrigin
   read "no-cors" = Just NoCors
   read "cors" = Just Cors
   read _ = Nothing
-
+  
   export
   ToFFI RequestMode String where
     toFFI = show
-
+  
   export
   FromFFI RequestMode String where
     fromFFI = read
 
 
 namespace RequestCredentials
-
+  
   public export
   data RequestCredentials = Omit | SameOrigin | Include
-
-  public export
+  
+  export
   Show RequestCredentials where
     show Omit = "omit"
     show SameOrigin = "same-origin"
     show Include = "include"
-
-  public export
+  
+  export
   Eq RequestCredentials where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord RequestCredentials where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe RequestCredentials
   read "omit" = Just Omit
   read "same-origin" = Just SameOrigin
   read "include" = Just Include
   read _ = Nothing
-
+  
   export
   ToFFI RequestCredentials String where
     toFFI = show
-
+  
   export
   FromFFI RequestCredentials String where
     fromFFI = read
 
 
 namespace RequestCache
-
+  
   public export
   data RequestCache =
       Default
@@ -180,8 +180,8 @@ namespace RequestCache
     | NoCache
     | ForceCache
     | OnlyIfCached
-
-  public export
+  
+  export
   Show RequestCache where
     show Default = "default"
     show NoStore = "no-store"
@@ -189,16 +189,16 @@ namespace RequestCache
     show NoCache = "no-cache"
     show ForceCache = "force-cache"
     show OnlyIfCached = "only-if-cached"
-
-  public export
+  
+  export
   Eq RequestCache where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord RequestCache where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe RequestCache
   read "default" = Just Default
   read "no-store" = Just NoStore
@@ -207,57 +207,57 @@ namespace RequestCache
   read "force-cache" = Just ForceCache
   read "only-if-cached" = Just OnlyIfCached
   read _ = Nothing
-
+  
   export
   ToFFI RequestCache String where
     toFFI = show
-
+  
   export
   FromFFI RequestCache String where
     fromFFI = read
 
 
 namespace RequestRedirect
-
+  
   public export
   data RequestRedirect = Follow | Error | Manual
-
-  public export
+  
+  export
   Show RequestRedirect where
     show Follow = "follow"
     show Error = "error"
     show Manual = "manual"
-
-  public export
+  
+  export
   Eq RequestRedirect where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord RequestRedirect where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe RequestRedirect
   read "follow" = Just Follow
   read "error" = Just Error
   read "manual" = Just Manual
   read _ = Nothing
-
+  
   export
   ToFFI RequestRedirect String where
     toFFI = show
-
+  
   export
   FromFFI RequestRedirect String where
     fromFFI = read
 
 
 namespace ResponseType
-
+  
   public export
   data ResponseType = Basic | Cors | Default | Error | Opaque | Opaqueredirect
-
-  public export
+  
+  export
   Show ResponseType where
     show Basic = "basic"
     show Cors = "cors"
@@ -265,16 +265,16 @@ namespace ResponseType
     show Error = "error"
     show Opaque = "opaque"
     show Opaqueredirect = "opaqueredirect"
-
-  public export
+  
+  export
   Eq ResponseType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ResponseType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ResponseType
   read "basic" = Just Basic
   read "cors" = Just Cors
@@ -283,18 +283,18 @@ namespace ResponseType
   read "opaque" = Just Opaque
   read "opaqueredirect" = Just Opaqueredirect
   read _ = Nothing
-
+  
   export
   ToFFI ResponseType String where
     toFFI = show
-
+  
   export
   FromFFI ResponseType String where
     fromFFI = read
 
 
 namespace ReferrerPolicy
-
+  
   public export
   data ReferrerPolicy =
       Empty
@@ -306,8 +306,8 @@ namespace ReferrerPolicy
     | OriginWhenCrossOrigin
     | StrictOriginWhenCrossOrigin
     | UnsafeUrl
-
-  public export
+  
+  export
   Show ReferrerPolicy where
     show Empty = ""
     show NoReferrer = "no-referrer"
@@ -318,16 +318,16 @@ namespace ReferrerPolicy
     show OriginWhenCrossOrigin = "origin-when-cross-origin"
     show StrictOriginWhenCrossOrigin = "strict-origin-when-cross-origin"
     show UnsafeUrl = "unsafe-url"
-
-  public export
+  
+  export
   Eq ReferrerPolicy where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ReferrerPolicy where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ReferrerPolicy
   read "" = Just Empty
   read "no-referrer" = Just NoReferrer
@@ -339,11 +339,11 @@ namespace ReferrerPolicy
   read "strict-origin-when-cross-origin" = Just StrictOriginWhenCrossOrigin
   read "unsafe-url" = Just UnsafeUrl
   read _ = Nothing
-
+  
   export
   ToFFI ReferrerPolicy String where
     toFFI = show
-
+  
   export
   FromFFI ReferrerPolicy String where
     fromFFI = read
@@ -423,3 +423,5 @@ ToFFI Body Body where toFFI = id
 
 export
 FromFFI Body Body where fromFFI = Just
+
+

--- a/src/Web/Internal/FilePrim.idr
+++ b/src/Web/Internal/FilePrim.idr
@@ -11,7 +11,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Blob
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new Blob(a,b)"
   prim__new :
@@ -34,22 +34,22 @@ namespace Blob
     -> UndefOr BlobPropertyBag
     -> PrimIO Blob
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : Blob -> PrimIO JSBits64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : Blob -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.arrayBuffer()"
   prim__arrayBuffer : Blob -> PrimIO (Promise ArrayBuffer)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.slice(a,b,c)"
   prim__slice :
@@ -59,12 +59,12 @@ namespace Blob
     -> UndefOr String
     -> PrimIO Blob
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stream()"
   prim__stream : Blob -> PrimIO ReadableStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text()"
   prim__text : Blob -> PrimIO (Promise String)
@@ -72,7 +72,7 @@ namespace Blob
 
 
 namespace File
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> new File(a,b,c)"
   prim__new :
@@ -95,12 +95,12 @@ namespace File
     -> UndefOr FilePropertyBag
     -> PrimIO File
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastModified"
   prim__lastModified : File -> PrimIO JSInt64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : File -> PrimIO String
@@ -108,12 +108,12 @@ namespace File
 
 
 namespace FileList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : FileList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : FileList -> Bits32 -> PrimIO (Nullable File)
@@ -121,119 +121,119 @@ namespace FileList
 
 
 namespace FileReader
-
+  
   export
   %foreign "browser:lambda:()=> new FileReader()"
   prim__new : PrimIO FileReader
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : FileReader -> PrimIO (Nullable DOMException)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onload"
   prim__onload : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onload = v}"
   prim__setOnload : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadend"
   prim__onloadend : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadend = v}"
   prim__setOnloadend : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadstart"
   prim__onloadstart : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadstart = v}"
   prim__setOnloadstart : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onprogress"
   prim__onprogress : FileReader -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onprogress = v}"
   prim__setOnprogress : FileReader -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : FileReader -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.result"
   prim__result : FileReader -> PrimIO (Nullable (Union2 String ArrayBuffer))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : FileReader -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsArrayBuffer(a)"
   prim__readAsArrayBuffer : FileReader -> Blob -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsBinaryString(a)"
   prim__readAsBinaryString : FileReader -> Blob -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsDataURL(a)"
   prim__readAsDataURL : FileReader -> Blob -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.readAsText(a,b)"
   prim__readAsText : FileReader -> Blob -> UndefOr String -> PrimIO ()
@@ -241,27 +241,27 @@ namespace FileReader
 
 
 namespace FileReaderSync
-
+  
   export
   %foreign "browser:lambda:()=> new FileReaderSync()"
   prim__new : PrimIO FileReaderSync
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsArrayBuffer(a)"
   prim__readAsArrayBuffer : FileReaderSync -> Blob -> PrimIO ArrayBuffer
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsBinaryString(a)"
   prim__readAsBinaryString : FileReaderSync -> Blob -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readAsDataURL(a)"
   prim__readAsDataURL : FileReaderSync -> Blob -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.readAsText(a,b)"
   prim__readAsText : FileReaderSync -> Blob -> UndefOr String -> PrimIO String
@@ -275,30 +275,30 @@ namespace FileReaderSync
 --------------------------------------------------------------------------------
 
 namespace BlobPropertyBag
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({type: a,endings: b})"
   prim__new : UndefOr String -> UndefOr String -> PrimIO BlobPropertyBag
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endings"
   prim__endings : BlobPropertyBag -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endings = v}"
   prim__setEndings : BlobPropertyBag -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : BlobPropertyBag -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : BlobPropertyBag -> UndefOr String -> PrimIO ()
@@ -307,18 +307,22 @@ namespace BlobPropertyBag
 
 
 namespace FilePropertyBag
-
+  
   export
   %foreign "browser:lambda:(a)=> ({lastModified: a})"
   prim__new : UndefOr JSInt64 -> PrimIO FilePropertyBag
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastModified"
   prim__lastModified : FilePropertyBag -> PrimIO (UndefOr JSInt64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lastModified = v}"
   prim__setLastModified : FilePropertyBag -> UndefOr JSInt64 -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/FileTypes.idr
+++ b/src/Web/Internal/FileTypes.idr
@@ -10,33 +10,33 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace EndingType
-
+  
   public export
   data EndingType = Transparent | Native
-
-  public export
+  
+  export
   Show EndingType where
     show Transparent = "transparent"
     show Native = "native"
-
-  public export
+  
+  export
   Eq EndingType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord EndingType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe EndingType
   read "transparent" = Just Transparent
   read "native" = Just Native
   read _ = Nothing
-
+  
   export
   ToFFI EndingType String where
     toFFI = show
-
+  
   export
   FromFFI EndingType String where
     fromFFI = read
@@ -127,3 +127,6 @@ ToFFI FilePropertyBag FilePropertyBag where toFFI = id
 
 export
 FromFFI FilePropertyBag FilePropertyBag where fromFFI = Just
+
+
+

--- a/src/Web/Internal/GeometryPrim.idr
+++ b/src/Web/Internal/GeometryPrim.idr
@@ -11,37 +11,37 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace DOMMatrix
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrix.fromFloat32Array(a)"
   prim__fromFloat32Array : Float32Array -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrix.fromFloat64Array(a)"
   prim__fromFloat64Array : Float64Array -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrix.fromMatrix(a)"
   prim__fromMatrix : UndefOr DOMMatrixInit -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.invertSelf()"
   prim__invertSelf : DOMMatrix -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.multiplySelf(a)"
   prim__multiplySelf : DOMMatrix -> UndefOr DOMMatrixInit -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.preMultiplySelf(a)"
   prim__preMultiplySelf : DOMMatrix -> UndefOr DOMMatrixInit -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.rotateAxisAngleSelf(a,b,c,d)"
   prim__rotateAxisAngleSelf :
@@ -52,7 +52,7 @@ namespace DOMMatrix
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.rotateFromVectorSelf(a,b)"
   prim__rotateFromVectorSelf :
@@ -61,7 +61,7 @@ namespace DOMMatrix
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.rotateSelf(a,b,c)"
   prim__rotateSelf :
@@ -71,7 +71,7 @@ namespace DOMMatrix
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.scale3dSelf(a,b,c,d)"
   prim__scale3dSelf :
@@ -82,7 +82,7 @@ namespace DOMMatrix
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.scaleSelf(a,b,c,d,e,f)"
   prim__scaleSelf :
@@ -95,22 +95,22 @@ namespace DOMMatrix
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setMatrixValue(a)"
   prim__setMatrixValue : DOMMatrix -> String -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.skewXSelf(a)"
   prim__skewXSelf : DOMMatrix -> UndefOr Double -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.skewYSelf(a)"
   prim__skewYSelf : DOMMatrix -> UndefOr Double -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.translateSelf(a,b,c)"
   prim__translateSelf :
@@ -123,157 +123,157 @@ namespace DOMMatrix
 
 
 namespace DOMMatrixReadOnly
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrixReadOnly.fromFloat32Array(a)"
   prim__fromFloat32Array : Float32Array -> PrimIO DOMMatrixReadOnly
 
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrixReadOnly.fromFloat64Array(a)"
   prim__fromFloat64Array : Float64Array -> PrimIO DOMMatrixReadOnly
 
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMMatrixReadOnly.fromMatrix(a)"
   prim__fromMatrix : UndefOr DOMMatrixInit -> PrimIO DOMMatrixReadOnly
 
-
+  
   export
   %foreign "browser:lambda:x=>x.a"
   prim__a : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.b"
   prim__b : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.c"
   prim__c : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.d"
   prim__d : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.e"
   prim__e : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.f"
   prim__f : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.is2D"
   prim__is2D : DOMMatrixReadOnly -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isIdentity"
   prim__isIdentity : DOMMatrixReadOnly -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m11"
   prim__m11 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m12"
   prim__m12 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m13"
   prim__m13 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m14"
   prim__m14 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m21"
   prim__m21 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m22"
   prim__m22 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m23"
   prim__m23 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m24"
   prim__m24 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m31"
   prim__m31 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m32"
   prim__m32 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m33"
   prim__m33 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m34"
   prim__m34 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m41"
   prim__m41 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m42"
   prim__m42 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m43"
   prim__m43 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m44"
   prim__m44 : DOMMatrixReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.flipX()"
   prim__flipX : DOMMatrixReadOnly -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.flipY()"
   prim__flipY : DOMMatrixReadOnly -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inverse()"
   prim__inverse : DOMMatrixReadOnly -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.multiply(a)"
   prim__multiply :
@@ -281,7 +281,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr DOMMatrixInit
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.rotateAxisAngle(a,b,c,d)"
   prim__rotateAxisAngle :
@@ -292,7 +292,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.rotate(a,b,c)"
   prim__rotate :
@@ -302,7 +302,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.rotateFromVector(a,b)"
   prim__rotateFromVector :
@@ -311,7 +311,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.scale3d(a,b,c,d)"
   prim__scale3d :
@@ -322,7 +322,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.scale(a,b,c,d,e,f)"
   prim__scale :
@@ -335,7 +335,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scaleNonUniform(a,b)"
   prim__scaleNonUniform :
@@ -344,37 +344,37 @@ namespace DOMMatrixReadOnly
     -> UndefOr Double
     -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.skewX(a)"
   prim__skewX : DOMMatrixReadOnly -> UndefOr Double -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.skewY(a)"
   prim__skewY : DOMMatrixReadOnly -> UndefOr Double -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toFloat32Array()"
   prim__toFloat32Array : DOMMatrixReadOnly -> PrimIO Float32Array
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toFloat64Array()"
   prim__toFloat64Array : DOMMatrixReadOnly -> PrimIO Float64Array
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : DOMMatrixReadOnly -> PrimIO Object
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toString()"
   prim__toString : DOMMatrixReadOnly -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.transformPoint(a)"
   prim__transformPoint :
@@ -382,7 +382,7 @@ namespace DOMMatrixReadOnly
     -> UndefOr DOMPointInit
     -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.translate(a,b,c)"
   prim__translate :
@@ -395,7 +395,7 @@ namespace DOMMatrixReadOnly
 
 
 namespace DOMPoint
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMPoint.fromPoint(a)"
   prim__fromPoint : UndefOr DOMPointInit -> PrimIO DOMPoint
@@ -403,32 +403,32 @@ namespace DOMPoint
 
 
 namespace DOMPointReadOnly
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMPointReadOnly.fromPoint(a)"
   prim__fromPoint : UndefOr DOMPointInit -> PrimIO DOMPointReadOnly
 
-
+  
   export
   %foreign "browser:lambda:x=>x.w"
   prim__w : DOMPointReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : DOMPointReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : DOMPointReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.z"
   prim__z : DOMPointReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.matrixTransform(a)"
   prim__matrixTransform :
@@ -436,7 +436,7 @@ namespace DOMPointReadOnly
     -> UndefOr DOMMatrixInit
     -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : DOMPointReadOnly -> PrimIO Object
@@ -444,42 +444,42 @@ namespace DOMPointReadOnly
 
 
 namespace DOMQuad
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMQuad.fromQuad(a)"
   prim__fromQuad : UndefOr DOMQuadInit -> PrimIO DOMQuad
 
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMQuad.fromRect(a)"
   prim__fromRect : UndefOr DOMRectInit -> PrimIO DOMQuad
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p1"
   prim__p1 : DOMQuad -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p2"
   prim__p2 : DOMQuad -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p3"
   prim__p3 : DOMQuad -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p4"
   prim__p4 : DOMQuad -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getBounds()"
   prim__getBounds : DOMQuad -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : DOMQuad -> PrimIO Object
@@ -487,7 +487,7 @@ namespace DOMQuad
 
 
 namespace DOMRect
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMRect.fromRect(a)"
   prim__fromRect : UndefOr DOMRectInit -> PrimIO DOMRect
@@ -495,12 +495,12 @@ namespace DOMRect
 
 
 namespace DOMRectList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : DOMRectList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : DOMRectList -> Bits32 -> PrimIO (Nullable DOMRect)
@@ -508,52 +508,52 @@ namespace DOMRectList
 
 
 namespace DOMRectReadOnly
-
+  
   export
   %foreign "browser:lambda:(a)=>DOMRectReadOnly.fromRect(a)"
   prim__fromRect : UndefOr DOMRectInit -> PrimIO DOMRectReadOnly
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bottom"
   prim__bottom : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.left"
   prim__left : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.right"
   prim__right : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.top"
   prim__top : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : DOMRectReadOnly -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : DOMRectReadOnly -> PrimIO Object
@@ -567,7 +567,7 @@ namespace DOMRectReadOnly
 --------------------------------------------------------------------------------
 
 namespace DOMMatrix2DInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l)=> ({a: a,b: b,c: c,d: d,e: e,f: f,m11: g,m12: h,m21: i,m22: j,m41: k,m42: l})"
   prim__new :
@@ -585,145 +585,145 @@ namespace DOMMatrix2DInit
     -> UndefOr Double
     -> PrimIO DOMMatrix2DInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.a"
   prim__a : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.a = v}"
   prim__setA : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.b"
   prim__b : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.b = v}"
   prim__setB : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.c"
   prim__c : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.c = v}"
   prim__setC : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.d"
   prim__d : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.d = v}"
   prim__setD : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.e"
   prim__e : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.e = v}"
   prim__setE : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.f"
   prim__f : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.f = v}"
   prim__setF : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m11"
   prim__m11 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m11 = v}"
   prim__setM11 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m12"
   prim__m12 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m12 = v}"
   prim__setM12 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m21"
   prim__m21 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m21 = v}"
   prim__setM21 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m22"
   prim__m22 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m22 = v}"
   prim__setM22 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m41"
   prim__m41 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m41 = v}"
   prim__setM41 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m42"
   prim__m42 : DOMMatrix2DInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m42 = v}"
   prim__setM42 : DOMMatrix2DInit -> UndefOr Double -> PrimIO ()
@@ -732,7 +732,7 @@ namespace DOMMatrix2DInit
 
 
 namespace DOMMatrixInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k)=> ({m13: a,m14: b,m23: c,m24: d,m31: e,m32: f,m33: g,m34: h,m43: i,m44: j,is2D: k})"
   prim__new :
@@ -749,133 +749,133 @@ namespace DOMMatrixInit
     -> UndefOr Boolean
     -> PrimIO DOMMatrixInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.is2D"
   prim__is2D : DOMMatrixInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.is2D = v}"
   prim__setIs2D : DOMMatrixInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m13"
   prim__m13 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m13 = v}"
   prim__setM13 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m14"
   prim__m14 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m14 = v}"
   prim__setM14 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m23"
   prim__m23 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m23 = v}"
   prim__setM23 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m24"
   prim__m24 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m24 = v}"
   prim__setM24 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m31"
   prim__m31 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m31 = v}"
   prim__setM31 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m32"
   prim__m32 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m32 = v}"
   prim__setM32 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m33"
   prim__m33 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m33 = v}"
   prim__setM33 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m34"
   prim__m34 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m34 = v}"
   prim__setM34 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m43"
   prim__m43 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m43 = v}"
   prim__setM43 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.m44"
   prim__m44 : DOMMatrixInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.m44 = v}"
   prim__setM44 : DOMMatrixInit -> UndefOr Double -> PrimIO ()
@@ -884,7 +884,7 @@ namespace DOMMatrixInit
 
 
 namespace DOMPointInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({x: a,y: b,z: c,w: d})"
   prim__new :
@@ -894,49 +894,49 @@ namespace DOMPointInit
     -> UndefOr Double
     -> PrimIO DOMPointInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.w"
   prim__w : DOMPointInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.w = v}"
   prim__setW : DOMPointInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : DOMPointInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.x = v}"
   prim__setX : DOMPointInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : DOMPointInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.y = v}"
   prim__setY : DOMPointInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.z"
   prim__z : DOMPointInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.z = v}"
   prim__setZ : DOMPointInit -> UndefOr Double -> PrimIO ()
@@ -945,7 +945,7 @@ namespace DOMPointInit
 
 
 namespace DOMQuadInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({p1: a,p2: b,p3: c,p4: d})"
   prim__new :
@@ -955,49 +955,49 @@ namespace DOMQuadInit
     -> UndefOr DOMPointInit
     -> PrimIO DOMQuadInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p1"
   prim__p1 : DOMQuadInit -> PrimIO (UndefOr DOMPointInit)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.p1 = v}"
   prim__setP1 : DOMQuadInit -> UndefOr DOMPointInit -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p2"
   prim__p2 : DOMQuadInit -> PrimIO (UndefOr DOMPointInit)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.p2 = v}"
   prim__setP2 : DOMQuadInit -> UndefOr DOMPointInit -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p3"
   prim__p3 : DOMQuadInit -> PrimIO (UndefOr DOMPointInit)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.p3 = v}"
   prim__setP3 : DOMQuadInit -> UndefOr DOMPointInit -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.p4"
   prim__p4 : DOMQuadInit -> PrimIO (UndefOr DOMPointInit)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.p4 = v}"
   prim__setP4 : DOMQuadInit -> UndefOr DOMPointInit -> PrimIO ()
@@ -1006,7 +1006,7 @@ namespace DOMQuadInit
 
 
 namespace DOMRectInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({x: a,y: b,width: c,height: d})"
   prim__new :
@@ -1016,49 +1016,53 @@ namespace DOMRectInit
     -> UndefOr Double
     -> PrimIO DOMRectInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : DOMRectInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : DOMRectInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : DOMRectInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : DOMRectInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : DOMRectInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.x = v}"
   prim__setX : DOMRectInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : DOMRectInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.y = v}"
   prim__setY : DOMRectInit -> UndefOr Double -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/GeometryTypes.idr
+++ b/src/Web/Internal/GeometryTypes.idr
@@ -150,3 +150,6 @@ ToFFI DOMRectInit DOMRectInit where toFFI = id
 
 export
 FromFFI DOMRectInit DOMRectInit where fromFFI = Just
+
+
+

--- a/src/Web/Internal/HtmlPrim.idr
+++ b/src/Web/Internal/HtmlPrim.idr
@@ -11,39 +11,39 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace AudioTrack
-
+  
   export
   %foreign "browser:lambda:x=>x.enabled"
   prim__enabled : AudioTrack -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.enabled = v}"
   prim__setEnabled : AudioTrack -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : AudioTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : AudioTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : AudioTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.language"
   prim__language : AudioTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sourceBuffer"
   prim__sourceBuffer : AudioTrack -> PrimIO (Nullable SourceBuffer)
@@ -51,23 +51,23 @@ namespace AudioTrack
 
 
 namespace AudioTrackList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : AudioTrackList -> Bits32 -> PrimIO AudioTrack
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : AudioTrackList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onaddtrack"
   prim__onaddtrack : AudioTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onaddtrack = v}"
   prim__setOnaddtrack :
@@ -76,13 +76,13 @@ namespace AudioTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : AudioTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange :
@@ -91,13 +91,13 @@ namespace AudioTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onremovetrack"
   prim__onremovetrack : AudioTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onremovetrack = v}"
   prim__setOnremovetrack :
@@ -106,7 +106,7 @@ namespace AudioTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getTrackById(a)"
   prim__getTrackById : AudioTrackList -> String -> PrimIO (Nullable AudioTrack)
@@ -114,7 +114,7 @@ namespace AudioTrackList
 
 
 namespace BarProp
-
+  
   export
   %foreign "browser:lambda:x=>x.visible"
   prim__visible : BarProp -> PrimIO Boolean
@@ -122,13 +122,13 @@ namespace BarProp
 
 
 namespace BeforeUnloadEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.returnValue"
   prim__returnValue : BeforeUnloadEvent -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.returnValue = v}"
   prim__setReturnValue : BeforeUnloadEvent -> String -> PrimIO ()
@@ -137,23 +137,23 @@ namespace BeforeUnloadEvent
 
 
 namespace BroadcastChannel
-
+  
   export
   %foreign "browser:lambda:(a)=> new BroadcastChannel(a)"
   prim__new : String -> PrimIO BroadcastChannel
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : BroadcastChannel -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : BroadcastChannel -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage :
@@ -162,7 +162,7 @@ namespace BroadcastChannel
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror :
@@ -170,7 +170,7 @@ namespace BroadcastChannel
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -179,12 +179,12 @@ namespace BroadcastChannel
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : BroadcastChannel -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.postMessage(a)"
   prim__postMessage : BroadcastChannel -> AnyPtr -> PrimIO ()
@@ -192,7 +192,7 @@ namespace BroadcastChannel
 
 
 namespace CanvasGradient
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.addColorStop(a,b)"
   prim__addColorStop : CanvasGradient -> Double -> String -> PrimIO ()
@@ -200,7 +200,7 @@ namespace CanvasGradient
 
 
 namespace CanvasPattern
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setTransform(a)"
   prim__setTransform : CanvasPattern -> UndefOr DOMMatrix2DInit -> PrimIO ()
@@ -208,12 +208,12 @@ namespace CanvasPattern
 
 
 namespace CanvasRenderingContext2D
-
+  
   export
   %foreign "browser:lambda:x=>x.canvas"
   prim__canvas : CanvasRenderingContext2D -> PrimIO HTMLCanvasElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getContextAttributes()"
   prim__getContextAttributes :
@@ -223,22 +223,22 @@ namespace CanvasRenderingContext2D
 
 
 namespace CloseEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new CloseEvent(a,b)"
   prim__new : String -> UndefOr CloseEventInit -> PrimIO CloseEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : CloseEvent -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reason"
   prim__reason : CloseEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.wasClean"
   prim__wasClean : CloseEvent -> PrimIO Boolean
@@ -246,7 +246,7 @@ namespace CloseEvent
 
 
 namespace CustomElementRegistry
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.define(a,b,c)"
   prim__define :
@@ -256,7 +256,7 @@ namespace CustomElementRegistry
     -> UndefOr ElementDefinitionOptions
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get :
@@ -264,12 +264,12 @@ namespace CustomElementRegistry
     -> String
     -> PrimIO (Union2 CustomElementConstructor Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.upgrade(a)"
   prim__upgrade : CustomElementRegistry -> Node -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.whenDefined(a)"
   prim__whenDefined :
@@ -280,12 +280,12 @@ namespace CustomElementRegistry
 
 
 namespace DOMParser
-
+  
   export
   %foreign "browser:lambda:()=> new DOMParser()"
   prim__new : PrimIO DOMParser
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.parseFromString(a,b)"
   prim__parseFromString : DOMParser -> String -> String -> PrimIO Document
@@ -293,17 +293,17 @@ namespace DOMParser
 
 
 namespace DOMStringList
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : DOMStringList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.contains(a)"
   prim__contains : DOMStringList -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : DOMStringList -> Bits32 -> PrimIO (Nullable String)
@@ -311,12 +311,12 @@ namespace DOMStringList
 
 
 namespace DOMStringMap
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : DOMStringMap -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : DOMStringMap -> String -> String -> PrimIO ()
@@ -324,66 +324,66 @@ namespace DOMStringMap
 
 
 namespace DataTransfer
-
+  
   export
   %foreign "browser:lambda:()=> new DataTransfer()"
   prim__new : PrimIO DataTransfer
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dropEffect"
   prim__dropEffect : DataTransfer -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dropEffect = v}"
   prim__setDropEffect : DataTransfer -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.effectAllowed"
   prim__effectAllowed : DataTransfer -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.effectAllowed = v}"
   prim__setEffectAllowed : DataTransfer -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.files"
   prim__files : DataTransfer -> PrimIO FileList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.items"
   prim__items : DataTransfer -> PrimIO DataTransferItemList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.types"
   prim__types : DataTransfer -> PrimIO (Array String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clearData(a)"
   prim__clearData : DataTransfer -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getData(a)"
   prim__getData : DataTransfer -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setData(a,b)"
   prim__setData : DataTransfer -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setDragImage(a,b,c)"
   prim__setDragImage : DataTransfer -> Element -> Int32 -> Int32 -> PrimIO ()
@@ -391,22 +391,22 @@ namespace DataTransfer
 
 
 namespace DataTransferItem
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : DataTransferItem -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : DataTransferItem -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAsFile()"
   prim__getAsFile : DataTransferItem -> PrimIO (Nullable File)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAsString(a)"
   prim__getAsString :
@@ -417,17 +417,17 @@ namespace DataTransferItem
 
 
 namespace DataTransferItemList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : DataTransferItemList -> Bits32 -> PrimIO DataTransferItem
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : DataTransferItemList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.add(a,b)"
   prim__add :
@@ -436,7 +436,7 @@ namespace DataTransferItemList
     -> String
     -> PrimIO (Nullable DataTransferItem)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.add(a)"
   prim__add1 :
@@ -444,12 +444,12 @@ namespace DataTransferItemList
     -> File
     -> PrimIO (Nullable DataTransferItem)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : DataTransferItemList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.remove(a)"
   prim__remove : DataTransferItemList -> Bits32 -> PrimIO ()
@@ -457,12 +457,12 @@ namespace DataTransferItemList
 
 
 namespace DedicatedWorkerGlobalScope
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : DedicatedWorkerGlobalScope -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage :
@@ -470,7 +470,7 @@ namespace DedicatedWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage :
@@ -479,7 +479,7 @@ namespace DedicatedWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror :
@@ -487,7 +487,7 @@ namespace DedicatedWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -496,12 +496,12 @@ namespace DedicatedWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : DedicatedWorkerGlobalScope -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage :
@@ -510,7 +510,7 @@ namespace DedicatedWorkerGlobalScope
     -> Array Object
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -522,12 +522,12 @@ namespace DedicatedWorkerGlobalScope
 
 
 namespace DragEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new DragEvent(a,b)"
   prim__new : String -> UndefOr DragEventInit -> PrimIO DragEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dataTransfer"
   prim__dataTransfer : DragEvent -> PrimIO (Nullable DataTransfer)
@@ -535,47 +535,47 @@ namespace DragEvent
 
 
 namespace ElementInternals
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : ElementInternals -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : ElementInternals -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowRoot"
   prim__shadowRoot : ElementInternals -> PrimIO (Nullable ShadowRoot)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : ElementInternals -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : ElementInternals -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : ElementInternals -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : ElementInternals -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : ElementInternals -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setFormValue(a,b)"
   prim__setFormValue :
@@ -584,7 +584,7 @@ namespace ElementInternals
     -> UndefOr (Nullable (Union3 File String FormData))
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setValidity(a,b,c)"
   prim__setValidity :
@@ -597,32 +597,32 @@ namespace ElementInternals
 
 
 namespace ErrorEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ErrorEvent(a,b)"
   prim__new : String -> UndefOr ErrorEventInit -> PrimIO ErrorEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.colno"
   prim__colno : ErrorEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : ErrorEvent -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.filename"
   prim__filename : ErrorEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lineno"
   prim__lineno : ErrorEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.message"
   prim__message : ErrorEvent -> PrimIO String
@@ -630,63 +630,63 @@ namespace ErrorEvent
 
 
 namespace EventSource
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new EventSource(a,b)"
   prim__new : String -> UndefOr EventSourceInit -> PrimIO EventSource
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : EventSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : EventSource -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : EventSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage : EventSource -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onopen"
   prim__onopen : EventSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onopen = v}"
   prim__setOnopen : EventSource -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : EventSource -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : EventSource -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.withCredentials"
   prim__withCredentials : EventSource -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : EventSource -> PrimIO ()
@@ -694,12 +694,12 @@ namespace EventSource
 
 
 namespace External
-
+  
   export
   %foreign "browser:lambda:x=>x.AddSearchProvider()"
   prim__AddSearchProvider : External -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.IsSearchProviderInstalled()"
   prim__IsSearchProviderInstalled : External -> PrimIO ()
@@ -707,12 +707,12 @@ namespace External
 
 
 namespace FormDataEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new FormDataEvent(a,b)"
   prim__new : String -> FormDataEventInit -> PrimIO FormDataEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formData"
   prim__formData : FormDataEvent -> PrimIO FormData
@@ -720,17 +720,17 @@ namespace FormDataEvent
 
 
 namespace HTMLAllCollection
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : HTMLAllCollection -> Bits32 -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : HTMLAllCollection -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item :
@@ -738,7 +738,7 @@ namespace HTMLAllCollection
     -> UndefOr String
     -> PrimIO (Nullable (Union2 HTMLCollection Element))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem :
@@ -749,167 +749,167 @@ namespace HTMLAllCollection
 
 
 namespace HTMLAnchorElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLAnchorElement()"
   prim__new : PrimIO HTMLAnchorElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.charset"
   prim__charset : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.charset = v}"
   prim__setCharset : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.coords"
   prim__coords : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.coords = v}"
   prim__setCoords : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.download"
   prim__download : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.download = v}"
   prim__setDownload : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hreflang"
   prim__hreflang : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hreflang = v}"
   prim__setHreflang : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ping"
   prim__ping : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ping = v}"
   prim__setPing : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rel"
   prim__rel : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rel = v}"
   prim__setRel : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relList"
   prim__relList : HTMLAnchorElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rev"
   prim__rev : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rev = v}"
   prim__setRev : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shape"
   prim__shape : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shape = v}"
   prim__setShape : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : HTMLAnchorElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLAnchorElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLAnchorElement -> String -> PrimIO ()
@@ -918,119 +918,119 @@ namespace HTMLAnchorElement
 
 
 namespace HTMLAreaElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLAreaElement()"
   prim__new : PrimIO HTMLAreaElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alt"
   prim__alt : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alt = v}"
   prim__setAlt : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.coords"
   prim__coords : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.coords = v}"
   prim__setCoords : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.download"
   prim__download : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.download = v}"
   prim__setDownload : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noHref"
   prim__noHref : HTMLAreaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noHref = v}"
   prim__setNoHref : HTMLAreaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ping"
   prim__ping : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ping = v}"
   prim__setPing : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rel"
   prim__rel : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rel = v}"
   prim__setRel : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relList"
   prim__relList : HTMLAreaElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shape"
   prim__shape : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shape = v}"
   prim__setShape : HTMLAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : HTMLAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget : HTMLAreaElement -> String -> PrimIO ()
@@ -1039,7 +1039,7 @@ namespace HTMLAreaElement
 
 
 namespace HTMLAudioElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLAudioElement()"
   prim__new : PrimIO HTMLAudioElement
@@ -1047,18 +1047,18 @@ namespace HTMLAudioElement
 
 
 namespace HTMLBRElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLBRElement()"
   prim__new : PrimIO HTMLBRElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear"
   prim__clear : HTMLBRElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clear = v}"
   prim__setClear : HTMLBRElement -> String -> PrimIO ()
@@ -1067,30 +1067,30 @@ namespace HTMLBRElement
 
 
 namespace HTMLBaseElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLBaseElement()"
   prim__new : PrimIO HTMLBaseElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : HTMLBaseElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.href = v}"
   prim__setHref : HTMLBaseElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : HTMLBaseElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget : HTMLBaseElement -> String -> PrimIO ()
@@ -1099,78 +1099,78 @@ namespace HTMLBaseElement
 
 
 namespace HTMLBodyElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLBodyElement()"
   prim__new : PrimIO HTMLBodyElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aLink"
   prim__aLink : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.aLink = v}"
   prim__setALink : HTMLBodyElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.background"
   prim__background : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.background = v}"
   prim__setBackground : HTMLBodyElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : HTMLBodyElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.link"
   prim__link : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.link = v}"
   prim__setLink : HTMLBodyElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : HTMLBodyElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vLink"
   prim__vLink : HTMLBodyElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vLink = v}"
   prim__setVLink : HTMLBodyElement -> String -> PrimIO ()
@@ -1179,155 +1179,155 @@ namespace HTMLBodyElement
 
 
 namespace HTMLButtonElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLButtonElement()"
   prim__new : PrimIO HTMLButtonElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLButtonElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLButtonElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLButtonElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formAction"
   prim__formAction : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formAction = v}"
   prim__setFormAction : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formEnctype"
   prim__formEnctype : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formEnctype = v}"
   prim__setFormEnctype : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formMethod"
   prim__formMethod : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formMethod = v}"
   prim__setFormMethod : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formNoValidate"
   prim__formNoValidate : HTMLButtonElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formNoValidate = v}"
   prim__setFormNoValidate : HTMLButtonElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formTarget"
   prim__formTarget : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formTarget = v}"
   prim__setFormTarget : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLButtonElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLButtonElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLButtonElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLButtonElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLButtonElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLButtonElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLButtonElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLButtonElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLButtonElement -> String -> PrimIO ()
@@ -1335,36 +1335,36 @@ namespace HTMLButtonElement
 
 
 namespace HTMLCanvasElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLCanvasElement()"
   prim__new : PrimIO HTMLCanvasElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLCanvasElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLCanvasElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLCanvasElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLCanvasElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getContext(a,b)"
   prim__getContext :
@@ -1379,7 +1379,7 @@ namespace HTMLCanvasElement
                WebGLRenderingContext
                WebGL2RenderingContext))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.toBlob(a,b,c)"
   prim__toBlob :
@@ -1389,7 +1389,7 @@ namespace HTMLCanvasElement
     -> UndefOr AnyPtr
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.toDataURL(a,b)"
   prim__toDataURL :
@@ -1398,7 +1398,7 @@ namespace HTMLCanvasElement
     -> UndefOr AnyPtr
     -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transferControlToOffscreen()"
   prim__transferControlToOffscreen : HTMLCanvasElement -> PrimIO OffscreenCanvas
@@ -1406,18 +1406,18 @@ namespace HTMLCanvasElement
 
 
 namespace HTMLDListElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDListElement()"
   prim__new : PrimIO HTMLDListElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compact"
   prim__compact : HTMLDListElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.compact = v}"
   prim__setCompact : HTMLDListElement -> Boolean -> PrimIO ()
@@ -1426,18 +1426,18 @@ namespace HTMLDListElement
 
 
 namespace HTMLDataElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDataElement()"
   prim__new : PrimIO HTMLDataElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLDataElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLDataElement -> String -> PrimIO ()
@@ -1446,12 +1446,12 @@ namespace HTMLDataElement
 
 
 namespace HTMLDataListElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDataListElement()"
   prim__new : PrimIO HTMLDataListElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.options"
   prim__options : HTMLDataListElement -> PrimIO HTMLCollection
@@ -1459,18 +1459,18 @@ namespace HTMLDataListElement
 
 
 namespace HTMLDetailsElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDetailsElement()"
   prim__new : PrimIO HTMLDetailsElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.open"
   prim__open : HTMLDetailsElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.open = v}"
   prim__setOpen : HTMLDetailsElement -> Boolean -> PrimIO ()
@@ -1479,46 +1479,46 @@ namespace HTMLDetailsElement
 
 
 namespace HTMLDialogElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDialogElement()"
   prim__new : PrimIO HTMLDialogElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.open"
   prim__open : HTMLDialogElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.open = v}"
   prim__setOpen : HTMLDialogElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.returnValue"
   prim__returnValue : HTMLDialogElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.returnValue = v}"
   prim__setReturnValue : HTMLDialogElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.close(a)"
   prim__close : HTMLDialogElement -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.show()"
   prim__show : HTMLDialogElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.showModal()"
   prim__showModal : HTMLDialogElement -> PrimIO ()
@@ -1526,18 +1526,18 @@ namespace HTMLDialogElement
 
 
 namespace HTMLDirectoryElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDirectoryElement()"
   prim__new : PrimIO HTMLDirectoryElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compact"
   prim__compact : HTMLDirectoryElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.compact = v}"
   prim__setCompact : HTMLDirectoryElement -> Boolean -> PrimIO ()
@@ -1546,18 +1546,18 @@ namespace HTMLDirectoryElement
 
 
 namespace HTMLDivElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLDivElement()"
   prim__new : PrimIO HTMLDivElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLDivElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLDivElement -> String -> PrimIO ()
@@ -1566,167 +1566,167 @@ namespace HTMLDivElement
 
 
 namespace HTMLElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLElement()"
   prim__new : PrimIO HTMLElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.accessKey"
   prim__accessKey : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.accessKey = v}"
   prim__setAccessKey : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.accessKeyLabel"
   prim__accessKeyLabel : HTMLElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autocapitalize"
   prim__autocapitalize : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autocapitalize = v}"
   prim__setAutocapitalize : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dir"
   prim__dir : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dir = v}"
   prim__setDir : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.draggable"
   prim__draggable : HTMLElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.draggable = v}"
   prim__setDraggable : HTMLElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hidden"
   prim__hidden : HTMLElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hidden = v}"
   prim__setHidden : HTMLElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.innerText"
   prim__innerText : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.innerText = v}"
   prim__setInnerText : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lang"
   prim__lang : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lang = v}"
   prim__setLang : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetHeight"
   prim__offsetHeight : HTMLElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetLeft"
   prim__offsetLeft : HTMLElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetParent"
   prim__offsetParent : HTMLElement -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetTop"
   prim__offsetTop : HTMLElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetWidth"
   prim__offsetWidth : HTMLElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.spellcheck"
   prim__spellcheck : HTMLElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.spellcheck = v}"
   prim__setSpellcheck : HTMLElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.title"
   prim__title : HTMLElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.title = v}"
   prim__setTitle : HTMLElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.translate"
   prim__translate : HTMLElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.translate = v}"
   prim__setTranslate : HTMLElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.attachInternals()"
   prim__attachInternals : HTMLElement -> PrimIO ElementInternals
 
-
+  
   export
   %foreign "browser:lambda:x=>x.click()"
   prim__click : HTMLElement -> PrimIO ()
@@ -1734,84 +1734,84 @@ namespace HTMLElement
 
 
 namespace HTMLEmbedElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLEmbedElement()"
   prim__new : PrimIO HTMLEmbedElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLEmbedElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLEmbedElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSVGDocument()"
   prim__getSVGDocument : HTMLEmbedElement -> PrimIO (Nullable Document)
@@ -1819,76 +1819,76 @@ namespace HTMLEmbedElement
 
 
 namespace HTMLFieldSetElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLFieldSetElement()"
   prim__new : PrimIO HTMLFieldSetElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLFieldSetElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLFieldSetElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.elements"
   prim__elements : HTMLFieldSetElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLFieldSetElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLFieldSetElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLFieldSetElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLFieldSetElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLFieldSetElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLFieldSetElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLFieldSetElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLFieldSetElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLFieldSetElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLFieldSetElement -> String -> PrimIO ()
@@ -1896,42 +1896,42 @@ namespace HTMLFieldSetElement
 
 
 namespace HTMLFontElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLFontElement()"
   prim__new : PrimIO HTMLFontElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.color"
   prim__color : HTMLFontElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.color = v}"
   prim__setColor : HTMLFontElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.face"
   prim__face : HTMLFontElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.face = v}"
   prim__setFace : HTMLFontElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : HTMLFontElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.size = v}"
   prim__setSize : HTMLFontElement -> String -> PrimIO ()
@@ -1940,7 +1940,7 @@ namespace HTMLFontElement
 
 
 namespace HTMLFormControlsCollection
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem :
@@ -1951,17 +1951,17 @@ namespace HTMLFormControlsCollection
 
 
 namespace HTMLFormElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLFormElement()"
   prim__new : PrimIO HTMLFormElement
 
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : HTMLFormElement -> Bits32 -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get1 :
@@ -1969,152 +1969,152 @@ namespace HTMLFormElement
     -> String
     -> PrimIO (Union2 RadioNodeList Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.acceptCharset"
   prim__acceptCharset : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.acceptCharset = v}"
   prim__setAcceptCharset : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.action"
   prim__action : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.action = v}"
   prim__setAction : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autocomplete"
   prim__autocomplete : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autocomplete = v}"
   prim__setAutocomplete : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.elements"
   prim__elements : HTMLFormElement -> PrimIO HTMLFormControlsCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.encoding"
   prim__encoding : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.encoding = v}"
   prim__setEncoding : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enctype"
   prim__enctype : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.enctype = v}"
   prim__setEnctype : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : HTMLFormElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.method"
   prim__method : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.method = v}"
   prim__setMethod : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noValidate"
   prim__noValidate : HTMLFormElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noValidate = v}"
   prim__setNoValidate : HTMLFormElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rel"
   prim__rel : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rel = v}"
   prim__setRel : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relList"
   prim__relList : HTMLFormElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : HTMLFormElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget : HTMLFormElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLFormElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLFormElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.requestSubmit(a)"
   prim__requestSubmit :
@@ -2122,12 +2122,12 @@ namespace HTMLFormElement
     -> UndefOr (Nullable HTMLElement)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reset()"
   prim__reset : HTMLFormElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.submit()"
   prim__submit : HTMLFormElement -> PrimIO ()
@@ -2135,112 +2135,112 @@ namespace HTMLFormElement
 
 
 namespace HTMLFrameElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLFrameElement()"
   prim__new : PrimIO HTMLFrameElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentDocument"
   prim__contentDocument : HTMLFrameElement -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentWindow"
   prim__contentWindow : HTMLFrameElement -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameBorder"
   prim__frameBorder : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameBorder = v}"
   prim__setFrameBorder : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.longDesc"
   prim__longDesc : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.longDesc = v}"
   prim__setLongDesc : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.marginHeight"
   prim__marginHeight : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.marginHeight = v}"
   prim__setMarginHeight : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.marginWidth"
   prim__marginWidth : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.marginWidth = v}"
   prim__setMarginWidth : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noResize"
   prim__noResize : HTMLFrameElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noResize = v}"
   prim__setNoResize : HTMLFrameElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrolling"
   prim__scrolling : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrolling = v}"
   prim__setScrolling : HTMLFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLFrameElement -> String -> PrimIO ()
@@ -2249,30 +2249,30 @@ namespace HTMLFrameElement
 
 
 namespace HTMLFrameSetElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLFrameSetElement()"
   prim__new : PrimIO HTMLFrameSetElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cols"
   prim__cols : HTMLFrameSetElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cols = v}"
   prim__setCols : HTMLFrameSetElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rows"
   prim__rows : HTMLFrameSetElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rows = v}"
   prim__setRows : HTMLFrameSetElement -> String -> PrimIO ()
@@ -2281,66 +2281,66 @@ namespace HTMLFrameSetElement
 
 
 namespace HTMLHRElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLHRElement()"
   prim__new : PrimIO HTMLHRElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLHRElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLHRElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.color"
   prim__color : HTMLHRElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.color = v}"
   prim__setColor : HTMLHRElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noShade"
   prim__noShade : HTMLHRElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noShade = v}"
   prim__setNoShade : HTMLHRElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : HTMLHRElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.size = v}"
   prim__setSize : HTMLHRElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLHRElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLHRElement -> String -> PrimIO ()
@@ -2349,7 +2349,7 @@ namespace HTMLHRElement
 
 
 namespace HTMLHeadElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLHeadElement()"
   prim__new : PrimIO HTMLHeadElement
@@ -2357,18 +2357,18 @@ namespace HTMLHeadElement
 
 
 namespace HTMLHeadingElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLHeadingElement()"
   prim__new : PrimIO HTMLHeadingElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLHeadingElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLHeadingElement -> String -> PrimIO ()
@@ -2377,18 +2377,18 @@ namespace HTMLHeadingElement
 
 
 namespace HTMLHtmlElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLHtmlElement()"
   prim__new : PrimIO HTMLHtmlElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.version"
   prim__version : HTMLHtmlElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.version = v}"
   prim__setVersion : HTMLHtmlElement -> String -> PrimIO ()
@@ -2397,207 +2397,207 @@ namespace HTMLHtmlElement
 
 
 namespace HTMLIFrameElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLIFrameElement()"
   prim__new : PrimIO HTMLIFrameElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.allow"
   prim__allow : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.allow = v}"
   prim__setAllow : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.allowFullscreen"
   prim__allowFullscreen : HTMLIFrameElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.allowFullscreen = v}"
   prim__setAllowFullscreen : HTMLIFrameElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentDocument"
   prim__contentDocument : HTMLIFrameElement -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentWindow"
   prim__contentWindow : HTMLIFrameElement -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameBorder"
   prim__frameBorder : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameBorder = v}"
   prim__setFrameBorder : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loading"
   prim__loading : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.loading = v}"
   prim__setLoading : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.longDesc"
   prim__longDesc : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.longDesc = v}"
   prim__setLongDesc : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.marginHeight"
   prim__marginHeight : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.marginHeight = v}"
   prim__setMarginHeight : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.marginWidth"
   prim__marginWidth : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.marginWidth = v}"
   prim__setMarginWidth : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sandbox"
   prim__sandbox : HTMLIFrameElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrolling"
   prim__scrolling : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrolling = v}"
   prim__setScrolling : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srcdoc"
   prim__srcdoc : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.srcdoc = v}"
   prim__setSrcdoc : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLIFrameElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLIFrameElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSVGDocument()"
   prim__getSVGDocument : HTMLIFrameElement -> PrimIO (Nullable Document)
@@ -2605,270 +2605,270 @@ namespace HTMLIFrameElement
 
 
 namespace HTMLImageElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLImageElement()"
   prim__new : PrimIO HTMLImageElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alt"
   prim__alt : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alt = v}"
   prim__setAlt : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.border"
   prim__border : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.border = v}"
   prim__setBorder : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.complete"
   prim__complete : HTMLImageElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : HTMLImageElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : HTMLImageElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentSrc"
   prim__currentSrc : HTMLImageElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.decoding"
   prim__decoding : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.decoding = v}"
   prim__setDecoding : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLImageElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLImageElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hspace"
   prim__hspace : HTMLImageElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hspace = v}"
   prim__setHspace : HTMLImageElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isMap"
   prim__isMap : HTMLImageElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.isMap = v}"
   prim__setIsMap : HTMLImageElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loading"
   prim__loading : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.loading = v}"
   prim__setLoading : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.longDesc"
   prim__longDesc : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.longDesc = v}"
   prim__setLongDesc : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lowsrc"
   prim__lowsrc : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lowsrc = v}"
   prim__setLowsrc : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.naturalHeight"
   prim__naturalHeight : HTMLImageElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.naturalWidth"
   prim__naturalWidth : HTMLImageElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sizes"
   prim__sizes : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sizes = v}"
   prim__setSizes : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srcset"
   prim__srcset : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.srcset = v}"
   prim__setSrcset : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.useMap"
   prim__useMap : HTMLImageElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.useMap = v}"
   prim__setUseMap : HTMLImageElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vspace"
   prim__vspace : HTMLImageElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vspace = v}"
   prim__setVspace : HTMLImageElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLImageElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLImageElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : HTMLImageElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : HTMLImageElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.decode()"
   prim__decode : HTMLImageElement -> PrimIO (Promise Undefined)
@@ -2876,535 +2876,535 @@ namespace HTMLImageElement
 
 
 namespace HTMLInputElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLInputElement()"
   prim__new : PrimIO HTMLInputElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.accept"
   prim__accept : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.accept = v}"
   prim__setAccept : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alt"
   prim__alt : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alt = v}"
   prim__setAlt : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autocomplete"
   prim__autocomplete : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autocomplete = v}"
   prim__setAutocomplete : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checked"
   prim__checked : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.checked = v}"
   prim__setChecked : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultChecked"
   prim__defaultChecked : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultChecked = v}"
   prim__setDefaultChecked : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultValue"
   prim__defaultValue : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultValue = v}"
   prim__setDefaultValue : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dirName"
   prim__dirName : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dirName = v}"
   prim__setDirName : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.files"
   prim__files : HTMLInputElement -> PrimIO (Nullable FileList)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.files = v}"
   prim__setFiles : HTMLInputElement -> Nullable FileList -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLInputElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formAction"
   prim__formAction : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formAction = v}"
   prim__setFormAction : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formEnctype"
   prim__formEnctype : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formEnctype = v}"
   prim__setFormEnctype : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formMethod"
   prim__formMethod : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formMethod = v}"
   prim__setFormMethod : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formNoValidate"
   prim__formNoValidate : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formNoValidate = v}"
   prim__setFormNoValidate : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formTarget"
   prim__formTarget : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formTarget = v}"
   prim__setFormTarget : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLInputElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLInputElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.indeterminate"
   prim__indeterminate : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.indeterminate = v}"
   prim__setIndeterminate : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLInputElement -> PrimIO (Nullable NodeList)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.list"
   prim__list : HTMLInputElement -> PrimIO (Nullable HTMLElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.max"
   prim__max : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.max = v}"
   prim__setMax : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.maxLength"
   prim__maxLength : HTMLInputElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.maxLength = v}"
   prim__setMaxLength : HTMLInputElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.min"
   prim__min : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.min = v}"
   prim__setMin : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.minLength"
   prim__minLength : HTMLInputElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.minLength = v}"
   prim__setMinLength : HTMLInputElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.multiple"
   prim__multiple : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.multiple = v}"
   prim__setMultiple : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pattern"
   prim__pattern : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pattern = v}"
   prim__setPattern : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.placeholder"
   prim__placeholder : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.placeholder = v}"
   prim__setPlaceholder : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readOnly"
   prim__readOnly : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.readOnly = v}"
   prim__setReadOnly : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.required"
   prim__required : HTMLInputElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.required = v}"
   prim__setRequired : HTMLInputElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionDirection"
   prim__selectionDirection : HTMLInputElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionDirection = v}"
   prim__setSelectionDirection : HTMLInputElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionEnd"
   prim__selectionEnd : HTMLInputElement -> PrimIO (Nullable Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionEnd = v}"
   prim__setSelectionEnd : HTMLInputElement -> Nullable Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionStart"
   prim__selectionStart : HTMLInputElement -> PrimIO (Nullable Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionStart = v}"
   prim__setSelectionStart : HTMLInputElement -> Nullable Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : HTMLInputElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.size = v}"
   prim__setSize : HTMLInputElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.step"
   prim__step : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.step = v}"
   prim__setStep : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.useMap"
   prim__useMap : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.useMap = v}"
   prim__setUseMap : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLInputElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLInputElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLInputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLInputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueAsDate"
   prim__valueAsDate : HTMLInputElement -> PrimIO (Nullable Object)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueAsDate = v}"
   prim__setValueAsDate : HTMLInputElement -> Nullable Object -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueAsNumber"
   prim__valueAsNumber : HTMLInputElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueAsNumber = v}"
   prim__setValueAsNumber : HTMLInputElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLInputElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLInputElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLInputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLInputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLInputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.select()"
   prim__select : HTMLInputElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLInputElement -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setRangeText(a)"
   prim__setRangeText : HTMLInputElement -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.setRangeText(a,b,c,d)"
   prim__setRangeText1 :
@@ -3415,7 +3415,7 @@ namespace HTMLInputElement
     -> UndefOr String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setSelectionRange(a,b,c)"
   prim__setSelectionRange :
@@ -3425,12 +3425,12 @@ namespace HTMLInputElement
     -> UndefOr String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.stepDown(a)"
   prim__stepDown : HTMLInputElement -> UndefOr Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.stepUp(a)"
   prim__stepUp : HTMLInputElement -> UndefOr Int32 -> PrimIO ()
@@ -3438,30 +3438,30 @@ namespace HTMLInputElement
 
 
 namespace HTMLLIElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLLIElement()"
   prim__new : PrimIO HTMLLIElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLLIElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLLIElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLLIElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLLIElement -> Int32 -> PrimIO ()
@@ -3470,28 +3470,28 @@ namespace HTMLLIElement
 
 
 namespace HTMLLabelElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLLabelElement()"
   prim__new : PrimIO HTMLLabelElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.control"
   prim__control : HTMLLabelElement -> PrimIO (Nullable HTMLElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLLabelElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.htmlFor"
   prim__htmlFor : HTMLLabelElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.htmlFor = v}"
   prim__setHtmlFor : HTMLLabelElement -> String -> PrimIO ()
@@ -3500,24 +3500,24 @@ namespace HTMLLabelElement
 
 
 namespace HTMLLegendElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLLegendElement()"
   prim__new : PrimIO HTMLLegendElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLLegendElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLLegendElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLLegendElement -> PrimIO (Nullable HTMLFormElement)
@@ -3525,196 +3525,196 @@ namespace HTMLLegendElement
 
 
 namespace HTMLLinkElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLLinkElement()"
   prim__new : PrimIO HTMLLinkElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.as"
   prim__as : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.as = v}"
   prim__setAs : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.charset"
   prim__charset : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.charset = v}"
   prim__setCharset : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : HTMLLinkElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : HTMLLinkElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLLinkElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLLinkElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.href = v}"
   prim__setHref : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hreflang"
   prim__hreflang : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hreflang = v}"
   prim__setHreflang : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.imageSizes"
   prim__imageSizes : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.imageSizes = v}"
   prim__setImageSizes : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.imageSrcset"
   prim__imageSrcset : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.imageSrcset = v}"
   prim__setImageSrcset : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.integrity"
   prim__integrity : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.integrity = v}"
   prim__setIntegrity : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.media = v}"
   prim__setMedia : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rel"
   prim__rel : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rel = v}"
   prim__setRel : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relList"
   prim__relList : HTMLLinkElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rev"
   prim__rev : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rev = v}"
   prim__setRev : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sizes"
   prim__sizes : HTMLLinkElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.target = v}"
   prim__setTarget : HTMLLinkElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLLinkElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLLinkElement -> String -> PrimIO ()
@@ -3723,23 +3723,23 @@ namespace HTMLLinkElement
 
 
 namespace HTMLMapElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLMapElement()"
   prim__new : PrimIO HTMLMapElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.areas"
   prim__areas : HTMLMapElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLMapElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLMapElement -> String -> PrimIO ()
@@ -3748,149 +3748,149 @@ namespace HTMLMapElement
 
 
 namespace HTMLMarqueeElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLMarqueeElement()"
   prim__new : PrimIO HTMLMarqueeElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.behavior"
   prim__behavior : HTMLMarqueeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.behavior = v}"
   prim__setBehavior : HTMLMarqueeElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : HTMLMarqueeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : HTMLMarqueeElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.direction"
   prim__direction : HTMLMarqueeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.direction = v}"
   prim__setDirection : HTMLMarqueeElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLMarqueeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLMarqueeElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hspace"
   prim__hspace : HTMLMarqueeElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hspace = v}"
   prim__setHspace : HTMLMarqueeElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loop"
   prim__loop : HTMLMarqueeElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.loop = v}"
   prim__setLoop : HTMLMarqueeElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollAmount"
   prim__scrollAmount : HTMLMarqueeElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrollAmount = v}"
   prim__setScrollAmount : HTMLMarqueeElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollDelay"
   prim__scrollDelay : HTMLMarqueeElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrollDelay = v}"
   prim__setScrollDelay : HTMLMarqueeElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.trueSpeed"
   prim__trueSpeed : HTMLMarqueeElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.trueSpeed = v}"
   prim__setTrueSpeed : HTMLMarqueeElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vspace"
   prim__vspace : HTMLMarqueeElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vspace = v}"
   prim__setVspace : HTMLMarqueeElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLMarqueeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLMarqueeElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start()"
   prim__start : HTMLMarqueeElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stop()"
   prim__stop : HTMLMarqueeElement -> PrimIO ()
@@ -3898,211 +3898,211 @@ namespace HTMLMarqueeElement
 
 
 namespace HTMLMediaElement
-
+  
   export
   %foreign "browser:lambda:x=>x.audioTracks"
   prim__audioTracks : HTMLMediaElement -> PrimIO AudioTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoplay"
   prim__autoplay : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoplay = v}"
   prim__setAutoplay : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.buffered"
   prim__buffered : HTMLMediaElement -> PrimIO TimeRanges
 
-
+  
   export
   %foreign "browser:lambda:x=>x.controls"
   prim__controls : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.controls = v}"
   prim__setControls : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : HTMLMediaElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : HTMLMediaElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentSrc"
   prim__currentSrc : HTMLMediaElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTime"
   prim__currentTime : HTMLMediaElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentTime = v}"
   prim__setCurrentTime : HTMLMediaElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultMuted"
   prim__defaultMuted : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultMuted = v}"
   prim__setDefaultMuted : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultPlaybackRate"
   prim__defaultPlaybackRate : HTMLMediaElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultPlaybackRate = v}"
   prim__setDefaultPlaybackRate : HTMLMediaElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.duration"
   prim__duration : HTMLMediaElement -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ended"
   prim__ended : HTMLMediaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : HTMLMediaElement -> PrimIO (Nullable MediaError)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loop"
   prim__loop : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.loop = v}"
   prim__setLoop : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.muted"
   prim__muted : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.muted = v}"
   prim__setMuted : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.networkState"
   prim__networkState : HTMLMediaElement -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.paused"
   prim__paused : HTMLMediaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.playbackRate"
   prim__playbackRate : HTMLMediaElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.playbackRate = v}"
   prim__setPlaybackRate : HTMLMediaElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.played"
   prim__played : HTMLMediaElement -> PrimIO TimeRanges
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preload"
   prim__preload : HTMLMediaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preload = v}"
   prim__setPreload : HTMLMediaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preservesPitch"
   prim__preservesPitch : HTMLMediaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preservesPitch = v}"
   prim__setPreservesPitch : HTMLMediaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : HTMLMediaElement -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.seekable"
   prim__seekable : HTMLMediaElement -> PrimIO TimeRanges
 
-
+  
   export
   %foreign "browser:lambda:x=>x.seeking"
   prim__seeking : HTMLMediaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLMediaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLMediaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srcObject"
   prim__srcObject :
@@ -4110,7 +4110,7 @@ namespace HTMLMediaElement
     -> PrimIO (Nullable (Union3 MediaStream MediaSource Blob))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.srcObject = v}"
   prim__setSrcObject :
@@ -4119,29 +4119,29 @@ namespace HTMLMediaElement
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textTracks"
   prim__textTracks : HTMLMediaElement -> PrimIO TextTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.videoTracks"
   prim__videoTracks : HTMLMediaElement -> PrimIO VideoTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.volume"
   prim__volume : HTMLMediaElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.volume = v}"
   prim__setVolume : HTMLMediaElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.addTextTrack(a,b,c)"
   prim__addTextTrack :
@@ -4151,32 +4151,32 @@ namespace HTMLMediaElement
     -> UndefOr String
     -> PrimIO TextTrack
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.canPlayType(a)"
   prim__canPlayType : HTMLMediaElement -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.fastSeek(a)"
   prim__fastSeek : HTMLMediaElement -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getStartDate()"
   prim__getStartDate : HTMLMediaElement -> PrimIO Object
 
-
+  
   export
   %foreign "browser:lambda:x=>x.load()"
   prim__load : HTMLMediaElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pause()"
   prim__pause : HTMLMediaElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.play()"
   prim__play : HTMLMediaElement -> PrimIO (Promise Undefined)
@@ -4184,18 +4184,18 @@ namespace HTMLMediaElement
 
 
 namespace HTMLMenuElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLMenuElement()"
   prim__new : PrimIO HTMLMenuElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compact"
   prim__compact : HTMLMenuElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.compact = v}"
   prim__setCompact : HTMLMenuElement -> Boolean -> PrimIO ()
@@ -4204,54 +4204,54 @@ namespace HTMLMenuElement
 
 
 namespace HTMLMetaElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLMetaElement()"
   prim__new : PrimIO HTMLMetaElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.content"
   prim__content : HTMLMetaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.content = v}"
   prim__setContent : HTMLMetaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.httpEquiv"
   prim__httpEquiv : HTMLMetaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.httpEquiv = v}"
   prim__setHttpEquiv : HTMLMetaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLMetaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLMetaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scheme"
   prim__scheme : HTMLMetaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scheme = v}"
   prim__setScheme : HTMLMetaElement -> String -> PrimIO ()
@@ -4260,83 +4260,83 @@ namespace HTMLMetaElement
 
 
 namespace HTMLMeterElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLMeterElement()"
   prim__new : PrimIO HTMLMeterElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.high"
   prim__high : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.high = v}"
   prim__setHigh : HTMLMeterElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLMeterElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.low"
   prim__low : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.low = v}"
   prim__setLow : HTMLMeterElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.max"
   prim__max : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.max = v}"
   prim__setMax : HTMLMeterElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.min"
   prim__min : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.min = v}"
   prim__setMin : HTMLMeterElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.optimum"
   prim__optimum : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.optimum = v}"
   prim__setOptimum : HTMLMeterElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLMeterElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLMeterElement -> Double -> PrimIO ()
@@ -4345,30 +4345,30 @@ namespace HTMLMeterElement
 
 
 namespace HTMLModElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLModElement()"
   prim__new : PrimIO HTMLModElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cite"
   prim__cite : HTMLModElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cite = v}"
   prim__setCite : HTMLModElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dateTime"
   prim__dateTime : HTMLModElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dateTime = v}"
   prim__setDateTime : HTMLModElement -> String -> PrimIO ()
@@ -4377,54 +4377,54 @@ namespace HTMLModElement
 
 
 namespace HTMLOListElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLOListElement()"
   prim__new : PrimIO HTMLOListElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compact"
   prim__compact : HTMLOListElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.compact = v}"
   prim__setCompact : HTMLOListElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reversed"
   prim__reversed : HTMLOListElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.reversed = v}"
   prim__setReversed : HTMLOListElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start"
   prim__start : HTMLOListElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.start = v}"
   prim__setStart : HTMLOListElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLOListElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLOListElement -> String -> PrimIO ()
@@ -4433,249 +4433,249 @@ namespace HTMLOListElement
 
 
 namespace HTMLObjectElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLObjectElement()"
   prim__new : PrimIO HTMLObjectElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.archive"
   prim__archive : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.archive = v}"
   prim__setArchive : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.border"
   prim__border : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.border = v}"
   prim__setBorder : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.code = v}"
   prim__setCode : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.codeBase"
   prim__codeBase : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.codeBase = v}"
   prim__setCodeBase : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.codeType"
   prim__codeType : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.codeType = v}"
   prim__setCodeType : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentDocument"
   prim__contentDocument : HTMLObjectElement -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.contentWindow"
   prim__contentWindow : HTMLObjectElement -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.declare"
   prim__declare : HTMLObjectElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.declare = v}"
   prim__setDeclare : HTMLObjectElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLObjectElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hspace"
   prim__hspace : HTMLObjectElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hspace = v}"
   prim__setHspace : HTMLObjectElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.standby"
   prim__standby : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.standby = v}"
   prim__setStandby : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.useMap"
   prim__useMap : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.useMap = v}"
   prim__setUseMap : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLObjectElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLObjectElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vspace"
   prim__vspace : HTMLObjectElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vspace = v}"
   prim__setVspace : HTMLObjectElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLObjectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLObjectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLObjectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLObjectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSVGDocument()"
   prim__getSVGDocument : HTMLObjectElement -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLObjectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLObjectElement -> String -> PrimIO ()
@@ -4683,30 +4683,30 @@ namespace HTMLObjectElement
 
 
 namespace HTMLOptGroupElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLOptGroupElement()"
   prim__new : PrimIO HTMLOptGroupElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLOptGroupElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLOptGroupElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : HTMLOptGroupElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.label = v}"
   prim__setLabel : HTMLOptGroupElement -> String -> PrimIO ()
@@ -4715,88 +4715,88 @@ namespace HTMLOptGroupElement
 
 
 namespace HTMLOptionElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLOptionElement()"
   prim__new : PrimIO HTMLOptionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultSelected"
   prim__defaultSelected : HTMLOptionElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultSelected = v}"
   prim__setDefaultSelected : HTMLOptionElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLOptionElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLOptionElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLOptionElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.index"
   prim__index : HTMLOptionElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : HTMLOptionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.label = v}"
   prim__setLabel : HTMLOptionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selected"
   prim__selected : HTMLOptionElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selected = v}"
   prim__setSelected : HTMLOptionElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : HTMLOptionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : HTMLOptionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLOptionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLOptionElement -> String -> PrimIO ()
@@ -4805,7 +4805,7 @@ namespace HTMLOptionElement
 
 
 namespace HTMLOptionsCollection
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set :
@@ -4814,31 +4814,31 @@ namespace HTMLOptionsCollection
     -> Nullable HTMLOptionElement
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : HTMLOptionsCollection -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.length = v}"
   prim__setLength : HTMLOptionsCollection -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectedIndex"
   prim__selectedIndex : HTMLOptionsCollection -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectedIndex = v}"
   prim__setSelectedIndex : HTMLOptionsCollection -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.add(a,b)"
   prim__add :
@@ -4847,7 +4847,7 @@ namespace HTMLOptionsCollection
     -> UndefOr (Nullable (Union2 HTMLElement Int32))
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.remove(a)"
   prim__remove : HTMLOptionsCollection -> Int32 -> PrimIO ()
@@ -4855,93 +4855,93 @@ namespace HTMLOptionsCollection
 
 
 namespace HTMLOutputElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLOutputElement()"
   prim__new : PrimIO HTMLOutputElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultValue"
   prim__defaultValue : HTMLOutputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultValue = v}"
   prim__setDefaultValue : HTMLOutputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLOutputElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.htmlFor"
   prim__htmlFor : HTMLOutputElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLOutputElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLOutputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLOutputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLOutputElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLOutputElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLOutputElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLOutputElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLOutputElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLOutputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLOutputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLOutputElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLOutputElement -> String -> PrimIO ()
@@ -4949,18 +4949,18 @@ namespace HTMLOutputElement
 
 
 namespace HTMLParagraphElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLParagraphElement()"
   prim__new : PrimIO HTMLParagraphElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLParagraphElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLParagraphElement -> String -> PrimIO ()
@@ -4969,54 +4969,54 @@ namespace HTMLParagraphElement
 
 
 namespace HTMLParamElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLParamElement()"
   prim__new : PrimIO HTMLParamElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLParamElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLParamElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLParamElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLParamElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLParamElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLParamElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueType"
   prim__valueType : HTMLParamElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueType = v}"
   prim__setValueType : HTMLParamElement -> String -> PrimIO ()
@@ -5025,7 +5025,7 @@ namespace HTMLParamElement
 
 
 namespace HTMLPictureElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLPictureElement()"
   prim__new : PrimIO HTMLPictureElement
@@ -5033,18 +5033,18 @@ namespace HTMLPictureElement
 
 
 namespace HTMLPreElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLPreElement()"
   prim__new : PrimIO HTMLPreElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLPreElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLPreElement -> Int32 -> PrimIO ()
@@ -5053,40 +5053,40 @@ namespace HTMLPreElement
 
 
 namespace HTMLProgressElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLProgressElement()"
   prim__new : PrimIO HTMLProgressElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLProgressElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.max"
   prim__max : HTMLProgressElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.max = v}"
   prim__setMax : HTMLProgressElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.position"
   prim__position : HTMLProgressElement -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLProgressElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLProgressElement -> Double -> PrimIO ()
@@ -5095,18 +5095,18 @@ namespace HTMLProgressElement
 
 
 namespace HTMLQuoteElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLQuoteElement()"
   prim__new : PrimIO HTMLQuoteElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cite"
   prim__cite : HTMLQuoteElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cite = v}"
   prim__setCite : HTMLQuoteElement -> String -> PrimIO ()
@@ -5115,150 +5115,150 @@ namespace HTMLQuoteElement
 
 
 namespace HTMLScriptElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLScriptElement()"
   prim__new : PrimIO HTMLScriptElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.async"
   prim__async : HTMLScriptElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.async = v}"
   prim__setAsync : HTMLScriptElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.charset"
   prim__charset : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.charset = v}"
   prim__setCharset : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : HTMLScriptElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : HTMLScriptElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defer"
   prim__defer : HTMLScriptElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defer = v}"
   prim__setDefer : HTMLScriptElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.event"
   prim__event : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.event = v}"
   prim__setEvent : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.htmlFor"
   prim__htmlFor : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.htmlFor = v}"
   prim__setHtmlFor : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.integrity"
   prim__integrity : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.integrity = v}"
   prim__setIntegrity : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noModule"
   prim__noModule : HTMLScriptElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noModule = v}"
   prim__setNoModule : HTMLScriptElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : HTMLScriptElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLScriptElement -> String -> PrimIO ()
@@ -5267,12 +5267,12 @@ namespace HTMLScriptElement
 
 
 namespace HTMLSelectElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLSelectElement()"
   prim__new : PrimIO HTMLSelectElement
 
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set :
@@ -5281,155 +5281,155 @@ namespace HTMLSelectElement
     -> Nullable HTMLOptionElement
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autocomplete"
   prim__autocomplete : HTMLSelectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autocomplete = v}"
   prim__setAutocomplete : HTMLSelectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLSelectElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLSelectElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLSelectElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLSelectElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : HTMLSelectElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.length = v}"
   prim__setLength : HTMLSelectElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.multiple"
   prim__multiple : HTMLSelectElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.multiple = v}"
   prim__setMultiple : HTMLSelectElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLSelectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLSelectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.options"
   prim__options : HTMLSelectElement -> PrimIO HTMLOptionsCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.required"
   prim__required : HTMLSelectElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.required = v}"
   prim__setRequired : HTMLSelectElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectedIndex"
   prim__selectedIndex : HTMLSelectElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectedIndex = v}"
   prim__setSelectedIndex : HTMLSelectElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectedOptions"
   prim__selectedOptions : HTMLSelectElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : HTMLSelectElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.size = v}"
   prim__setSize : HTMLSelectElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLSelectElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLSelectElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLSelectElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLSelectElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLSelectElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLSelectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.add(a,b)"
   prim__add :
@@ -5438,17 +5438,17 @@ namespace HTMLSelectElement
     -> UndefOr (Nullable (Union2 HTMLElement Int32))
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLSelectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : HTMLSelectElement -> Bits32 -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem :
@@ -5456,22 +5456,22 @@ namespace HTMLSelectElement
     -> String
     -> PrimIO (Nullable HTMLOptionElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.remove()"
   prim__remove : HTMLSelectElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.remove(a)"
   prim__remove1 : HTMLSelectElement -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLSelectElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLSelectElement -> String -> PrimIO ()
@@ -5479,24 +5479,24 @@ namespace HTMLSelectElement
 
 
 namespace HTMLSlotElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLSlotElement()"
   prim__new : PrimIO HTMLSlotElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLSlotElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLSlotElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.assignedElements(a)"
   prim__assignedElements :
@@ -5504,7 +5504,7 @@ namespace HTMLSlotElement
     -> UndefOr AssignedNodesOptions
     -> PrimIO (Array Element)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.assignedNodes(a)"
   prim__assignedNodes :
@@ -5515,90 +5515,90 @@ namespace HTMLSlotElement
 
 
 namespace HTMLSourceElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLSourceElement()"
   prim__new : PrimIO HTMLSourceElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLSourceElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLSourceElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : HTMLSourceElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.media = v}"
   prim__setMedia : HTMLSourceElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sizes"
   prim__sizes : HTMLSourceElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sizes = v}"
   prim__setSizes : HTMLSourceElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLSourceElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLSourceElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srcset"
   prim__srcset : HTMLSourceElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.srcset = v}"
   prim__setSrcset : HTMLSourceElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLSourceElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLSourceElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLSourceElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLSourceElement -> Bits32 -> PrimIO ()
@@ -5607,7 +5607,7 @@ namespace HTMLSourceElement
 
 
 namespace HTMLSpanElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLSpanElement()"
   prim__new : PrimIO HTMLSpanElement
@@ -5615,30 +5615,30 @@ namespace HTMLSpanElement
 
 
 namespace HTMLStyleElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLStyleElement()"
   prim__new : PrimIO HTMLStyleElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : HTMLStyleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.media = v}"
   prim__setMedia : HTMLStyleElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLStyleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLStyleElement -> String -> PrimIO ()
@@ -5647,18 +5647,18 @@ namespace HTMLStyleElement
 
 
 namespace HTMLTableCaptionElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableCaptionElement()"
   prim__new : PrimIO HTMLTableCaptionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableCaptionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableCaptionElement -> String -> PrimIO ()
@@ -5667,179 +5667,179 @@ namespace HTMLTableCaptionElement
 
 
 namespace HTMLTableCellElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableCellElement()"
   prim__new : PrimIO HTMLTableCellElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abbr"
   prim__abbr : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.abbr = v}"
   prim__setAbbr : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.axis"
   prim__axis : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.axis = v}"
   prim__setAxis : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cellIndex"
   prim__cellIndex : HTMLTableCellElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ch"
   prim__ch : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ch = v}"
   prim__setCh : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.chOff"
   prim__chOff : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.chOff = v}"
   prim__setChOff : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.colSpan"
   prim__colSpan : HTMLTableCellElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.colSpan = v}"
   prim__setColSpan : HTMLTableCellElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headers"
   prim__headers : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.headers = v}"
   prim__setHeaders : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noWrap"
   prim__noWrap : HTMLTableCellElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noWrap = v}"
   prim__setNoWrap : HTMLTableCellElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rowSpan"
   prim__rowSpan : HTMLTableCellElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rowSpan = v}"
   prim__setRowSpan : HTMLTableCellElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scope"
   prim__scope : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scope = v}"
   prim__setScope : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vAlign"
   prim__vAlign : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vAlign = v}"
   prim__setVAlign : HTMLTableCellElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLTableCellElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLTableCellElement -> String -> PrimIO ()
@@ -5848,78 +5848,78 @@ namespace HTMLTableCellElement
 
 
 namespace HTMLTableColElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableColElement()"
   prim__new : PrimIO HTMLTableColElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableColElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableColElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ch"
   prim__ch : HTMLTableColElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ch = v}"
   prim__setCh : HTMLTableColElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.chOff"
   prim__chOff : HTMLTableColElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.chOff = v}"
   prim__setChOff : HTMLTableColElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.span"
   prim__span : HTMLTableColElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.span = v}"
   prim__setSpan : HTMLTableColElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vAlign"
   prim__vAlign : HTMLTableColElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vAlign = v}"
   prim__setVAlign : HTMLTableColElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLTableColElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLTableColElement -> String -> PrimIO ()
@@ -5928,54 +5928,54 @@ namespace HTMLTableColElement
 
 
 namespace HTMLTableElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableElement()"
   prim__new : PrimIO HTMLTableElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.border"
   prim__border : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.border = v}"
   prim__setBorder : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.caption"
   prim__caption : HTMLTableElement -> PrimIO (Nullable HTMLTableCaptionElement)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.caption = v}"
   prim__setCaption :
@@ -5984,83 +5984,83 @@ namespace HTMLTableElement
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cellPadding"
   prim__cellPadding : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cellPadding = v}"
   prim__setCellPadding : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cellSpacing"
   prim__cellSpacing : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cellSpacing = v}"
   prim__setCellSpacing : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frame"
   prim__frame : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frame = v}"
   prim__setFrame : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rows"
   prim__rows : HTMLTableElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rules"
   prim__rules : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rules = v}"
   prim__setRules : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.summary"
   prim__summary : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.summary = v}"
   prim__setSummary : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tBodies"
   prim__tBodies : HTMLTableElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tFoot"
   prim__tFoot : HTMLTableElement -> PrimIO (Nullable HTMLTableSectionElement)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.tFoot = v}"
   prim__setTFoot :
@@ -6069,13 +6069,13 @@ namespace HTMLTableElement
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tHead"
   prim__tHead : HTMLTableElement -> PrimIO (Nullable HTMLTableSectionElement)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.tHead = v}"
   prim__setTHead :
@@ -6084,59 +6084,59 @@ namespace HTMLTableElement
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLTableElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLTableElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createCaption()"
   prim__createCaption : HTMLTableElement -> PrimIO HTMLTableCaptionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createTBody()"
   prim__createTBody : HTMLTableElement -> PrimIO HTMLTableSectionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createTFoot()"
   prim__createTFoot : HTMLTableElement -> PrimIO HTMLTableSectionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createTHead()"
   prim__createTHead : HTMLTableElement -> PrimIO HTMLTableSectionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deleteCaption()"
   prim__deleteCaption : HTMLTableElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteRow(a)"
   prim__deleteRow : HTMLTableElement -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deleteTFoot()"
   prim__deleteTFoot : HTMLTableElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deleteTHead()"
   prim__deleteTHead : HTMLTableElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.insertRow(a)"
   prim__insertRow :
@@ -6147,92 +6147,92 @@ namespace HTMLTableElement
 
 
 namespace HTMLTableRowElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableRowElement()"
   prim__new : PrimIO HTMLTableRowElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableRowElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableRowElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bgColor"
   prim__bgColor : HTMLTableRowElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.bgColor = v}"
   prim__setBgColor : HTMLTableRowElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cells"
   prim__cells : HTMLTableRowElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ch"
   prim__ch : HTMLTableRowElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ch = v}"
   prim__setCh : HTMLTableRowElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.chOff"
   prim__chOff : HTMLTableRowElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.chOff = v}"
   prim__setChOff : HTMLTableRowElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rowIndex"
   prim__rowIndex : HTMLTableRowElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sectionRowIndex"
   prim__sectionRowIndex : HTMLTableRowElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vAlign"
   prim__vAlign : HTMLTableRowElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vAlign = v}"
   prim__setVAlign : HTMLTableRowElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteCell(a)"
   prim__deleteCell : HTMLTableRowElement -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.insertCell(a)"
   prim__insertCell :
@@ -6243,70 +6243,70 @@ namespace HTMLTableRowElement
 
 
 namespace HTMLTableSectionElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTableSectionElement()"
   prim__new : PrimIO HTMLTableSectionElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : HTMLTableSectionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : HTMLTableSectionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ch"
   prim__ch : HTMLTableSectionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ch = v}"
   prim__setCh : HTMLTableSectionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.chOff"
   prim__chOff : HTMLTableSectionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.chOff = v}"
   prim__setChOff : HTMLTableSectionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rows"
   prim__rows : HTMLTableSectionElement -> PrimIO HTMLCollection
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vAlign"
   prim__vAlign : HTMLTableSectionElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.vAlign = v}"
   prim__setVAlign : HTMLTableSectionElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteRow(a)"
   prim__deleteRow : HTMLTableSectionElement -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.insertRow(a)"
   prim__insertRow :
@@ -6317,12 +6317,12 @@ namespace HTMLTableSectionElement
 
 
 namespace HTMLTemplateElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTemplateElement()"
   prim__new : PrimIO HTMLTemplateElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.content"
   prim__content : HTMLTemplateElement -> PrimIO DocumentFragment
@@ -6330,276 +6330,276 @@ namespace HTMLTemplateElement
 
 
 namespace HTMLTextAreaElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTextAreaElement()"
   prim__new : PrimIO HTMLTextAreaElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autocomplete"
   prim__autocomplete : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autocomplete = v}"
   prim__setAutocomplete : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cols"
   prim__cols : HTMLTextAreaElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cols = v}"
   prim__setCols : HTMLTextAreaElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.defaultValue"
   prim__defaultValue : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.defaultValue = v}"
   prim__setDefaultValue : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dirName"
   prim__dirName : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dirName = v}"
   prim__setDirName : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.disabled"
   prim__disabled : HTMLTextAreaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.disabled = v}"
   prim__setDisabled : HTMLTextAreaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.form"
   prim__form : HTMLTextAreaElement -> PrimIO (Nullable HTMLFormElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.labels"
   prim__labels : HTMLTextAreaElement -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.maxLength"
   prim__maxLength : HTMLTextAreaElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.maxLength = v}"
   prim__setMaxLength : HTMLTextAreaElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.minLength"
   prim__minLength : HTMLTextAreaElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.minLength = v}"
   prim__setMinLength : HTMLTextAreaElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.placeholder"
   prim__placeholder : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.placeholder = v}"
   prim__setPlaceholder : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readOnly"
   prim__readOnly : HTMLTextAreaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.readOnly = v}"
   prim__setReadOnly : HTMLTextAreaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.required"
   prim__required : HTMLTextAreaElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.required = v}"
   prim__setRequired : HTMLTextAreaElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rows"
   prim__rows : HTMLTextAreaElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rows = v}"
   prim__setRows : HTMLTextAreaElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionDirection"
   prim__selectionDirection : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionDirection = v}"
   prim__setSelectionDirection : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionEnd"
   prim__selectionEnd : HTMLTextAreaElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionEnd = v}"
   prim__setSelectionEnd : HTMLTextAreaElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectionStart"
   prim__selectionStart : HTMLTextAreaElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selectionStart = v}"
   prim__setSelectionStart : HTMLTextAreaElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textLength"
   prim__textLength : HTMLTextAreaElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLTextAreaElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validationMessage"
   prim__validationMessage : HTMLTextAreaElement -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.validity"
   prim__validity : HTMLTextAreaElement -> PrimIO ValidityState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.willValidate"
   prim__willValidate : HTMLTextAreaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.wrap"
   prim__wrap : HTMLTextAreaElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.wrap = v}"
   prim__setWrap : HTMLTextAreaElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.checkValidity()"
   prim__checkValidity : HTMLTextAreaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reportValidity()"
   prim__reportValidity : HTMLTextAreaElement -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.select()"
   prim__select : HTMLTextAreaElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setCustomValidity(a)"
   prim__setCustomValidity : HTMLTextAreaElement -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setRangeText(a)"
   prim__setRangeText : HTMLTextAreaElement -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.setRangeText(a,b,c,d)"
   prim__setRangeText1 :
@@ -6610,7 +6610,7 @@ namespace HTMLTextAreaElement
     -> UndefOr String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setSelectionRange(a,b,c)"
   prim__setSelectionRange :
@@ -6623,18 +6623,18 @@ namespace HTMLTextAreaElement
 
 
 namespace HTMLTimeElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTimeElement()"
   prim__new : PrimIO HTMLTimeElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dateTime"
   prim__dateTime : HTMLTimeElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dateTime = v}"
   prim__setDateTime : HTMLTimeElement -> String -> PrimIO ()
@@ -6643,18 +6643,18 @@ namespace HTMLTimeElement
 
 
 namespace HTMLTitleElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTitleElement()"
   prim__new : PrimIO HTMLTitleElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : HTMLTitleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : HTMLTitleElement -> String -> PrimIO ()
@@ -6663,77 +6663,77 @@ namespace HTMLTitleElement
 
 
 namespace HTMLTrackElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLTrackElement()"
   prim__new : PrimIO HTMLTrackElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.default"
   prim__default : HTMLTrackElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.default = v}"
   prim__setDefault : HTMLTrackElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : HTMLTrackElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.kind = v}"
   prim__setKind : HTMLTrackElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : HTMLTrackElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.label = v}"
   prim__setLabel : HTMLTrackElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : HTMLTrackElement -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.src"
   prim__src : HTMLTrackElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.src = v}"
   prim__setSrc : HTMLTrackElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.srclang"
   prim__srclang : HTMLTrackElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.srclang = v}"
   prim__setSrclang : HTMLTrackElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track : HTMLTrackElement -> PrimIO TextTrack
@@ -6741,30 +6741,30 @@ namespace HTMLTrackElement
 
 
 namespace HTMLUListElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLUListElement()"
   prim__new : PrimIO HTMLUListElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.compact"
   prim__compact : HTMLUListElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.compact = v}"
   prim__setCompact : HTMLUListElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : HTMLUListElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : HTMLUListElement -> String -> PrimIO ()
@@ -6774,64 +6774,64 @@ namespace HTMLUListElement
 
 
 namespace HTMLVideoElement
-
+  
   export
   %foreign "browser:lambda:()=> new HTMLVideoElement()"
   prim__new : PrimIO HTMLVideoElement
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : HTMLVideoElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : HTMLVideoElement -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.playsInline"
   prim__playsInline : HTMLVideoElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.playsInline = v}"
   prim__setPlaysInline : HTMLVideoElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.poster"
   prim__poster : HTMLVideoElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.poster = v}"
   prim__setPoster : HTMLVideoElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.videoHeight"
   prim__videoHeight : HTMLVideoElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.videoWidth"
   prim__videoWidth : HTMLVideoElement -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : HTMLVideoElement -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : HTMLVideoElement -> Bits32 -> PrimIO ()
@@ -6840,17 +6840,17 @@ namespace HTMLVideoElement
 
 
 namespace HashChangeEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new HashChangeEvent(a,b)"
   prim__new : String -> UndefOr HashChangeEventInit -> PrimIO HashChangeEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newURL"
   prim__newURL : HashChangeEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldURL"
   prim__oldURL : HashChangeEvent -> PrimIO String
@@ -6858,44 +6858,44 @@ namespace HashChangeEvent
 
 
 namespace History
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : History -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollRestoration"
   prim__scrollRestoration : History -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scrollRestoration = v}"
   prim__setScrollRestoration : History -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : History -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.back()"
   prim__back : History -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.forward()"
   prim__forward : History -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.go(a)"
   prim__go : History -> UndefOr Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.pushState(a,b,c)"
   prim__pushState :
@@ -6905,7 +6905,7 @@ namespace History
     -> UndefOr (Nullable String)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.replaceState(a,b,c)"
   prim__replaceState :
@@ -6918,17 +6918,17 @@ namespace History
 
 
 namespace ImageBitmap
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : ImageBitmap -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : ImageBitmap -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : ImageBitmap -> PrimIO ()
@@ -6936,14 +6936,14 @@ namespace ImageBitmap
 
 
 namespace ImageBitmapRenderingContext
-
+  
   export
   %foreign "browser:lambda:x=>x.canvas"
   prim__canvas :
        ImageBitmapRenderingContext
     -> PrimIO (Union2 HTMLCanvasElement OffscreenCanvas)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.transferFromImageBitmap(a)"
   prim__transferFromImageBitmap :
@@ -6954,27 +6954,27 @@ namespace ImageBitmapRenderingContext
 
 
 namespace ImageData
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ImageData(a,b)"
   prim__new : Bits32 -> Bits32 -> PrimIO ImageData
 
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> new ImageData(a,b,c)"
   prim__new1 : UInt8ClampedArray -> Bits32 -> UndefOr Bits32 -> PrimIO ImageData
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : ImageData -> PrimIO UInt8ClampedArray
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : ImageData -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : ImageData -> PrimIO Bits32
@@ -6982,123 +6982,123 @@ namespace ImageData
 
 
 namespace Location
-
+  
   export
   %foreign "browser:lambda:x=>x.ancestorOrigins"
   prim__ancestorOrigins : Location -> PrimIO DOMStringList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hash"
   prim__hash : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hash = v}"
   prim__setHash : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.host"
   prim__host : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.host = v}"
   prim__setHost : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hostname"
   prim__hostname : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hostname = v}"
   prim__setHostname : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.href = v}"
   prim__setHref : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : Location -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pathname"
   prim__pathname : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pathname = v}"
   prim__setPathname : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port"
   prim__port : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.port = v}"
   prim__setPort : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.protocol"
   prim__protocol : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.protocol = v}"
   prim__setProtocol : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.search"
   prim__search : Location -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.search = v}"
   prim__setSearch : Location -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.assign(a)"
   prim__assign : Location -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reload()"
   prim__reload : Location -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.replace(a)"
   prim__replace : Location -> String -> PrimIO ()
@@ -7106,12 +7106,12 @@ namespace Location
 
 
 namespace MediaError
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : MediaError -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.message"
   prim__message : MediaError -> PrimIO String
@@ -7119,17 +7119,17 @@ namespace MediaError
 
 
 namespace MessageChannel
-
+  
   export
   %foreign "browser:lambda:()=> new MessageChannel()"
   prim__new : PrimIO MessageChannel
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port1"
   prim__port1 : MessageChannel -> PrimIO MessagePort
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port2"
   prim__port2 : MessageChannel -> PrimIO MessagePort
@@ -7137,39 +7137,39 @@ namespace MessageChannel
 
 
 namespace MessageEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new MessageEvent(a,b)"
   prim__new : String -> UndefOr MessageEventInit -> PrimIO MessageEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : MessageEvent -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastEventId"
   prim__lastEventId : MessageEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : MessageEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ports"
   prim__ports : MessageEvent -> PrimIO (Array MessagePort)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source :
        MessageEvent
     -> PrimIO (Nullable (Union3 WindowProxy MessagePort ServiceWorker))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.initMessageEvent(a,b,c,d,e,f,g,h)"
   prim__initMessageEvent :
@@ -7187,25 +7187,25 @@ namespace MessageEvent
 
 
 namespace MessagePort
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : MessagePort -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage : MessagePort -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror : MessagePort -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -7214,17 +7214,17 @@ namespace MessagePort
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : MessagePort -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage : MessagePort -> AnyPtr -> Array Object -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -7233,7 +7233,7 @@ namespace MessagePort
     -> UndefOr PostMessageOptions
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start()"
   prim__start : MessagePort -> PrimIO ()
@@ -7241,22 +7241,22 @@ namespace MessagePort
 
 
 namespace MimeType
-
+  
   export
   %foreign "browser:lambda:x=>x.description"
   prim__description : MimeType -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enabledPlugin"
   prim__enabledPlugin : MimeType -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.suffixes"
   prim__suffixes : MimeType -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : MimeType -> PrimIO ()
@@ -7264,17 +7264,17 @@ namespace MimeType
 
 
 namespace MimeTypeArray
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : MimeTypeArray -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : MimeTypeArray -> Bits32 -> PrimIO (Nullable Object)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem : MimeTypeArray -> String -> PrimIO (Nullable Object)
@@ -7282,27 +7282,27 @@ namespace MimeTypeArray
 
 
 namespace Navigator
-
+  
   export
   %foreign "browser:lambda:x=>x.clipboard"
   prim__clipboard : Navigator -> PrimIO Clipboard
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mediaDevices"
   prim__mediaDevices : Navigator -> PrimIO MediaDevices
 
-
+  
   export
   %foreign "browser:lambda:x=>x.permissions"
   prim__permissions : Navigator -> PrimIO Permissions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.serviceWorker"
   prim__serviceWorker : Navigator -> PrimIO ServiceWorkerContainer
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.getUserMedia(a,b,c)"
   prim__getUserMedia :
@@ -7315,36 +7315,36 @@ namespace Navigator
 
 
 namespace OffscreenCanvas
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new OffscreenCanvas(a,b)"
   prim__new : JSBits64 -> JSBits64 -> PrimIO OffscreenCanvas
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : OffscreenCanvas -> PrimIO JSBits64
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : OffscreenCanvas -> JSBits64 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : OffscreenCanvas -> PrimIO JSBits64
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : OffscreenCanvas -> JSBits64 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.convertToBlob(a)"
   prim__convertToBlob :
@@ -7352,7 +7352,7 @@ namespace OffscreenCanvas
     -> UndefOr ImageEncodeOptions
     -> PrimIO (Promise Blob)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getContext(a,b)"
   prim__getContext :
@@ -7367,7 +7367,7 @@ namespace OffscreenCanvas
                WebGLRenderingContext
                WebGL2RenderingContext))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transferToImageBitmap()"
   prim__transferToImageBitmap : OffscreenCanvas -> PrimIO ImageBitmap
@@ -7375,12 +7375,12 @@ namespace OffscreenCanvas
 
 
 namespace OffscreenCanvasRenderingContext2D
-
+  
   export
   %foreign "browser:lambda:x=>x.canvas"
   prim__canvas : OffscreenCanvasRenderingContext2D -> PrimIO OffscreenCanvas
 
-
+  
   export
   %foreign "browser:lambda:x=>x.commit()"
   prim__commit : OffscreenCanvasRenderingContext2D -> PrimIO ()
@@ -7388,7 +7388,7 @@ namespace OffscreenCanvasRenderingContext2D
 
 
 namespace PageTransitionEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new PageTransitionEvent(a,b)"
   prim__new :
@@ -7396,7 +7396,7 @@ namespace PageTransitionEvent
     -> UndefOr PageTransitionEventInit
     -> PrimIO PageTransitionEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.persisted"
   prim__persisted : PageTransitionEvent -> PrimIO Boolean
@@ -7404,12 +7404,12 @@ namespace PageTransitionEvent
 
 
 namespace Path2D
-
+  
   export
   %foreign "browser:lambda:(a)=> new Path2D(a)"
   prim__new : UndefOr (Union2 Path2D String) -> PrimIO Path2D
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.addPath(a,b)"
   prim__addPath : Path2D -> Path2D -> UndefOr DOMMatrix2DInit -> PrimIO ()
@@ -7417,32 +7417,32 @@ namespace Path2D
 
 
 namespace Plugin
-
+  
   export
   %foreign "browser:lambda:x=>x.description"
   prim__description : Plugin -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.filename"
   prim__filename : Plugin -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : Plugin -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : Plugin -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : Plugin -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem : Plugin -> String -> PrimIO ()
@@ -7450,22 +7450,22 @@ namespace Plugin
 
 
 namespace PluginArray
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : PluginArray -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.item(a)"
   prim__item : PluginArray -> Bits32 -> PrimIO (Nullable Object)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.namedItem(a)"
   prim__namedItem : PluginArray -> String -> PrimIO (Nullable Object)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.refresh()"
   prim__refresh : PluginArray -> PrimIO ()
@@ -7473,12 +7473,12 @@ namespace PluginArray
 
 
 namespace PopStateEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new PopStateEvent(a,b)"
   prim__new : String -> UndefOr PopStateEventInit -> PrimIO PopStateEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : PopStateEvent -> PrimIO AnyPtr
@@ -7486,7 +7486,7 @@ namespace PopStateEvent
 
 
 namespace PromiseRejectionEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new PromiseRejectionEvent(a,b)"
   prim__new :
@@ -7494,12 +7494,12 @@ namespace PromiseRejectionEvent
     -> PromiseRejectionEventInit
     -> PrimIO PromiseRejectionEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.promise"
   prim__promise : PromiseRejectionEvent -> PrimIO (Promise AnyPtr)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reason"
   prim__reason : PromiseRejectionEvent -> PrimIO AnyPtr
@@ -7507,13 +7507,13 @@ namespace PromiseRejectionEvent
 
 
 namespace RadioNodeList
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : RadioNodeList -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : RadioNodeList -> String -> PrimIO ()
@@ -7522,7 +7522,7 @@ namespace RadioNodeList
 
 
 namespace SharedWorker
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new SharedWorker(a,b)"
   prim__new :
@@ -7530,7 +7530,7 @@ namespace SharedWorker
     -> UndefOr (Union2 String WorkerOptions)
     -> PrimIO SharedWorker
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port"
   prim__port : SharedWorker -> PrimIO MessagePort
@@ -7538,12 +7538,12 @@ namespace SharedWorker
 
 
 namespace SharedWorkerGlobalScope
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : SharedWorkerGlobalScope -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onconnect"
   prim__onconnect :
@@ -7551,7 +7551,7 @@ namespace SharedWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onconnect = v}"
   prim__setOnconnect :
@@ -7560,7 +7560,7 @@ namespace SharedWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : SharedWorkerGlobalScope -> PrimIO ()
@@ -7568,27 +7568,27 @@ namespace SharedWorkerGlobalScope
 
 
 namespace Storage
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : Storage -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : Storage -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : Storage -> String -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.key(a)"
   prim__key : Storage -> Bits32 -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setItem(a,b)"
   prim__setItem : Storage -> String -> String -> PrimIO ()
@@ -7596,37 +7596,37 @@ namespace Storage
 
 
 namespace StorageEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new StorageEvent(a,b)"
   prim__new : String -> UndefOr StorageEventInit -> PrimIO StorageEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.key"
   prim__key : StorageEvent -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newValue"
   prim__newValue : StorageEvent -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldValue"
   prim__oldValue : StorageEvent -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.storageArea"
   prim__storageArea : StorageEvent -> PrimIO (Nullable Storage)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : StorageEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.initStorageEvent(a,b,c,d,e,f,g,h)"
   prim__initStorageEvent :
@@ -7644,12 +7644,12 @@ namespace StorageEvent
 
 
 namespace SubmitEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new SubmitEvent(a,b)"
   prim__new : String -> UndefOr SubmitEventInit -> PrimIO SubmitEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.submitter"
   prim__submitter : SubmitEvent -> PrimIO (Nullable HTMLElement)
@@ -7657,62 +7657,62 @@ namespace SubmitEvent
 
 
 namespace TextMetrics
-
+  
   export
   %foreign "browser:lambda:x=>x.actualBoundingBoxAscent"
   prim__actualBoundingBoxAscent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.actualBoundingBoxDescent"
   prim__actualBoundingBoxDescent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.actualBoundingBoxLeft"
   prim__actualBoundingBoxLeft : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.actualBoundingBoxRight"
   prim__actualBoundingBoxRight : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alphabeticBaseline"
   prim__alphabeticBaseline : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.emHeightAscent"
   prim__emHeightAscent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.emHeightDescent"
   prim__emHeightDescent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fontBoundingBoxAscent"
   prim__fontBoundingBoxAscent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fontBoundingBoxDescent"
   prim__fontBoundingBoxDescent : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hangingBaseline"
   prim__hangingBaseline : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ideographicBaseline"
   prim__ideographicBaseline : TextMetrics -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : TextMetrics -> PrimIO Double
@@ -7720,76 +7720,76 @@ namespace TextMetrics
 
 
 namespace TextTrack
-
+  
   export
   %foreign "browser:lambda:x=>x.activeCues"
   prim__activeCues : TextTrack -> PrimIO (Nullable TextTrackCueList)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cues"
   prim__cues : TextTrack -> PrimIO (Nullable TextTrackCueList)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : TextTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inBandMetadataTrackDispatchType"
   prim__inBandMetadataTrackDispatchType : TextTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : TextTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : TextTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.language"
   prim__language : TextTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : TextTrack -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mode = v}"
   prim__setMode : TextTrack -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncuechange"
   prim__oncuechange : TextTrack -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncuechange = v}"
   prim__setOncuechange : TextTrack -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sourceBuffer"
   prim__sourceBuffer : TextTrack -> PrimIO (Nullable SourceBuffer)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.addCue(a)"
   prim__addCue : TextTrack -> TextTrackCue -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeCue(a)"
   prim__removeCue : TextTrack -> TextTrackCue -> PrimIO ()
@@ -7797,79 +7797,79 @@ namespace TextTrack
 
 
 namespace TextTrackCue
-
+  
   export
   %foreign "browser:lambda:x=>x.endTime"
   prim__endTime : TextTrackCue -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.endTime = v}"
   prim__setEndTime : TextTrackCue -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : TextTrackCue -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.id = v}"
   prim__setId : TextTrackCue -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onenter"
   prim__onenter : TextTrackCue -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onenter = v}"
   prim__setOnenter : TextTrackCue -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onexit"
   prim__onexit : TextTrackCue -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onexit = v}"
   prim__setOnexit : TextTrackCue -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pauseOnExit"
   prim__pauseOnExit : TextTrackCue -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pauseOnExit = v}"
   prim__setPauseOnExit : TextTrackCue -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startTime"
   prim__startTime : TextTrackCue -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.startTime = v}"
   prim__setStartTime : TextTrackCue -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track : TextTrackCue -> PrimIO (Nullable TextTrack)
@@ -7877,17 +7877,17 @@ namespace TextTrackCue
 
 
 namespace TextTrackCueList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : TextTrackCueList -> Bits32 -> PrimIO TextTrackCue
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : TextTrackCueList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getCueById(a)"
   prim__getCueById :
@@ -7898,23 +7898,23 @@ namespace TextTrackCueList
 
 
 namespace TextTrackList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : TextTrackList -> Bits32 -> PrimIO TextTrack
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : TextTrackList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onaddtrack"
   prim__onaddtrack : TextTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onaddtrack = v}"
   prim__setOnaddtrack :
@@ -7923,25 +7923,25 @@ namespace TextTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : TextTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange : TextTrackList -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onremovetrack"
   prim__onremovetrack : TextTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onremovetrack = v}"
   prim__setOnremovetrack :
@@ -7950,7 +7950,7 @@ namespace TextTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getTrackById(a)"
   prim__getTrackById : TextTrackList -> String -> PrimIO (Nullable TextTrack)
@@ -7958,17 +7958,17 @@ namespace TextTrackList
 
 
 namespace TimeRanges
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : TimeRanges -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.end(a)"
   prim__end : TimeRanges -> Bits32 -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.start(a)"
   prim__start : TimeRanges -> Bits32 -> PrimIO Double
@@ -7976,12 +7976,12 @@ namespace TimeRanges
 
 
 namespace TrackEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new TrackEvent(a,b)"
   prim__new : String -> UndefOr TrackEventInit -> PrimIO TrackEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track :
@@ -7991,57 +7991,57 @@ namespace TrackEvent
 
 
 namespace ValidityState
-
+  
   export
   %foreign "browser:lambda:x=>x.badInput"
   prim__badInput : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.customError"
   prim__customError : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.patternMismatch"
   prim__patternMismatch : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeOverflow"
   prim__rangeOverflow : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeUnderflow"
   prim__rangeUnderflow : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stepMismatch"
   prim__stepMismatch : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tooLong"
   prim__tooLong : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tooShort"
   prim__tooShort : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.typeMismatch"
   prim__typeMismatch : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valid"
   prim__valid : ValidityState -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueMissing"
   prim__valueMissing : ValidityState -> PrimIO Boolean
@@ -8049,39 +8049,39 @@ namespace ValidityState
 
 
 namespace VideoTrack
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : VideoTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : VideoTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : VideoTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.language"
   prim__language : VideoTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selected"
   prim__selected : VideoTrack -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.selected = v}"
   prim__setSelected : VideoTrack -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sourceBuffer"
   prim__sourceBuffer : VideoTrack -> PrimIO (Nullable SourceBuffer)
@@ -8089,23 +8089,23 @@ namespace VideoTrack
 
 
 namespace VideoTrackList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : VideoTrackList -> Bits32 -> PrimIO VideoTrack
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : VideoTrackList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onaddtrack"
   prim__onaddtrack : VideoTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onaddtrack = v}"
   prim__setOnaddtrack :
@@ -8114,13 +8114,13 @@ namespace VideoTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : VideoTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange :
@@ -8129,13 +8129,13 @@ namespace VideoTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onremovetrack"
   prim__onremovetrack : VideoTrackList -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onremovetrack = v}"
   prim__setOnremovetrack :
@@ -8144,12 +8144,12 @@ namespace VideoTrackList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.selectedIndex"
   prim__selectedIndex : VideoTrackList -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getTrackById(a)"
   prim__getTrackById : VideoTrackList -> String -> PrimIO (Nullable VideoTrack)
@@ -8157,7 +8157,7 @@ namespace VideoTrackList
 
 
 namespace WebSocket
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new WebSocket(a,b)"
   prim__new :
@@ -8165,112 +8165,112 @@ namespace WebSocket
     -> UndefOr (Union2 String (Array String))
     -> PrimIO WebSocket
 
-
+  
   export
   %foreign "browser:lambda:x=>x.binaryType"
   prim__binaryType : WebSocket -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.binaryType = v}"
   prim__setBinaryType : WebSocket -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.bufferedAmount"
   prim__bufferedAmount : WebSocket -> PrimIO JSBits64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.extensions"
   prim__extensions : WebSocket -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onclose"
   prim__onclose : WebSocket -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onclose = v}"
   prim__setOnclose : WebSocket -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : WebSocket -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : WebSocket -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : WebSocket -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage : WebSocket -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onopen"
   prim__onopen : WebSocket -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onopen = v}"
   prim__setOnopen : WebSocket -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.protocol"
   prim__protocol : WebSocket -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : WebSocket -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : WebSocket -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.close(a,b)"
   prim__close : WebSocket -> UndefOr Bits16 -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.send(a)"
   prim__send : WebSocket -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.send(a)"
   prim__send1 : WebSocket -> Blob -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.send(a)"
   prim__send2 : WebSocket -> ArrayBuffer -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.send(a)"
   prim__send3 :
@@ -8291,268 +8291,268 @@ namespace WebSocket
 
 
 namespace Window
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : Window -> String -> PrimIO Object
 
-
+  
   export
   %foreign "browser:lambda:x=>x.closed"
   prim__closed : Window -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.customElements"
   prim__customElements : Window -> PrimIO CustomElementRegistry
 
-
+  
   export
   %foreign "browser:lambda:x=>x.devicePixelRatio"
   prim__devicePixelRatio : Window -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.document"
   prim__document : Window -> PrimIO Document
 
-
+  
   export
   %foreign "browser:lambda:x=>x.event"
   prim__event : Window -> PrimIO (Union2 Event Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.external"
   prim__external : Window -> PrimIO External
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameElement"
   prim__frameElement : Window -> PrimIO (Nullable Element)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frames"
   prim__frames : Window -> PrimIO WindowProxy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.history"
   prim__history : Window -> PrimIO History
 
-
+  
   export
   %foreign "browser:lambda:x=>x.innerHeight"
   prim__innerHeight : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.innerWidth"
   prim__innerWidth : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : Window -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.location"
   prim__location : Window -> PrimIO Location
 
-
+  
   export
   %foreign "browser:lambda:x=>x.locationbar"
   prim__locationbar : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.menubar"
   prim__menubar : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : Window -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : Window -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.navigator"
   prim__navigator : Window -> PrimIO Navigator
 
-
+  
   export
   %foreign "browser:lambda:x=>x.opener"
   prim__opener : Window -> PrimIO AnyPtr
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.opener = v}"
   prim__setOpener : Window -> AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.originAgentCluster"
   prim__originAgentCluster : Window -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.outerHeight"
   prim__outerHeight : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.outerWidth"
   prim__outerWidth : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageXOffset"
   prim__pageXOffset : Window -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageYOffset"
   prim__pageYOffset : Window -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.parent"
   prim__parent : Window -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.personalbar"
   prim__personalbar : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screen"
   prim__screen : Window -> PrimIO Screen
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenLeft"
   prim__screenLeft : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenTop"
   prim__screenTop : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenX"
   prim__screenX : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenY"
   prim__screenY : Window -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollX"
   prim__scrollX : Window -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollY"
   prim__scrollY : Window -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollbars"
   prim__scrollbars : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.self"
   prim__self : Window -> PrimIO WindowProxy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.status"
   prim__status : Window -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.status = v}"
   prim__setStatus : Window -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.statusbar"
   prim__statusbar : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toolbar"
   prim__toolbar : Window -> PrimIO BarProp
 
-
+  
   export
   %foreign "browser:lambda:x=>x.top"
   prim__top : Window -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.visualViewport"
   prim__visualViewport : Window -> PrimIO (Nullable VisualViewport)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.window"
   prim__window : Window -> PrimIO WindowProxy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alert()"
   prim__alert : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.alert(a)"
   prim__alert1 : Window -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.blur()"
   prim__blur : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.captureEvents()"
   prim__captureEvents : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.confirm(a)"
   prim__confirm : Window -> UndefOr String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.focus()"
   prim__focus : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getComputedStyle(a,b)"
   prim__getComputedStyle :
@@ -8561,22 +8561,22 @@ namespace Window
     -> UndefOr (Nullable String)
     -> PrimIO CSSStyleDeclaration
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.matchMedia(a)"
   prim__matchMedia : Window -> String -> PrimIO MediaQueryList
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.moveBy(a,b)"
   prim__moveBy : Window -> Int32 -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.moveTo(a,b)"
   prim__moveTo : Window -> Int32 -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.open(a,b,c)"
   prim__open :
@@ -8586,7 +8586,7 @@ namespace Window
     -> UndefOr String
     -> PrimIO (Nullable WindowProxy)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.postMessage(a,b,c)"
   prim__postMessage :
@@ -8596,7 +8596,7 @@ namespace Window
     -> UndefOr (Array Object)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -8605,12 +8605,12 @@ namespace Window
     -> UndefOr WindowPostMessageOptions
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.print()"
   prim__print : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.prompt(a,b)"
   prim__prompt :
@@ -8619,52 +8619,52 @@ namespace Window
     -> UndefOr String
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.releaseEvents()"
   prim__releaseEvents : Window -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.resizeBy(a,b)"
   prim__resizeBy : Window -> Int32 -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.resizeTo(a,b)"
   prim__resizeTo : Window -> Int32 -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollBy(a)"
   prim__scrollBy : Window -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scrollBy(a,b)"
   prim__scrollBy1 : Window -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollTo(a)"
   prim__scrollTo : Window -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scrollTo(a,b)"
   prim__scrollTo1 : Window -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scroll(a)"
   prim__scroll : Window -> UndefOr ScrollToOptions -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scroll(a,b)"
   prim__scroll1 : Window -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stop()"
   prim__stop : Window -> PrimIO ()
@@ -8672,41 +8672,41 @@ namespace Window
 
 
 namespace Worker
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new Worker(a,b)"
   prim__new : String -> UndefOr WorkerOptions -> PrimIO Worker
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : Worker -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage : Worker -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror : Worker -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror : Worker -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage : Worker -> AnyPtr -> Array Object -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -8715,7 +8715,7 @@ namespace Worker
     -> UndefOr PostMessageOptions
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.terminate()"
   prim__terminate : Worker -> PrimIO ()
@@ -8723,17 +8723,17 @@ namespace Worker
 
 
 namespace WorkerGlobalScope
-
+  
   export
   %foreign "browser:lambda:x=>x.location"
   prim__location : WorkerGlobalScope -> PrimIO WorkerLocation
 
-
+  
   export
   %foreign "browser:lambda:x=>x.navigator"
   prim__navigator : WorkerGlobalScope -> PrimIO WorkerNavigator
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror :
@@ -8741,7 +8741,7 @@ namespace WorkerGlobalScope
     -> PrimIO (Nullable OnErrorEventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror :
@@ -8750,7 +8750,7 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onlanguagechange"
   prim__onlanguagechange :
@@ -8758,7 +8758,7 @@ namespace WorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onlanguagechange = v}"
   prim__setOnlanguagechange :
@@ -8767,13 +8767,13 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onoffline"
   prim__onoffline : WorkerGlobalScope -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onoffline = v}"
   prim__setOnoffline :
@@ -8782,13 +8782,13 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ononline"
   prim__ononline : WorkerGlobalScope -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ononline = v}"
   prim__setOnonline :
@@ -8797,7 +8797,7 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onrejectionhandled"
   prim__onrejectionhandled :
@@ -8805,7 +8805,7 @@ namespace WorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onrejectionhandled = v}"
   prim__setOnrejectionhandled :
@@ -8814,7 +8814,7 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onunhandledrejection"
   prim__onunhandledrejection :
@@ -8822,7 +8822,7 @@ namespace WorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onunhandledrejection = v}"
   prim__setOnunhandledrejection :
@@ -8831,12 +8831,12 @@ namespace WorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.self"
   prim__self : WorkerGlobalScope -> PrimIO WorkerGlobalScope
 
-
+  
   export
   %foreign "browser:lambda:(x,va)=>x.importScripts(...va())"
   prim__importScripts : WorkerGlobalScope -> IO (Array String) -> PrimIO ()
@@ -8844,47 +8844,47 @@ namespace WorkerGlobalScope
 
 
 namespace WorkerLocation
-
+  
   export
   %foreign "browser:lambda:x=>x.hash"
   prim__hash : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.host"
   prim__host : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hostname"
   prim__hostname : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pathname"
   prim__pathname : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port"
   prim__port : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.protocol"
   prim__protocol : WorkerLocation -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.search"
   prim__search : WorkerLocation -> PrimIO String
@@ -8892,12 +8892,12 @@ namespace WorkerLocation
 
 
 namespace WorkerNavigator
-
+  
   export
   %foreign "browser:lambda:x=>x.permissions"
   prim__permissions : WorkerNavigator -> PrimIO Permissions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.serviceWorker"
   prim__serviceWorker : WorkerNavigator -> PrimIO ServiceWorkerContainer
@@ -8905,7 +8905,7 @@ namespace WorkerNavigator
 
 
 namespace Worklet
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.addModule(a,b)"
   prim__addModule :
@@ -8923,493 +8923,493 @@ namespace Worklet
 --------------------------------------------------------------------------------
 
 namespace ARIAMixin
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaAtomic"
   prim__ariaAtomic : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaAtomic = v}"
   prim__setAriaAtomic : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaAutoComplete"
   prim__ariaAutoComplete : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaAutoComplete = v}"
   prim__setAriaAutoComplete : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaBusy"
   prim__ariaBusy : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaBusy = v}"
   prim__setAriaBusy : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaChecked"
   prim__ariaChecked : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaChecked = v}"
   prim__setAriaChecked : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaColCount"
   prim__ariaColCount : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaColCount = v}"
   prim__setAriaColCount : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaColIndex"
   prim__ariaColIndex : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaColIndex = v}"
   prim__setAriaColIndex : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaColIndexText"
   prim__ariaColIndexText : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaColIndexText = v}"
   prim__setAriaColIndexText : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaColSpan"
   prim__ariaColSpan : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaColSpan = v}"
   prim__setAriaColSpan : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaCurrent"
   prim__ariaCurrent : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaCurrent = v}"
   prim__setAriaCurrent : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaDescription"
   prim__ariaDescription : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaDescription = v}"
   prim__setAriaDescription : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaDisabled"
   prim__ariaDisabled : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaDisabled = v}"
   prim__setAriaDisabled : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaExpanded"
   prim__ariaExpanded : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaExpanded = v}"
   prim__setAriaExpanded : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaHasPopup"
   prim__ariaHasPopup : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaHasPopup = v}"
   prim__setAriaHasPopup : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaHidden"
   prim__ariaHidden : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaHidden = v}"
   prim__setAriaHidden : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaInvalid"
   prim__ariaInvalid : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaInvalid = v}"
   prim__setAriaInvalid : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaKeyShortcuts"
   prim__ariaKeyShortcuts : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaKeyShortcuts = v}"
   prim__setAriaKeyShortcuts : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaLabel"
   prim__ariaLabel : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaLabel = v}"
   prim__setAriaLabel : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaLevel"
   prim__ariaLevel : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaLevel = v}"
   prim__setAriaLevel : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaLive"
   prim__ariaLive : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaLive = v}"
   prim__setAriaLive : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaModal"
   prim__ariaModal : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaModal = v}"
   prim__setAriaModal : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaMultiLine"
   prim__ariaMultiLine : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaMultiLine = v}"
   prim__setAriaMultiLine : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaMultiSelectable"
   prim__ariaMultiSelectable : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaMultiSelectable = v}"
   prim__setAriaMultiSelectable : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaOrientation"
   prim__ariaOrientation : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaOrientation = v}"
   prim__setAriaOrientation : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaPlaceholder"
   prim__ariaPlaceholder : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaPlaceholder = v}"
   prim__setAriaPlaceholder : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaPosInSet"
   prim__ariaPosInSet : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaPosInSet = v}"
   prim__setAriaPosInSet : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaPressed"
   prim__ariaPressed : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaPressed = v}"
   prim__setAriaPressed : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaReadOnly"
   prim__ariaReadOnly : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaReadOnly = v}"
   prim__setAriaReadOnly : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRequired"
   prim__ariaRequired : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRequired = v}"
   prim__setAriaRequired : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRoleDescription"
   prim__ariaRoleDescription : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRoleDescription = v}"
   prim__setAriaRoleDescription : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRowCount"
   prim__ariaRowCount : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRowCount = v}"
   prim__setAriaRowCount : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRowIndex"
   prim__ariaRowIndex : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRowIndex = v}"
   prim__setAriaRowIndex : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRowIndexText"
   prim__ariaRowIndexText : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRowIndexText = v}"
   prim__setAriaRowIndexText : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaRowSpan"
   prim__ariaRowSpan : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaRowSpan = v}"
   prim__setAriaRowSpan : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaSelected"
   prim__ariaSelected : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaSelected = v}"
   prim__setAriaSelected : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaSetSize"
   prim__ariaSetSize : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaSetSize = v}"
   prim__setAriaSetSize : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaSort"
   prim__ariaSort : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaSort = v}"
   prim__setAriaSort : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaValueMax"
   prim__ariaValueMax : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaValueMax = v}"
   prim__setAriaValueMax : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaValueMin"
   prim__ariaValueMin : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaValueMin = v}"
   prim__setAriaValueMin : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaValueNow"
   prim__ariaValueNow : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaValueNow = v}"
   prim__setAriaValueNow : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ariaValueText"
   prim__ariaValueText : ARIAMixin -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ariaValueText = v}"
   prim__setAriaValueText : ARIAMixin -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.role"
   prim__role : ARIAMixin -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.role = v}"
   prim__setRole : ARIAMixin -> Nullable String -> PrimIO ()
@@ -9418,13 +9418,13 @@ namespace ARIAMixin
 
 
 namespace AbstractWorker
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : AbstractWorker -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : AbstractWorker -> Nullable EventHandlerNonNull -> PrimIO ()
@@ -9433,25 +9433,25 @@ namespace AbstractWorker
 
 
 namespace CanvasCompositing
-
+  
   export
   %foreign "browser:lambda:x=>x.globalAlpha"
   prim__globalAlpha : CanvasCompositing -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.globalAlpha = v}"
   prim__setGlobalAlpha : CanvasCompositing -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.globalCompositeOperation"
   prim__globalCompositeOperation : CanvasCompositing -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.globalCompositeOperation = v}"
   prim__setGlobalCompositeOperation : CanvasCompositing -> String -> PrimIO ()
@@ -9460,7 +9460,7 @@ namespace CanvasCompositing
 
 
 namespace CanvasDrawImage
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.drawImage(a,b,c)"
   prim__drawImage :
@@ -9476,7 +9476,7 @@ namespace CanvasDrawImage
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.drawImage(a,b,c,d,e)"
   prim__drawImage1 :
@@ -9494,7 +9494,7 @@ namespace CanvasDrawImage
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.drawImage(a,b,c,d,e,f,g,h,i)"
   prim__drawImage2 :
@@ -9519,32 +9519,32 @@ namespace CanvasDrawImage
 
 
 namespace CanvasDrawPath
-
+  
   export
   %foreign "browser:lambda:x=>x.beginPath()"
   prim__beginPath : CanvasDrawPath -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clip(a)"
   prim__clip : CanvasDrawPath -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.clip(a,b)"
   prim__clip1 : CanvasDrawPath -> Path2D -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.fill(a)"
   prim__fill : CanvasDrawPath -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.fill(a,b)"
   prim__fill1 : CanvasDrawPath -> Path2D -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.isPointInPath(a,b,c)"
   prim__isPointInPath :
@@ -9554,7 +9554,7 @@ namespace CanvasDrawPath
     -> UndefOr String
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.isPointInPath(a,b,c,d)"
   prim__isPointInPath1 :
@@ -9565,12 +9565,12 @@ namespace CanvasDrawPath
     -> UndefOr String
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.isPointInStroke(a,b)"
   prim__isPointInStroke : CanvasDrawPath -> Double -> Double -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.isPointInStroke(a,b,c)"
   prim__isPointInStroke1 :
@@ -9580,12 +9580,12 @@ namespace CanvasDrawPath
     -> Double
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stroke()"
   prim__stroke : CanvasDrawPath -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.stroke(a)"
   prim__stroke1 : CanvasDrawPath -> Path2D -> PrimIO ()
@@ -9593,7 +9593,7 @@ namespace CanvasDrawPath
 
 
 namespace CanvasFillStrokeStyles
-
+  
   export
   %foreign "browser:lambda:x=>x.fillStyle"
   prim__fillStyle :
@@ -9601,7 +9601,7 @@ namespace CanvasFillStrokeStyles
     -> PrimIO (Union3 String CanvasGradient CanvasPattern)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fillStyle = v}"
   prim__setFillStyle :
@@ -9610,7 +9610,7 @@ namespace CanvasFillStrokeStyles
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.strokeStyle"
   prim__strokeStyle :
@@ -9618,7 +9618,7 @@ namespace CanvasFillStrokeStyles
     -> PrimIO (Union3 String CanvasGradient CanvasPattern)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.strokeStyle = v}"
   prim__setStrokeStyle :
@@ -9627,7 +9627,7 @@ namespace CanvasFillStrokeStyles
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.createLinearGradient(a,b,c,d)"
   prim__createLinearGradient :
@@ -9638,7 +9638,7 @@ namespace CanvasFillStrokeStyles
     -> Double
     -> PrimIO CanvasGradient
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createPattern(a,b)"
   prim__createPattern :
@@ -9653,7 +9653,7 @@ namespace CanvasFillStrokeStyles
     -> String
     -> PrimIO (Nullable CanvasPattern)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.createRadialGradient(a,b,c,d,e,f)"
   prim__createRadialGradient :
@@ -9669,13 +9669,13 @@ namespace CanvasFillStrokeStyles
 
 
 namespace CanvasFilters
-
+  
   export
   %foreign "browser:lambda:x=>x.filter"
   prim__filter : CanvasFilters -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.filter = v}"
   prim__setFilter : CanvasFilters -> String -> PrimIO ()
@@ -9684,17 +9684,17 @@ namespace CanvasFilters
 
 
 namespace CanvasImageData
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createImageData(a,b)"
   prim__createImageData : CanvasImageData -> Int32 -> Int32 -> PrimIO ImageData
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createImageData(a)"
   prim__createImageData1 : CanvasImageData -> ImageData -> PrimIO ImageData
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.getImageData(a,b,c,d)"
   prim__getImageData :
@@ -9705,7 +9705,7 @@ namespace CanvasImageData
     -> Int32
     -> PrimIO ImageData
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.putImageData(a,b,c)"
   prim__putImageData :
@@ -9715,7 +9715,7 @@ namespace CanvasImageData
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.putImageData(a,b,c,d,e,f,g)"
   prim__putImageData1 :
@@ -9732,25 +9732,25 @@ namespace CanvasImageData
 
 
 namespace CanvasImageSmoothing
-
+  
   export
   %foreign "browser:lambda:x=>x.imageSmoothingEnabled"
   prim__imageSmoothingEnabled : CanvasImageSmoothing -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.imageSmoothingEnabled = v}"
   prim__setImageSmoothingEnabled : CanvasImageSmoothing -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.imageSmoothingQuality"
   prim__imageSmoothingQuality : CanvasImageSmoothing -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.imageSmoothingQuality = v}"
   prim__setImageSmoothingQuality : CanvasImageSmoothing -> String -> PrimIO ()
@@ -9759,7 +9759,7 @@ namespace CanvasImageSmoothing
 
 
 namespace CanvasPath
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.arc(a,b,c,d,e,f)"
   prim__arc :
@@ -9772,7 +9772,7 @@ namespace CanvasPath
     -> UndefOr Boolean
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.arcTo(a,b,c,d,e)"
   prim__arcTo :
@@ -9784,7 +9784,7 @@ namespace CanvasPath
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.bezierCurveTo(a,b,c,d,e,f)"
   prim__bezierCurveTo :
@@ -9797,12 +9797,12 @@ namespace CanvasPath
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.closePath()"
   prim__closePath : CanvasPath -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.ellipse(a,b,c,d,e,f,g,h)"
   prim__ellipse :
@@ -9817,17 +9817,17 @@ namespace CanvasPath
     -> UndefOr Boolean
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.lineTo(a,b)"
   prim__lineTo : CanvasPath -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.moveTo(a,b)"
   prim__moveTo : CanvasPath -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.quadraticCurveTo(a,b,c,d)"
   prim__quadraticCurveTo :
@@ -9838,7 +9838,7 @@ namespace CanvasPath
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.rect(a,b,c,d)"
   prim__rect : CanvasPath -> Double -> Double -> Double -> Double -> PrimIO ()
@@ -9846,72 +9846,72 @@ namespace CanvasPath
 
 
 namespace CanvasPathDrawingStyles
-
+  
   export
   %foreign "browser:lambda:x=>x.lineCap"
   prim__lineCap : CanvasPathDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lineCap = v}"
   prim__setLineCap : CanvasPathDrawingStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lineDashOffset"
   prim__lineDashOffset : CanvasPathDrawingStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lineDashOffset = v}"
   prim__setLineDashOffset : CanvasPathDrawingStyles -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lineJoin"
   prim__lineJoin : CanvasPathDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lineJoin = v}"
   prim__setLineJoin : CanvasPathDrawingStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lineWidth"
   prim__lineWidth : CanvasPathDrawingStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lineWidth = v}"
   prim__setLineWidth : CanvasPathDrawingStyles -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.miterLimit"
   prim__miterLimit : CanvasPathDrawingStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.miterLimit = v}"
   prim__setMiterLimit : CanvasPathDrawingStyles -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getLineDash()"
   prim__getLineDash : CanvasPathDrawingStyles -> PrimIO (Array Double)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setLineDash(a)"
   prim__setLineDash : CanvasPathDrawingStyles -> Array Double -> PrimIO ()
@@ -9919,7 +9919,7 @@ namespace CanvasPathDrawingStyles
 
 
 namespace CanvasRect
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearRect(a,b,c,d)"
   prim__clearRect :
@@ -9930,7 +9930,7 @@ namespace CanvasRect
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.fillRect(a,b,c,d)"
   prim__fillRect :
@@ -9941,7 +9941,7 @@ namespace CanvasRect
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.strokeRect(a,b,c,d)"
   prim__strokeRect :
@@ -9955,49 +9955,49 @@ namespace CanvasRect
 
 
 namespace CanvasShadowStyles
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowBlur"
   prim__shadowBlur : CanvasShadowStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shadowBlur = v}"
   prim__setShadowBlur : CanvasShadowStyles -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowColor"
   prim__shadowColor : CanvasShadowStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shadowColor = v}"
   prim__setShadowColor : CanvasShadowStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowOffsetX"
   prim__shadowOffsetX : CanvasShadowStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shadowOffsetX = v}"
   prim__setShadowOffsetX : CanvasShadowStyles -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shadowOffsetY"
   prim__shadowOffsetY : CanvasShadowStyles -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shadowOffsetY = v}"
   prim__setShadowOffsetY : CanvasShadowStyles -> Double -> PrimIO ()
@@ -10006,12 +10006,12 @@ namespace CanvasShadowStyles
 
 
 namespace CanvasState
-
+  
   export
   %foreign "browser:lambda:x=>x.restore()"
   prim__restore : CanvasState -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.save()"
   prim__save : CanvasState -> PrimIO ()
@@ -10019,7 +10019,7 @@ namespace CanvasState
 
 
 namespace CanvasText
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.fillText(a,b,c,d)"
   prim__fillText :
@@ -10030,12 +10030,12 @@ namespace CanvasText
     -> UndefOr Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.measureText(a)"
   prim__measureText : CanvasText -> String -> PrimIO TextMetrics
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.strokeText(a,b,c,d)"
   prim__strokeText :
@@ -10049,49 +10049,49 @@ namespace CanvasText
 
 
 namespace CanvasTextDrawingStyles
-
+  
   export
   %foreign "browser:lambda:x=>x.direction"
   prim__direction : CanvasTextDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.direction = v}"
   prim__setDirection : CanvasTextDrawingStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.font"
   prim__font : CanvasTextDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.font = v}"
   prim__setFont : CanvasTextDrawingStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textAlign"
   prim__textAlign : CanvasTextDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.textAlign = v}"
   prim__setTextAlign : CanvasTextDrawingStyles -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textBaseline"
   prim__textBaseline : CanvasTextDrawingStyles -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.textBaseline = v}"
   prim__setTextBaseline : CanvasTextDrawingStyles -> String -> PrimIO ()
@@ -10100,27 +10100,27 @@ namespace CanvasTextDrawingStyles
 
 
 namespace CanvasTransform
-
+  
   export
   %foreign "browser:lambda:x=>x.getTransform()"
   prim__getTransform : CanvasTransform -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resetTransform()"
   prim__resetTransform : CanvasTransform -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.rotate(a)"
   prim__rotate : CanvasTransform -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.scale(a,b)"
   prim__scale : CanvasTransform -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.setTransform(a,b,c,d,e,f)"
   prim__setTransform :
@@ -10133,12 +10133,12 @@ namespace CanvasTransform
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setTransform(a)"
   prim__setTransform1 : CanvasTransform -> UndefOr DOMMatrix2DInit -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.transform(a,b,c,d,e,f)"
   prim__transform :
@@ -10151,7 +10151,7 @@ namespace CanvasTransform
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.translate(a,b)"
   prim__translate : CanvasTransform -> Double -> Double -> PrimIO ()
@@ -10159,12 +10159,12 @@ namespace CanvasTransform
 
 
 namespace CanvasUserInterface
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.drawFocusIfNeeded(a)"
   prim__drawFocusIfNeeded : CanvasUserInterface -> Element -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.drawFocusIfNeeded(a,b)"
   prim__drawFocusIfNeeded1 :
@@ -10173,12 +10173,12 @@ namespace CanvasUserInterface
     -> Element
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scrollPathIntoView()"
   prim__scrollPathIntoView : CanvasUserInterface -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.scrollPathIntoView(a)"
   prim__scrollPathIntoView1 : CanvasUserInterface -> Path2D -> PrimIO ()
@@ -10186,7 +10186,7 @@ namespace CanvasUserInterface
 
 
 namespace DocumentAndElementEventHandlers
-
+  
   export
   %foreign "browser:lambda:x=>x.oncopy"
   prim__oncopy :
@@ -10194,7 +10194,7 @@ namespace DocumentAndElementEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncopy = v}"
   prim__setOncopy :
@@ -10203,7 +10203,7 @@ namespace DocumentAndElementEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncut"
   prim__oncut :
@@ -10211,7 +10211,7 @@ namespace DocumentAndElementEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncut = v}"
   prim__setOncut :
@@ -10220,7 +10220,7 @@ namespace DocumentAndElementEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onpaste"
   prim__onpaste :
@@ -10228,7 +10228,7 @@ namespace DocumentAndElementEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onpaste = v}"
   prim__setOnpaste :
@@ -10240,43 +10240,43 @@ namespace DocumentAndElementEventHandlers
 
 
 namespace ElementContentEditable
-
+  
   export
   %foreign "browser:lambda:x=>x.contentEditable"
   prim__contentEditable : ElementContentEditable -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.contentEditable = v}"
   prim__setContentEditable : ElementContentEditable -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enterKeyHint"
   prim__enterKeyHint : ElementContentEditable -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.enterKeyHint = v}"
   prim__setEnterKeyHint : ElementContentEditable -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inputMode"
   prim__inputMode : ElementContentEditable -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.inputMode = v}"
   prim__setInputMode : ElementContentEditable -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isContentEditable"
   prim__isContentEditable : ElementContentEditable -> PrimIO Boolean
@@ -10284,25 +10284,25 @@ namespace ElementContentEditable
 
 
 namespace GlobalEventHandlers
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : GlobalEventHandlers -> PrimIO (Nullable UIEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : GlobalEventHandlers -> Nullable UIEventHandler -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onauxclick"
   prim__onauxclick : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onauxclick = v}"
   prim__setOnauxclick :
@@ -10311,13 +10311,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onblur"
   prim__onblur : GlobalEventHandlers -> PrimIO (Nullable FocusEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onblur = v}"
   prim__setOnblur :
@@ -10326,13 +10326,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncancel"
   prim__oncancel : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncancel = v}"
   prim__setOncancel :
@@ -10341,13 +10341,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncanplay"
   prim__oncanplay : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncanplay = v}"
   prim__setOncanplay :
@@ -10356,7 +10356,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncanplaythrough"
   prim__oncanplaythrough :
@@ -10364,7 +10364,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncanplaythrough = v}"
   prim__setOncanplaythrough :
@@ -10373,13 +10373,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange :
@@ -10388,13 +10388,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onclick"
   prim__onclick : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onclick = v}"
   prim__setOnclick :
@@ -10403,13 +10403,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onclose"
   prim__onclose : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onclose = v}"
   prim__setOnclose :
@@ -10418,7 +10418,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncontextmenu"
   prim__oncontextmenu :
@@ -10426,7 +10426,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncontextmenu = v}"
   prim__setOncontextmenu :
@@ -10435,7 +10435,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncuechange"
   prim__oncuechange :
@@ -10443,7 +10443,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncuechange = v}"
   prim__setOncuechange :
@@ -10452,13 +10452,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondblclick"
   prim__ondblclick : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondblclick = v}"
   prim__setOndblclick :
@@ -10467,13 +10467,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondrag"
   prim__ondrag : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondrag = v}"
   prim__setOndrag :
@@ -10482,13 +10482,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondragend"
   prim__ondragend : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondragend = v}"
   prim__setOndragend :
@@ -10497,7 +10497,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondragenter"
   prim__ondragenter :
@@ -10505,7 +10505,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondragenter = v}"
   prim__setOndragenter :
@@ -10514,7 +10514,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondragleave"
   prim__ondragleave :
@@ -10522,7 +10522,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondragleave = v}"
   prim__setOndragleave :
@@ -10531,7 +10531,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondragover"
   prim__ondragover :
@@ -10539,7 +10539,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondragover = v}"
   prim__setOndragover :
@@ -10548,7 +10548,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondragstart"
   prim__ondragstart :
@@ -10556,7 +10556,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondragstart = v}"
   prim__setOndragstart :
@@ -10565,13 +10565,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondrop"
   prim__ondrop : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondrop = v}"
   prim__setOndrop :
@@ -10580,7 +10580,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ondurationchange"
   prim__ondurationchange :
@@ -10588,7 +10588,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondurationchange = v}"
   prim__setOndurationchange :
@@ -10597,13 +10597,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onemptied"
   prim__onemptied : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onemptied = v}"
   prim__setOnemptied :
@@ -10612,13 +10612,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onended"
   prim__onended : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onended = v}"
   prim__setOnended :
@@ -10627,7 +10627,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror :
@@ -10635,7 +10635,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable OnErrorEventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror :
@@ -10644,13 +10644,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onfocus"
   prim__onfocus : GlobalEventHandlers -> PrimIO (Nullable FocusEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onfocus = v}"
   prim__setOnfocus :
@@ -10659,7 +10659,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onformdata"
   prim__onformdata :
@@ -10667,7 +10667,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onformdata = v}"
   prim__setOnformdata :
@@ -10676,13 +10676,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oninput"
   prim__oninput : GlobalEventHandlers -> PrimIO (Nullable InputEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oninput = v}"
   prim__setOninput :
@@ -10691,13 +10691,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oninvalid"
   prim__oninvalid : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oninvalid = v}"
   prim__setOninvalid :
@@ -10706,7 +10706,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onkeydown"
   prim__onkeydown :
@@ -10714,7 +10714,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable KeyboardEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onkeydown = v}"
   prim__setOnkeydown :
@@ -10723,7 +10723,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onkeypress"
   prim__onkeypress :
@@ -10731,7 +10731,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onkeypress = v}"
   prim__setOnkeypress :
@@ -10740,13 +10740,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onkeyup"
   prim__onkeyup : GlobalEventHandlers -> PrimIO (Nullable KeyboardEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onkeyup = v}"
   prim__setOnkeyup :
@@ -10755,19 +10755,19 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onload"
   prim__onload : GlobalEventHandlers -> PrimIO (Nullable UIEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onload = v}"
   prim__setOnload : GlobalEventHandlers -> Nullable UIEventHandler -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadeddata"
   prim__onloadeddata :
@@ -10775,7 +10775,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadeddata = v}"
   prim__setOnloadeddata :
@@ -10784,7 +10784,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadedmetadata"
   prim__onloadedmetadata :
@@ -10792,7 +10792,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadedmetadata = v}"
   prim__setOnloadedmetadata :
@@ -10801,7 +10801,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadstart"
   prim__onloadstart :
@@ -10809,7 +10809,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadstart = v}"
   prim__setOnloadstart :
@@ -10818,13 +10818,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmousedown"
   prim__onmousedown : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmousedown = v}"
   prim__setOnmousedown :
@@ -10833,7 +10833,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmouseenter"
   prim__onmouseenter :
@@ -10841,7 +10841,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmouseenter = v}"
   prim__setOnmouseenter :
@@ -10850,7 +10850,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmouseleave"
   prim__onmouseleave :
@@ -10858,7 +10858,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmouseleave = v}"
   prim__setOnmouseleave :
@@ -10867,13 +10867,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmousemove"
   prim__onmousemove : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmousemove = v}"
   prim__setOnmousemove :
@@ -10882,13 +10882,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmouseout"
   prim__onmouseout : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmouseout = v}"
   prim__setOnmouseout :
@@ -10897,13 +10897,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmouseover"
   prim__onmouseover : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmouseover = v}"
   prim__setOnmouseover :
@@ -10912,13 +10912,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmouseup"
   prim__onmouseup : GlobalEventHandlers -> PrimIO (Nullable MouseEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmouseup = v}"
   prim__setOnmouseup :
@@ -10927,13 +10927,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onpause"
   prim__onpause : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onpause = v}"
   prim__setOnpause :
@@ -10942,13 +10942,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onplay"
   prim__onplay : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onplay = v}"
   prim__setOnplay :
@@ -10957,13 +10957,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onplaying"
   prim__onplaying : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onplaying = v}"
   prim__setOnplaying :
@@ -10972,7 +10972,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onprogress"
   prim__onprogress :
@@ -10980,7 +10980,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onprogress = v}"
   prim__setOnprogress :
@@ -10989,7 +10989,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onratechange"
   prim__onratechange :
@@ -10997,7 +10997,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onratechange = v}"
   prim__setOnratechange :
@@ -11006,13 +11006,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onreset"
   prim__onreset : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onreset = v}"
   prim__setOnreset :
@@ -11021,13 +11021,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onresize"
   prim__onresize : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onresize = v}"
   prim__setOnresize :
@@ -11036,13 +11036,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onscroll"
   prim__onscroll : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onscroll = v}"
   prim__setOnscroll :
@@ -11051,7 +11051,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsecuritypolicyviolation"
   prim__onsecuritypolicyviolation :
@@ -11059,7 +11059,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsecuritypolicyviolation = v}"
   prim__setOnsecuritypolicyviolation :
@@ -11068,13 +11068,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onseeked"
   prim__onseeked : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onseeked = v}"
   prim__setOnseeked :
@@ -11083,13 +11083,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onseeking"
   prim__onseeking : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onseeking = v}"
   prim__setOnseeking :
@@ -11098,13 +11098,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onselect"
   prim__onselect : GlobalEventHandlers -> PrimIO (Nullable UIEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onselect = v}"
   prim__setOnselect :
@@ -11113,7 +11113,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onslotchange"
   prim__onslotchange :
@@ -11121,7 +11121,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onslotchange = v}"
   prim__setOnslotchange :
@@ -11130,13 +11130,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onstalled"
   prim__onstalled : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onstalled = v}"
   prim__setOnstalled :
@@ -11145,13 +11145,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsubmit"
   prim__onsubmit : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsubmit = v}"
   prim__setOnsubmit :
@@ -11160,13 +11160,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsuspend"
   prim__onsuspend : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsuspend = v}"
   prim__setOnsuspend :
@@ -11175,7 +11175,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ontimeupdate"
   prim__ontimeupdate :
@@ -11183,7 +11183,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ontimeupdate = v}"
   prim__setOntimeupdate :
@@ -11192,13 +11192,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ontoggle"
   prim__ontoggle : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ontoggle = v}"
   prim__setOntoggle :
@@ -11207,7 +11207,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onvolumechange"
   prim__onvolumechange :
@@ -11215,7 +11215,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onvolumechange = v}"
   prim__setOnvolumechange :
@@ -11224,13 +11224,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwaiting"
   prim__onwaiting : GlobalEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwaiting = v}"
   prim__setOnwaiting :
@@ -11239,7 +11239,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwebkitanimationend"
   prim__onwebkitanimationend :
@@ -11247,7 +11247,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwebkitanimationend = v}"
   prim__setOnwebkitanimationend :
@@ -11256,7 +11256,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwebkitanimationiteration"
   prim__onwebkitanimationiteration :
@@ -11264,7 +11264,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwebkitanimationiteration = v}"
   prim__setOnwebkitanimationiteration :
@@ -11273,7 +11273,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwebkitanimationstart"
   prim__onwebkitanimationstart :
@@ -11281,7 +11281,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwebkitanimationstart = v}"
   prim__setOnwebkitanimationstart :
@@ -11290,7 +11290,7 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwebkittransitionend"
   prim__onwebkittransitionend :
@@ -11298,7 +11298,7 @@ namespace GlobalEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwebkittransitionend = v}"
   prim__setOnwebkittransitionend :
@@ -11307,13 +11307,13 @@ namespace GlobalEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onwheel"
   prim__onwheel : GlobalEventHandlers -> PrimIO (Nullable WheelEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onwheel = v}"
   prim__setOnwheel :
@@ -11325,126 +11325,126 @@ namespace GlobalEventHandlers
 
 
 namespace HTMLHyperlinkElementUtils
-
+  
   export
   %foreign "browser:lambda:x=>x.hash"
   prim__hash : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hash = v}"
   prim__setHash : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.host"
   prim__host : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.host = v}"
   prim__setHost : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hostname"
   prim__hostname : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hostname = v}"
   prim__setHostname : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.href = v}"
   prim__setHref : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : HTMLHyperlinkElementUtils -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.password"
   prim__password : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.password = v}"
   prim__setPassword : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pathname"
   prim__pathname : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pathname = v}"
   prim__setPathname : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port"
   prim__port : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.port = v}"
   prim__setPort : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.protocol"
   prim__protocol : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.protocol = v}"
   prim__setProtocol : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.search"
   prim__search : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.search = v}"
   prim__setSearch : HTMLHyperlinkElementUtils -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.username"
   prim__username : HTMLHyperlinkElementUtils -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.username = v}"
   prim__setUsername : HTMLHyperlinkElementUtils -> String -> PrimIO ()
@@ -11453,53 +11453,53 @@ namespace HTMLHyperlinkElementUtils
 
 
 namespace HTMLOrSVGElement
-
+  
   export
   %foreign "browser:lambda:x=>x.autofocus"
   prim__autofocus : HTMLOrSVGElement -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autofocus = v}"
   prim__setAutofocus : HTMLOrSVGElement -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dataset"
   prim__dataset : HTMLOrSVGElement -> PrimIO DOMStringMap
 
-
+  
   export
   %foreign "browser:lambda:x=>x.nonce"
   prim__nonce : HTMLOrSVGElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.nonce = v}"
   prim__setNonce : HTMLOrSVGElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tabIndex"
   prim__tabIndex : HTMLOrSVGElement -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.tabIndex = v}"
   prim__setTabIndex : HTMLOrSVGElement -> Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.blur()"
   prim__blur : HTMLOrSVGElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.focus(a)"
   prim__focus : HTMLOrSVGElement -> UndefOr FocusOptions -> PrimIO ()
@@ -11507,7 +11507,7 @@ namespace HTMLOrSVGElement
 
 
 namespace NavigatorConcurrentHardware
-
+  
   export
   %foreign "browser:lambda:x=>x.hardwareConcurrency"
   prim__hardwareConcurrency : NavigatorConcurrentHardware -> PrimIO JSBits64
@@ -11515,7 +11515,7 @@ namespace NavigatorConcurrentHardware
 
 
 namespace NavigatorContentUtils
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.registerProtocolHandler(a,b)"
   prim__registerProtocolHandler :
@@ -11524,7 +11524,7 @@ namespace NavigatorContentUtils
     -> String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.unregisterProtocolHandler(a,b)"
   prim__unregisterProtocolHandler :
@@ -11536,7 +11536,7 @@ namespace NavigatorContentUtils
 
 
 namespace NavigatorCookies
-
+  
   export
   %foreign "browser:lambda:x=>x.cookieEnabled"
   prim__cookieEnabled : NavigatorCookies -> PrimIO Boolean
@@ -11544,47 +11544,47 @@ namespace NavigatorCookies
 
 
 namespace NavigatorID
-
+  
   export
   %foreign "browser:lambda:x=>x.appCodeName"
   prim__appCodeName : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.appName"
   prim__appName : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.appVersion"
   prim__appVersion : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.platform"
   prim__platform : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.product"
   prim__product : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.productSub"
   prim__productSub : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.userAgent"
   prim__userAgent : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vendor"
   prim__vendor : NavigatorID -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.vendorSub"
   prim__vendorSub : NavigatorID -> PrimIO String
@@ -11592,12 +11592,12 @@ namespace NavigatorID
 
 
 namespace NavigatorLanguage
-
+  
   export
   %foreign "browser:lambda:x=>x.language"
   prim__language : NavigatorLanguage -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.languages"
   prim__languages : NavigatorLanguage -> PrimIO (Array String)
@@ -11605,7 +11605,7 @@ namespace NavigatorLanguage
 
 
 namespace NavigatorOnLine
-
+  
   export
   %foreign "browser:lambda:x=>x.onLine"
   prim__onLine : NavigatorOnLine -> PrimIO Boolean
@@ -11613,17 +11613,17 @@ namespace NavigatorOnLine
 
 
 namespace NavigatorPlugins
-
+  
   export
   %foreign "browser:lambda:x=>x.mimeTypes"
   prim__mimeTypes : NavigatorPlugins -> PrimIO MimeTypeArray
 
-
+  
   export
   %foreign "browser:lambda:x=>x.plugins"
   prim__plugins : NavigatorPlugins -> PrimIO PluginArray
 
-
+  
   export
   %foreign "browser:lambda:x=>x.javaEnabled()"
   prim__javaEnabled : NavigatorPlugins -> PrimIO Boolean
@@ -11631,7 +11631,7 @@ namespace NavigatorPlugins
 
 
 namespace WindowEventHandlers
-
+  
   export
   %foreign "browser:lambda:x=>x.onafterprint"
   prim__onafterprint :
@@ -11639,7 +11639,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onafterprint = v}"
   prim__setOnafterprint :
@@ -11648,7 +11648,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onbeforeprint"
   prim__onbeforeprint :
@@ -11656,7 +11656,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onbeforeprint = v}"
   prim__setOnbeforeprint :
@@ -11665,7 +11665,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onbeforeunload"
   prim__onbeforeunload :
@@ -11673,7 +11673,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable OnBeforeUnloadEventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onbeforeunload = v}"
   prim__setOnbeforeunload :
@@ -11682,7 +11682,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onhashchange"
   prim__onhashchange :
@@ -11690,7 +11690,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onhashchange = v}"
   prim__setOnhashchange :
@@ -11699,7 +11699,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onlanguagechange"
   prim__onlanguagechange :
@@ -11707,7 +11707,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onlanguagechange = v}"
   prim__setOnlanguagechange :
@@ -11716,13 +11716,13 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage : WindowEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage :
@@ -11731,7 +11731,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror :
@@ -11739,7 +11739,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -11748,13 +11748,13 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onoffline"
   prim__onoffline : WindowEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onoffline = v}"
   prim__setOnoffline :
@@ -11763,13 +11763,13 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ononline"
   prim__ononline : WindowEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ononline = v}"
   prim__setOnonline :
@@ -11778,7 +11778,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onpagehide"
   prim__onpagehide :
@@ -11786,7 +11786,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onpagehide = v}"
   prim__setOnpagehide :
@@ -11795,7 +11795,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onpageshow"
   prim__onpageshow :
@@ -11803,7 +11803,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onpageshow = v}"
   prim__setOnpageshow :
@@ -11812,7 +11812,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onpopstate"
   prim__onpopstate :
@@ -11820,7 +11820,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onpopstate = v}"
   prim__setOnpopstate :
@@ -11829,7 +11829,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onrejectionhandled"
   prim__onrejectionhandled :
@@ -11837,7 +11837,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onrejectionhandled = v}"
   prim__setOnrejectionhandled :
@@ -11846,13 +11846,13 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onstorage"
   prim__onstorage : WindowEventHandlers -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onstorage = v}"
   prim__setOnstorage :
@@ -11861,7 +11861,7 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onunhandledrejection"
   prim__onunhandledrejection :
@@ -11869,7 +11869,7 @@ namespace WindowEventHandlers
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onunhandledrejection = v}"
   prim__setOnunhandledrejection :
@@ -11878,13 +11878,13 @@ namespace WindowEventHandlers
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onunload"
   prim__onunload : WindowEventHandlers -> PrimIO (Nullable UIEventHandler)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onunload = v}"
   prim__setOnunload :
@@ -11896,7 +11896,7 @@ namespace WindowEventHandlers
 
 
 namespace WindowLocalStorage
-
+  
   export
   %foreign "browser:lambda:x=>x.localStorage"
   prim__localStorage : WindowLocalStorage -> PrimIO Storage
@@ -11904,57 +11904,57 @@ namespace WindowLocalStorage
 
 
 namespace WindowOrWorkerGlobalScope
-
+  
   export
   %foreign "browser:lambda:x=>x.caches"
   prim__caches : WindowOrWorkerGlobalScope -> PrimIO CacheStorage
 
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOriginIsolated"
   prim__crossOriginIsolated : WindowOrWorkerGlobalScope -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.indexedDB"
   prim__indexedDB : WindowOrWorkerGlobalScope -> PrimIO IDBFactory
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isSecureContext"
   prim__isSecureContext : WindowOrWorkerGlobalScope -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : WindowOrWorkerGlobalScope -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.performance"
   prim__performance : WindowOrWorkerGlobalScope -> PrimIO Performance
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.atob(a)"
   prim__atob : WindowOrWorkerGlobalScope -> String -> PrimIO ByteString
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.btoa(a)"
   prim__btoa : WindowOrWorkerGlobalScope -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clearInterval(a)"
   prim__clearInterval : WindowOrWorkerGlobalScope -> UndefOr Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clearTimeout(a)"
   prim__clearTimeout : WindowOrWorkerGlobalScope -> UndefOr Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createImageBitmap(a,b)"
   prim__createImageBitmap :
@@ -11971,7 +11971,7 @@ namespace WindowOrWorkerGlobalScope
     -> UndefOr ImageBitmapOptions
     -> PrimIO (Promise ImageBitmap)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.createImageBitmap(a,b,c,d,e,f)"
   prim__createImageBitmap1 :
@@ -11992,7 +11992,7 @@ namespace WindowOrWorkerGlobalScope
     -> UndefOr ImageBitmapOptions
     -> PrimIO (Promise ImageBitmap)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.fetch(a,b)"
   prim__fetch :
@@ -12001,17 +12001,17 @@ namespace WindowOrWorkerGlobalScope
     -> UndefOr RequestInit
     -> PrimIO (Promise Response)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.queueMicrotask(a)"
   prim__queueMicrotask : WindowOrWorkerGlobalScope -> VoidFunction -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.reportError(a)"
   prim__reportError : WindowOrWorkerGlobalScope -> AnyPtr -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.structuredClone(a,b)"
   prim__structuredClone :
@@ -12028,18 +12028,18 @@ namespace WindowOrWorkerGlobalScope
 --------------------------------------------------------------------------------
 
 namespace AssignedNodesOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({flatten: a})"
   prim__new : UndefOr Boolean -> PrimIO AssignedNodesOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.flatten"
   prim__flatten : AssignedNodesOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.flatten = v}"
   prim__setFlatten : AssignedNodesOptions -> UndefOr Boolean -> PrimIO ()
@@ -12048,7 +12048,7 @@ namespace AssignedNodesOptions
 
 
 namespace CanvasRenderingContext2DSettings
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({alpha: a,desynchronized: b})"
   prim__new :
@@ -12056,13 +12056,13 @@ namespace CanvasRenderingContext2DSettings
     -> UndefOr Boolean
     -> PrimIO CanvasRenderingContext2DSettings
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alpha"
   prim__alpha : CanvasRenderingContext2DSettings -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alpha = v}"
   prim__setAlpha :
@@ -12071,7 +12071,7 @@ namespace CanvasRenderingContext2DSettings
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.desynchronized"
   prim__desynchronized :
@@ -12079,7 +12079,7 @@ namespace CanvasRenderingContext2DSettings
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.desynchronized = v}"
   prim__setDesynchronized :
@@ -12091,7 +12091,7 @@ namespace CanvasRenderingContext2DSettings
 
 
 namespace CloseEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({wasClean: a,code: b,reason: c})"
   prim__new :
@@ -12100,37 +12100,37 @@ namespace CloseEventInit
     -> UndefOr String
     -> PrimIO CloseEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : CloseEventInit -> PrimIO (UndefOr Bits16)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.code = v}"
   prim__setCode : CloseEventInit -> UndefOr Bits16 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reason"
   prim__reason : CloseEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.reason = v}"
   prim__setReason : CloseEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.wasClean"
   prim__wasClean : CloseEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.wasClean = v}"
   prim__setWasClean : CloseEventInit -> UndefOr Boolean -> PrimIO ()
@@ -12139,18 +12139,18 @@ namespace CloseEventInit
 
 
 namespace DragEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({dataTransfer: a})"
   prim__new : UndefOr (Nullable DataTransfer) -> PrimIO DragEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dataTransfer"
   prim__dataTransfer : DragEventInit -> PrimIO (UndefOr (Nullable DataTransfer))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.dataTransfer = v}"
   prim__setDataTransfer :
@@ -12162,18 +12162,18 @@ namespace DragEventInit
 
 
 namespace ElementDefinitionOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({extends: a})"
   prim__new : UndefOr String -> PrimIO ElementDefinitionOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.extends"
   prim__extends : ElementDefinitionOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.extends = v}"
   prim__setExtends : ElementDefinitionOptions -> UndefOr String -> PrimIO ()
@@ -12182,7 +12182,7 @@ namespace ElementDefinitionOptions
 
 
 namespace ErrorEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({message: a,filename: b,lineno: c,colno: d,error: e})"
   prim__new :
@@ -12193,61 +12193,61 @@ namespace ErrorEventInit
     -> UndefOr AnyPtr
     -> PrimIO ErrorEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.colno"
   prim__colno : ErrorEventInit -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.colno = v}"
   prim__setColno : ErrorEventInit -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : ErrorEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.error = v}"
   prim__setError : ErrorEventInit -> UndefOr AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.filename"
   prim__filename : ErrorEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.filename = v}"
   prim__setFilename : ErrorEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lineno"
   prim__lineno : ErrorEventInit -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lineno = v}"
   prim__setLineno : ErrorEventInit -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.message"
   prim__message : ErrorEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.message = v}"
   prim__setMessage : ErrorEventInit -> UndefOr String -> PrimIO ()
@@ -12256,18 +12256,18 @@ namespace ErrorEventInit
 
 
 namespace EventSourceInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({withCredentials: a})"
   prim__new : UndefOr Boolean -> PrimIO EventSourceInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.withCredentials"
   prim__withCredentials : EventSourceInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.withCredentials = v}"
   prim__setWithCredentials : EventSourceInit -> UndefOr Boolean -> PrimIO ()
@@ -12276,18 +12276,18 @@ namespace EventSourceInit
 
 
 namespace FocusOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({preventScroll: a})"
   prim__new : UndefOr Boolean -> PrimIO FocusOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventScroll"
   prim__preventScroll : FocusOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preventScroll = v}"
   prim__setPreventScroll : FocusOptions -> UndefOr Boolean -> PrimIO ()
@@ -12296,18 +12296,18 @@ namespace FocusOptions
 
 
 namespace FormDataEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({formData: a})"
   prim__new : FormData -> PrimIO FormDataEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.formData"
   prim__formData : FormDataEventInit -> PrimIO FormData
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.formData = v}"
   prim__setFormData : FormDataEventInit -> FormData -> PrimIO ()
@@ -12316,30 +12316,30 @@ namespace FormDataEventInit
 
 
 namespace HashChangeEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({oldURL: a,newURL: b})"
   prim__new : UndefOr String -> UndefOr String -> PrimIO HashChangeEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newURL"
   prim__newURL : HashChangeEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.newURL = v}"
   prim__setNewURL : HashChangeEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldURL"
   prim__oldURL : HashChangeEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oldURL = v}"
   prim__setOldURL : HashChangeEventInit -> UndefOr String -> PrimIO ()
@@ -12348,7 +12348,7 @@ namespace HashChangeEventInit
 
 
 namespace ImageBitmapOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f)=> ({imageOrientation: a,premultiplyAlpha: b,colorSpaceConversion: c,resizeWidth: d,resizeHeight: e,resizeQuality: f})"
   prim__new :
@@ -12360,13 +12360,13 @@ namespace ImageBitmapOptions
     -> UndefOr String
     -> PrimIO ImageBitmapOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.colorSpaceConversion"
   prim__colorSpaceConversion : ImageBitmapOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.colorSpaceConversion = v}"
   prim__setColorSpaceConversion :
@@ -12375,61 +12375,61 @@ namespace ImageBitmapOptions
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.imageOrientation"
   prim__imageOrientation : ImageBitmapOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.imageOrientation = v}"
   prim__setImageOrientation : ImageBitmapOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.premultiplyAlpha"
   prim__premultiplyAlpha : ImageBitmapOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.premultiplyAlpha = v}"
   prim__setPremultiplyAlpha : ImageBitmapOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeHeight"
   prim__resizeHeight : ImageBitmapOptions -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeHeight = v}"
   prim__setResizeHeight : ImageBitmapOptions -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeQuality"
   prim__resizeQuality : ImageBitmapOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeQuality = v}"
   prim__setResizeQuality : ImageBitmapOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeWidth"
   prim__resizeWidth : ImageBitmapOptions -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeWidth = v}"
   prim__setResizeWidth : ImageBitmapOptions -> UndefOr Bits32 -> PrimIO ()
@@ -12438,18 +12438,18 @@ namespace ImageBitmapOptions
 
 
 namespace ImageBitmapRenderingContextSettings
-
+  
   export
   %foreign "browser:lambda:(a)=> ({alpha: a})"
   prim__new : UndefOr Boolean -> PrimIO ImageBitmapRenderingContextSettings
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alpha"
   prim__alpha : ImageBitmapRenderingContextSettings -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alpha = v}"
   prim__setAlpha :
@@ -12461,30 +12461,30 @@ namespace ImageBitmapRenderingContextSettings
 
 
 namespace ImageEncodeOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({type: a,quality: b})"
   prim__new : UndefOr String -> UndefOr Double -> PrimIO ImageEncodeOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.quality"
   prim__quality : ImageEncodeOptions -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.quality = v}"
   prim__setQuality : ImageEncodeOptions -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : ImageEncodeOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : ImageEncodeOptions -> UndefOr String -> PrimIO ()
@@ -12493,7 +12493,7 @@ namespace ImageEncodeOptions
 
 
 namespace MessageEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({data: a,origin: b,lastEventId: c,source: d,ports: e})"
   prim__new :
@@ -12504,55 +12504,55 @@ namespace MessageEventInit
     -> UndefOr (Array MessagePort)
     -> PrimIO MessageEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : MessageEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : MessageEventInit -> UndefOr AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastEventId"
   prim__lastEventId : MessageEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lastEventId = v}"
   prim__setLastEventId : MessageEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : MessageEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.origin = v}"
   prim__setOrigin : MessageEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ports"
   prim__ports : MessageEventInit -> PrimIO (UndefOr (Array MessagePort))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ports = v}"
   prim__setPorts : MessageEventInit -> UndefOr (Array MessagePort) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source :
@@ -12561,7 +12561,7 @@ namespace MessageEventInit
          (UndefOr (Nullable (Union3 WindowProxy MessagePort ServiceWorker)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.source = v}"
   prim__setSource :
@@ -12573,18 +12573,18 @@ namespace MessageEventInit
 
 
 namespace PageTransitionEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({persisted: a})"
   prim__new : UndefOr Boolean -> PrimIO PageTransitionEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.persisted"
   prim__persisted : PageTransitionEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.persisted = v}"
   prim__setPersisted : PageTransitionEventInit -> UndefOr Boolean -> PrimIO ()
@@ -12593,18 +12593,18 @@ namespace PageTransitionEventInit
 
 
 namespace PopStateEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({state: a})"
   prim__new : UndefOr AnyPtr -> PrimIO PopStateEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : PopStateEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.state = v}"
   prim__setState : PopStateEventInit -> UndefOr AnyPtr -> PrimIO ()
@@ -12613,18 +12613,18 @@ namespace PopStateEventInit
 
 
 namespace PostMessageOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({transfer: a})"
   prim__new : UndefOr (Array Object) -> PrimIO PostMessageOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transfer"
   prim__transfer : PostMessageOptions -> PrimIO (UndefOr (Array Object))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.transfer = v}"
   prim__setTransfer : PostMessageOptions -> UndefOr (Array Object) -> PrimIO ()
@@ -12633,7 +12633,7 @@ namespace PostMessageOptions
 
 
 namespace PromiseRejectionEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({promise: a,reason: b})"
   prim__new :
@@ -12641,25 +12641,25 @@ namespace PromiseRejectionEventInit
     -> UndefOr AnyPtr
     -> PrimIO PromiseRejectionEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.promise"
   prim__promise : PromiseRejectionEventInit -> PrimIO (Promise AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.promise = v}"
   prim__setPromise : PromiseRejectionEventInit -> Promise AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.reason"
   prim__reason : PromiseRejectionEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.reason = v}"
   prim__setReason : PromiseRejectionEventInit -> UndefOr AnyPtr -> PrimIO ()
@@ -12668,7 +12668,7 @@ namespace PromiseRejectionEventInit
 
 
 namespace StorageEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({key: a,oldValue: b,newValue: c,url: d,storageArea: e})"
   prim__new :
@@ -12679,49 +12679,49 @@ namespace StorageEventInit
     -> UndefOr (Nullable Storage)
     -> PrimIO StorageEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.key"
   prim__key : StorageEventInit -> PrimIO (UndefOr (Nullable String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.key = v}"
   prim__setKey : StorageEventInit -> UndefOr (Nullable String) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newValue"
   prim__newValue : StorageEventInit -> PrimIO (UndefOr (Nullable String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.newValue = v}"
   prim__setNewValue : StorageEventInit -> UndefOr (Nullable String) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldValue"
   prim__oldValue : StorageEventInit -> PrimIO (UndefOr (Nullable String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oldValue = v}"
   prim__setOldValue : StorageEventInit -> UndefOr (Nullable String) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.storageArea"
   prim__storageArea : StorageEventInit -> PrimIO (UndefOr (Nullable Storage))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.storageArea = v}"
   prim__setStorageArea :
@@ -12730,13 +12730,13 @@ namespace StorageEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : StorageEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.url = v}"
   prim__setUrl : StorageEventInit -> UndefOr String -> PrimIO ()
@@ -12745,18 +12745,18 @@ namespace StorageEventInit
 
 
 namespace StructuredSerializeOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({transfer: a})"
   prim__new : UndefOr (Array Object) -> PrimIO StructuredSerializeOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transfer"
   prim__transfer : StructuredSerializeOptions -> PrimIO (UndefOr (Array Object))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.transfer = v}"
   prim__setTransfer :
@@ -12768,18 +12768,18 @@ namespace StructuredSerializeOptions
 
 
 namespace SubmitEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({submitter: a})"
   prim__new : UndefOr (Nullable HTMLElement) -> PrimIO SubmitEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.submitter"
   prim__submitter : SubmitEventInit -> PrimIO (UndefOr (Nullable HTMLElement))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.submitter = v}"
   prim__setSubmitter :
@@ -12791,14 +12791,14 @@ namespace SubmitEventInit
 
 
 namespace TrackEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({track: a})"
   prim__new :
        UndefOr (Nullable (Union3 VideoTrack AudioTrack TextTrack))
     -> PrimIO TrackEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track :
@@ -12806,7 +12806,7 @@ namespace TrackEventInit
     -> PrimIO (UndefOr (Nullable (Union3 VideoTrack AudioTrack TextTrack)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.track = v}"
   prim__setTrack :
@@ -12818,7 +12818,7 @@ namespace TrackEventInit
 
 
 namespace ValidityStateFlags
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j)=> ({valueMissing: a,typeMismatch: b,patternMismatch: c,tooLong: d,tooShort: e,rangeUnderflow: f,rangeOverflow: g,stepMismatch: h,badInput: i,customError: j})"
   prim__new :
@@ -12834,121 +12834,121 @@ namespace ValidityStateFlags
     -> UndefOr Boolean
     -> PrimIO ValidityStateFlags
 
-
+  
   export
   %foreign "browser:lambda:x=>x.badInput"
   prim__badInput : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.badInput = v}"
   prim__setBadInput : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.customError"
   prim__customError : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.customError = v}"
   prim__setCustomError : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.patternMismatch"
   prim__patternMismatch : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.patternMismatch = v}"
   prim__setPatternMismatch : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeOverflow"
   prim__rangeOverflow : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rangeOverflow = v}"
   prim__setRangeOverflow : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeUnderflow"
   prim__rangeUnderflow : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rangeUnderflow = v}"
   prim__setRangeUnderflow : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stepMismatch"
   prim__stepMismatch : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.stepMismatch = v}"
   prim__setStepMismatch : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tooLong"
   prim__tooLong : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.tooLong = v}"
   prim__setTooLong : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tooShort"
   prim__tooShort : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.tooShort = v}"
   prim__setTooShort : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.typeMismatch"
   prim__typeMismatch : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.typeMismatch = v}"
   prim__setTypeMismatch : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueMissing"
   prim__valueMissing : ValidityStateFlags -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueMissing = v}"
   prim__setValueMissing : ValidityStateFlags -> UndefOr Boolean -> PrimIO ()
@@ -12957,18 +12957,18 @@ namespace ValidityStateFlags
 
 
 namespace WindowPostMessageOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({targetOrigin: a})"
   prim__new : UndefOr String -> PrimIO WindowPostMessageOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.targetOrigin"
   prim__targetOrigin : WindowPostMessageOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.targetOrigin = v}"
   prim__setTargetOrigin :
@@ -12980,7 +12980,7 @@ namespace WindowPostMessageOptions
 
 
 namespace WorkerOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({type: a,credentials: b,name: c})"
   prim__new :
@@ -12989,37 +12989,37 @@ namespace WorkerOptions
     -> UndefOr String
     -> PrimIO WorkerOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.credentials"
   prim__credentials : WorkerOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.credentials = v}"
   prim__setCredentials : WorkerOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : WorkerOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : WorkerOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : WorkerOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : WorkerOptions -> UndefOr String -> PrimIO ()
@@ -13028,18 +13028,18 @@ namespace WorkerOptions
 
 
 namespace WorkletOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({credentials: a})"
   prim__new : UndefOr String -> PrimIO WorkletOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.credentials"
   prim__credentials : WorkletOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.credentials = v}"
   prim__setCredentials : WorkletOptions -> UndefOr String -> PrimIO ()
@@ -13053,7 +13053,7 @@ namespace WorkletOptions
 --------------------------------------------------------------------------------
 
 namespace BlobCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toBlobCallback : (Nullable Blob -> IO ()) -> PrimIO BlobCallback
@@ -13061,7 +13061,7 @@ namespace BlobCallback
 
 
 namespace CompositionEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toCompositionEventHandler :
@@ -13071,7 +13071,7 @@ namespace CompositionEventHandler
 
 
 namespace CustomElementConstructor
-
+  
   export
   %foreign "browser:lambda:x=>()=>x()()"
   prim__toCustomElementConstructor :
@@ -13081,7 +13081,7 @@ namespace CustomElementConstructor
 
 
 namespace EventHandlerNonNull
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toEventHandlerNonNull :
@@ -13091,7 +13091,7 @@ namespace EventHandlerNonNull
 
 
 namespace FocusEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toFocusEventHandler : (FocusEvent -> IO ()) -> PrimIO FocusEventHandler
@@ -13099,7 +13099,7 @@ namespace FocusEventHandler
 
 
 namespace FunctionStringCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toFunctionStringCallback :
@@ -13109,7 +13109,7 @@ namespace FunctionStringCallback
 
 
 namespace InputEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toInputEventHandler : (InputEvent -> IO ()) -> PrimIO InputEventHandler
@@ -13117,7 +13117,7 @@ namespace InputEventHandler
 
 
 namespace KeyboardEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toKeyboardEventHandler :
@@ -13127,7 +13127,7 @@ namespace KeyboardEventHandler
 
 
 namespace MouseEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toMouseEventHandler : (MouseEvent -> IO ()) -> PrimIO MouseEventHandler
@@ -13135,7 +13135,7 @@ namespace MouseEventHandler
 
 
 namespace OnBeforeUnloadEventHandlerNonNull
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toOnBeforeUnloadEventHandlerNonNull :
@@ -13145,7 +13145,7 @@ namespace OnBeforeUnloadEventHandlerNonNull
 
 
 namespace OnErrorEventHandlerNonNull
-
+  
   export
   %foreign "browser:lambda:x=>(a,b,c,d,e)=>x(a,b,c,d,e)()"
   prim__toOnErrorEventHandlerNonNull :
@@ -13161,7 +13161,7 @@ namespace OnErrorEventHandlerNonNull
 
 
 namespace UIEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUIEventHandler : (UIEvent -> IO ()) -> PrimIO UIEventHandler
@@ -13169,7 +13169,9 @@ namespace UIEventHandler
 
 
 namespace WheelEventHandler
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toWheelEventHandler : (WheelEvent -> IO ()) -> PrimIO WheelEventHandler
+
+

--- a/src/Web/Internal/HtmlTypes.idr
+++ b/src/Web/Internal/HtmlTypes.idr
@@ -10,7 +10,7 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace DOMParserSupportedType
-
+  
   public export
   data DOMParserSupportedType =
       TextHtml
@@ -18,24 +18,24 @@ namespace DOMParserSupportedType
     | ApplicationXml
     | ApplicationXhtmlXml
     | ImageSvgXml
-
-  public export
+  
+  export
   Show DOMParserSupportedType where
     show TextHtml = "text/html"
     show TextXml = "text/xml"
     show ApplicationXml = "application/xml"
     show ApplicationXhtmlXml = "application/xhtml+xml"
     show ImageSvgXml = "image/svg+xml"
-
-  public export
+  
+  export
   Eq DOMParserSupportedType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord DOMParserSupportedType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe DOMParserSupportedType
   read "text/html" = Just TextHtml
   read "text/xml" = Just TextXml
@@ -43,417 +43,417 @@ namespace DOMParserSupportedType
   read "application/xhtml+xml" = Just ApplicationXhtmlXml
   read "image/svg+xml" = Just ImageSvgXml
   read _ = Nothing
-
+  
   export
   ToFFI DOMParserSupportedType String where
     toFFI = show
-
+  
   export
   FromFFI DOMParserSupportedType String where
     fromFFI = read
 
 
 namespace DocumentReadyState
-
+  
   public export
   data DocumentReadyState = Loading | Interactive | Complete
-
-  public export
+  
+  export
   Show DocumentReadyState where
     show Loading = "loading"
     show Interactive = "interactive"
     show Complete = "complete"
-
-  public export
+  
+  export
   Eq DocumentReadyState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord DocumentReadyState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe DocumentReadyState
   read "loading" = Just Loading
   read "interactive" = Just Interactive
   read "complete" = Just Complete
   read _ = Nothing
-
+  
   export
   ToFFI DocumentReadyState String where
     toFFI = show
-
+  
   export
   FromFFI DocumentReadyState String where
     fromFFI = read
 
 
 namespace CanPlayTypeResult
-
+  
   public export
   data CanPlayTypeResult = Empty | Maybe | Probably
-
-  public export
+  
+  export
   Show CanPlayTypeResult where
     show Empty = ""
     show Maybe = "maybe"
     show Probably = "probably"
-
-  public export
+  
+  export
   Eq CanPlayTypeResult where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanPlayTypeResult where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanPlayTypeResult
   read "" = Just Empty
   read "maybe" = Just Maybe
   read "probably" = Just Probably
   read _ = Nothing
-
+  
   export
   ToFFI CanPlayTypeResult String where
     toFFI = show
-
+  
   export
   FromFFI CanPlayTypeResult String where
     fromFFI = read
 
 
 namespace ScrollRestoration
-
+  
   public export
   data ScrollRestoration = Auto | Manual
-
-  public export
+  
+  export
   Show ScrollRestoration where
     show Auto = "auto"
     show Manual = "manual"
-
-  public export
+  
+  export
   Eq ScrollRestoration where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ScrollRestoration where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ScrollRestoration
   read "auto" = Just Auto
   read "manual" = Just Manual
   read _ = Nothing
-
+  
   export
   ToFFI ScrollRestoration String where
     toFFI = show
-
+  
   export
   FromFFI ScrollRestoration String where
     fromFFI = read
 
 
 namespace ImageOrientation
-
+  
   public export
   data ImageOrientation = None | FlipY
-
-  public export
+  
+  export
   Show ImageOrientation where
     show None = "none"
     show FlipY = "flipY"
-
-  public export
+  
+  export
   Eq ImageOrientation where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ImageOrientation where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ImageOrientation
   read "none" = Just None
   read "flipY" = Just FlipY
   read _ = Nothing
-
+  
   export
   ToFFI ImageOrientation String where
     toFFI = show
-
+  
   export
   FromFFI ImageOrientation String where
     fromFFI = read
 
 
 namespace PremultiplyAlpha
-
+  
   public export
   data PremultiplyAlpha = None | Premultiply | Default
-
-  public export
+  
+  export
   Show PremultiplyAlpha where
     show None = "none"
     show Premultiply = "premultiply"
     show Default = "default"
-
-  public export
+  
+  export
   Eq PremultiplyAlpha where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord PremultiplyAlpha where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe PremultiplyAlpha
   read "none" = Just None
   read "premultiply" = Just Premultiply
   read "default" = Just Default
   read _ = Nothing
-
+  
   export
   ToFFI PremultiplyAlpha String where
     toFFI = show
-
+  
   export
   FromFFI PremultiplyAlpha String where
     fromFFI = read
 
 
 namespace ColorSpaceConversion
-
+  
   public export
   data ColorSpaceConversion = None | Default
-
-  public export
+  
+  export
   Show ColorSpaceConversion where
     show None = "none"
     show Default = "default"
-
-  public export
+  
+  export
   Eq ColorSpaceConversion where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ColorSpaceConversion where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ColorSpaceConversion
   read "none" = Just None
   read "default" = Just Default
   read _ = Nothing
-
+  
   export
   ToFFI ColorSpaceConversion String where
     toFFI = show
-
+  
   export
   FromFFI ColorSpaceConversion String where
     fromFFI = read
 
 
 namespace ResizeQuality
-
+  
   public export
   data ResizeQuality = Pixelated | Low | Medium | High
-
-  public export
+  
+  export
   Show ResizeQuality where
     show Pixelated = "pixelated"
     show Low = "low"
     show Medium = "medium"
     show High = "high"
-
-  public export
+  
+  export
   Eq ResizeQuality where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ResizeQuality where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ResizeQuality
   read "pixelated" = Just Pixelated
   read "low" = Just Low
   read "medium" = Just Medium
   read "high" = Just High
   read _ = Nothing
-
+  
   export
   ToFFI ResizeQuality String where
     toFFI = show
-
+  
   export
   FromFFI ResizeQuality String where
     fromFFI = read
 
 
 namespace CanvasFillRule
-
+  
   public export
   data CanvasFillRule = Nonzero | Evenodd
-
-  public export
+  
+  export
   Show CanvasFillRule where
     show Nonzero = "nonzero"
     show Evenodd = "evenodd"
-
-  public export
+  
+  export
   Eq CanvasFillRule where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasFillRule where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasFillRule
   read "nonzero" = Just Nonzero
   read "evenodd" = Just Evenodd
   read _ = Nothing
-
+  
   export
   ToFFI CanvasFillRule String where
     toFFI = show
-
+  
   export
   FromFFI CanvasFillRule String where
     fromFFI = read
 
 
 namespace ImageSmoothingQuality
-
+  
   public export
   data ImageSmoothingQuality = Low | Medium | High
-
-  public export
+  
+  export
   Show ImageSmoothingQuality where
     show Low = "low"
     show Medium = "medium"
     show High = "high"
-
-  public export
+  
+  export
   Eq ImageSmoothingQuality where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ImageSmoothingQuality where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ImageSmoothingQuality
   read "low" = Just Low
   read "medium" = Just Medium
   read "high" = Just High
   read _ = Nothing
-
+  
   export
   ToFFI ImageSmoothingQuality String where
     toFFI = show
-
+  
   export
   FromFFI ImageSmoothingQuality String where
     fromFFI = read
 
 
 namespace CanvasLineCap
-
+  
   public export
   data CanvasLineCap = Butt | Round | Square
-
-  public export
+  
+  export
   Show CanvasLineCap where
     show Butt = "butt"
     show Round = "round"
     show Square = "square"
-
-  public export
+  
+  export
   Eq CanvasLineCap where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasLineCap where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasLineCap
   read "butt" = Just Butt
   read "round" = Just Round
   read "square" = Just Square
   read _ = Nothing
-
+  
   export
   ToFFI CanvasLineCap String where
     toFFI = show
-
+  
   export
   FromFFI CanvasLineCap String where
     fromFFI = read
 
 
 namespace CanvasLineJoin
-
+  
   public export
   data CanvasLineJoin = Round | Bevel | Miter
-
-  public export
+  
+  export
   Show CanvasLineJoin where
     show Round = "round"
     show Bevel = "bevel"
     show Miter = "miter"
-
-  public export
+  
+  export
   Eq CanvasLineJoin where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasLineJoin where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasLineJoin
   read "round" = Just Round
   read "bevel" = Just Bevel
   read "miter" = Just Miter
   read _ = Nothing
-
+  
   export
   ToFFI CanvasLineJoin String where
     toFFI = show
-
+  
   export
   FromFFI CanvasLineJoin String where
     fromFFI = read
 
 
 namespace CanvasTextAlign
-
+  
   public export
   data CanvasTextAlign = Start | End | Left | Right | Center
-
-  public export
+  
+  export
   Show CanvasTextAlign where
     show Start = "start"
     show End = "end"
     show Left = "left"
     show Right = "right"
     show Center = "center"
-
-  public export
+  
+  export
   Eq CanvasTextAlign where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasTextAlign where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasTextAlign
   read "start" = Just Start
   read "end" = Just End
@@ -461,18 +461,18 @@ namespace CanvasTextAlign
   read "right" = Just Right
   read "center" = Just Center
   read _ = Nothing
-
+  
   export
   ToFFI CanvasTextAlign String where
     toFFI = show
-
+  
   export
   FromFFI CanvasTextAlign String where
     fromFFI = read
 
 
 namespace CanvasTextBaseline
-
+  
   public export
   data CanvasTextBaseline =
       Top
@@ -481,8 +481,8 @@ namespace CanvasTextBaseline
     | Alphabetic
     | Ideographic
     | Bottom
-
-  public export
+  
+  export
   Show CanvasTextBaseline where
     show Top = "top"
     show Hanging = "hanging"
@@ -490,16 +490,16 @@ namespace CanvasTextBaseline
     show Alphabetic = "alphabetic"
     show Ideographic = "ideographic"
     show Bottom = "bottom"
-
-  public export
+  
+  export
   Eq CanvasTextBaseline where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasTextBaseline where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasTextBaseline
   read "top" = Just Top
   read "hanging" = Just Hanging
@@ -508,145 +508,145 @@ namespace CanvasTextBaseline
   read "ideographic" = Just Ideographic
   read "bottom" = Just Bottom
   read _ = Nothing
-
+  
   export
   ToFFI CanvasTextBaseline String where
     toFFI = show
-
+  
   export
   FromFFI CanvasTextBaseline String where
     fromFFI = read
 
 
 namespace CanvasDirection
-
+  
   public export
   data CanvasDirection = Ltr | Rtl | Inherit
-
-  public export
+  
+  export
   Show CanvasDirection where
     show Ltr = "ltr"
     show Rtl = "rtl"
     show Inherit = "inherit"
-
-  public export
+  
+  export
   Eq CanvasDirection where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord CanvasDirection where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe CanvasDirection
   read "ltr" = Just Ltr
   read "rtl" = Just Rtl
   read "inherit" = Just Inherit
   read _ = Nothing
-
+  
   export
   ToFFI CanvasDirection String where
     toFFI = show
-
+  
   export
   FromFFI CanvasDirection String where
     fromFFI = read
 
 
 namespace OffscreenRenderingContextId
-
+  
   public export
   data OffscreenRenderingContextId = TwoD | Bitmaprenderer | Webgl | Webgl2
-
-  public export
+  
+  export
   Show OffscreenRenderingContextId where
     show TwoD = "2d"
     show Bitmaprenderer = "bitmaprenderer"
     show Webgl = "webgl"
     show Webgl2 = "webgl2"
-
-  public export
+  
+  export
   Eq OffscreenRenderingContextId where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord OffscreenRenderingContextId where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe OffscreenRenderingContextId
   read "2d" = Just TwoD
   read "bitmaprenderer" = Just Bitmaprenderer
   read "webgl" = Just Webgl
   read "webgl2" = Just Webgl2
   read _ = Nothing
-
+  
   export
   ToFFI OffscreenRenderingContextId String where
     toFFI = show
-
+  
   export
   FromFFI OffscreenRenderingContextId String where
     fromFFI = read
 
 
 namespace TextTrackMode
-
+  
   public export
   data TextTrackMode = Disabled | Hidden | Showing
-
-  public export
+  
+  export
   Show TextTrackMode where
     show Disabled = "disabled"
     show Hidden = "hidden"
     show Showing = "showing"
-
-  public export
+  
+  export
   Eq TextTrackMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord TextTrackMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe TextTrackMode
   read "disabled" = Just Disabled
   read "hidden" = Just Hidden
   read "showing" = Just Showing
   read _ = Nothing
-
+  
   export
   ToFFI TextTrackMode String where
     toFFI = show
-
+  
   export
   FromFFI TextTrackMode String where
     fromFFI = read
 
 
 namespace TextTrackKind
-
+  
   public export
   data TextTrackKind = Subtitles | Captions | Descriptions | Chapters | Metadata
-
-  public export
+  
+  export
   Show TextTrackKind where
     show Subtitles = "subtitles"
     show Captions = "captions"
     show Descriptions = "descriptions"
     show Chapters = "chapters"
     show Metadata = "metadata"
-
-  public export
+  
+  export
   Eq TextTrackKind where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord TextTrackKind where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe TextTrackKind
   read "subtitles" = Just Subtitles
   read "captions" = Just Captions
@@ -654,114 +654,114 @@ namespace TextTrackKind
   read "chapters" = Just Chapters
   read "metadata" = Just Metadata
   read _ = Nothing
-
+  
   export
   ToFFI TextTrackKind String where
     toFFI = show
-
+  
   export
   FromFFI TextTrackKind String where
     fromFFI = read
 
 
 namespace BinaryType
-
+  
   public export
   data BinaryType = Blob | Arraybuffer
-
-  public export
+  
+  export
   Show BinaryType where
     show Blob = "blob"
     show Arraybuffer = "arraybuffer"
-
-  public export
+  
+  export
   Eq BinaryType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord BinaryType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe BinaryType
   read "blob" = Just Blob
   read "arraybuffer" = Just Arraybuffer
   read _ = Nothing
-
+  
   export
   ToFFI BinaryType String where
     toFFI = show
-
+  
   export
   FromFFI BinaryType String where
     fromFFI = read
 
 
 namespace WorkerType
-
+  
   public export
   data WorkerType = Classic | Module
-
-  public export
+  
+  export
   Show WorkerType where
     show Classic = "classic"
     show Module = "module"
-
-  public export
+  
+  export
   Eq WorkerType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord WorkerType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe WorkerType
   read "classic" = Just Classic
   read "module" = Just Module
   read _ = Nothing
-
+  
   export
   ToFFI WorkerType String where
     toFFI = show
-
+  
   export
   FromFFI WorkerType String where
     fromFFI = read
 
 
 namespace SelectionMode
-
+  
   public export
   data SelectionMode = Select | Start | End | Preserve
-
-  public export
+  
+  export
   Show SelectionMode where
     show Select = "select"
     show Start = "start"
     show End = "end"
     show Preserve = "preserve"
-
-  public export
+  
+  export
   Eq SelectionMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord SelectionMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe SelectionMode
   read "select" = Just Select
   read "start" = Just Start
   read "end" = Just End
   read "preserve" = Just Preserve
   read _ = Nothing
-
+  
   export
   ToFFI SelectionMode String where
     toFFI = show
-
+  
   export
   FromFFI SelectionMode String where
     fromFFI = read
@@ -3066,3 +3066,4 @@ ToFFI WheelEventHandler WheelEventHandler where toFFI = id
 
 export
 FromFFI WheelEventHandler WheelEventHandler where fromFFI = Just
+

--- a/src/Web/Internal/IndexedDBPrim.idr
+++ b/src/Web/Internal/IndexedDBPrim.idr
@@ -11,52 +11,52 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace IDBCursor
-
+  
   export
   %foreign "browser:lambda:x=>x.direction"
   prim__direction : IDBCursor -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.key"
   prim__key : IDBCursor -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.primaryKey"
   prim__primaryKey : IDBCursor -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.request"
   prim__request : IDBCursor -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source : IDBCursor -> PrimIO (Union2 IDBObjectStore IDBIndex)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.advance(a)"
   prim__advance : IDBCursor -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.continue(a)"
   prim__continue : IDBCursor -> UndefOr AnyPtr -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.continuePrimaryKey(a,b)"
   prim__continuePrimaryKey : IDBCursor -> AnyPtr -> AnyPtr -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.delete()"
   prim__delete : IDBCursor -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.update(a)"
   prim__update : IDBCursor -> AnyPtr -> PrimIO IDBRequest
@@ -64,7 +64,7 @@ namespace IDBCursor
 
 
 namespace IDBCursorWithValue
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : IDBCursorWithValue -> PrimIO AnyPtr
@@ -72,59 +72,59 @@ namespace IDBCursorWithValue
 
 
 namespace IDBDatabase
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : IDBDatabase -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.objectStoreNames"
   prim__objectStoreNames : IDBDatabase -> PrimIO DOMStringList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : IDBDatabase -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : IDBDatabase -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onclose"
   prim__onclose : IDBDatabase -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onclose = v}"
   prim__setOnclose : IDBDatabase -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : IDBDatabase -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : IDBDatabase -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onversionchange"
   prim__onversionchange : IDBDatabase -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onversionchange = v}"
   prim__setOnversionchange :
@@ -133,17 +133,17 @@ namespace IDBDatabase
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.version"
   prim__version : IDBDatabase -> PrimIO JSBits64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : IDBDatabase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.createObjectStore(a,b)"
   prim__createObjectStore :
@@ -152,12 +152,12 @@ namespace IDBDatabase
     -> UndefOr IDBObjectStoreParameters
     -> PrimIO IDBObjectStore
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteObjectStore(a)"
   prim__deleteObjectStore : IDBDatabase -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.transaction(a,b,c)"
   prim__transaction :
@@ -170,22 +170,22 @@ namespace IDBDatabase
 
 
 namespace IDBFactory
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.cmp(a,b)"
   prim__cmp : IDBFactory -> AnyPtr -> AnyPtr -> PrimIO Int16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.databases()"
   prim__databases : IDBFactory -> PrimIO (Promise (Array IDBDatabaseInfo))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteDatabase(a)"
   prim__deleteDatabase : IDBFactory -> String -> PrimIO IDBOpenDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.open(a,b)"
   prim__open :
@@ -197,44 +197,44 @@ namespace IDBFactory
 
 
 namespace IDBIndex
-
+  
   export
   %foreign "browser:lambda:x=>x.keyPath"
   prim__keyPath : IDBIndex -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.multiEntry"
   prim__multiEntry : IDBIndex -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : IDBIndex -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : IDBIndex -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.objectStore"
   prim__objectStore : IDBIndex -> PrimIO IDBObjectStore
 
-
+  
   export
   %foreign "browser:lambda:x=>x.unique"
   prim__unique : IDBIndex -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.count(a)"
   prim__count : IDBIndex -> UndefOr AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAll(a,b)"
   prim__getAll :
@@ -243,7 +243,7 @@ namespace IDBIndex
     -> UndefOr Bits32
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAllKeys(a,b)"
   prim__getAllKeys :
@@ -252,17 +252,17 @@ namespace IDBIndex
     -> UndefOr Bits32
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : IDBIndex -> AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getKey(a)"
   prim__getKey : IDBIndex -> AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.openCursor(a,b)"
   prim__openCursor :
@@ -271,7 +271,7 @@ namespace IDBIndex
     -> UndefOr String
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.openKeyCursor(a,b)"
   prim__openKeyCursor :
@@ -283,7 +283,7 @@ namespace IDBIndex
 
 
 namespace IDBKeyRange
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=>IDBKeyRange.bound(a,b,c,d)"
   prim__bound :
@@ -293,42 +293,42 @@ namespace IDBKeyRange
     -> UndefOr Boolean
     -> PrimIO IDBKeyRange
 
-
+  
   export
   %foreign "browser:lambda:(a,b)=>IDBKeyRange.lowerBound(a,b)"
   prim__lowerBound : AnyPtr -> UndefOr Boolean -> PrimIO IDBKeyRange
 
-
+  
   export
   %foreign "browser:lambda:(a)=>IDBKeyRange.only(a)"
   prim__only : AnyPtr -> PrimIO IDBKeyRange
 
-
+  
   export
   %foreign "browser:lambda:(a,b)=>IDBKeyRange.upperBound(a,b)"
   prim__upperBound : AnyPtr -> UndefOr Boolean -> PrimIO IDBKeyRange
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lower"
   prim__lower : IDBKeyRange -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lowerOpen"
   prim__lowerOpen : IDBKeyRange -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.upper"
   prim__upper : IDBKeyRange -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.upperOpen"
   prim__upperOpen : IDBKeyRange -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.includes(a)"
   prim__includes : IDBKeyRange -> AnyPtr -> PrimIO Boolean
@@ -336,54 +336,54 @@ namespace IDBKeyRange
 
 
 namespace IDBObjectStore
-
+  
   export
   %foreign "browser:lambda:x=>x.autoIncrement"
   prim__autoIncrement : IDBObjectStore -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.indexNames"
   prim__indexNames : IDBObjectStore -> PrimIO DOMStringList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keyPath"
   prim__keyPath : IDBObjectStore -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : IDBObjectStore -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : IDBObjectStore -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transaction"
   prim__transaction : IDBObjectStore -> PrimIO IDBTransaction
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.add(a,b)"
   prim__add : IDBObjectStore -> AnyPtr -> UndefOr AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : IDBObjectStore -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.count(a)"
   prim__count : IDBObjectStore -> UndefOr AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.createIndex(a,b,c)"
   prim__createIndex :
@@ -393,17 +393,17 @@ namespace IDBObjectStore
     -> UndefOr IDBIndexParameters
     -> PrimIO IDBIndex
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.delete(a)"
   prim__delete : IDBObjectStore -> AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteIndex(a)"
   prim__deleteIndex : IDBObjectStore -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAll(a,b)"
   prim__getAll :
@@ -412,7 +412,7 @@ namespace IDBObjectStore
     -> UndefOr Bits32
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAllKeys(a,b)"
   prim__getAllKeys :
@@ -421,22 +421,22 @@ namespace IDBObjectStore
     -> UndefOr Bits32
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : IDBObjectStore -> AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getKey(a)"
   prim__getKey : IDBObjectStore -> AnyPtr -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.index(a)"
   prim__index : IDBObjectStore -> String -> PrimIO IDBIndex
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.openCursor(a,b)"
   prim__openCursor :
@@ -445,7 +445,7 @@ namespace IDBObjectStore
     -> UndefOr String
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.openKeyCursor(a,b)"
   prim__openKeyCursor :
@@ -454,7 +454,7 @@ namespace IDBObjectStore
     -> UndefOr String
     -> PrimIO IDBRequest
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.put(a,b)"
   prim__put : IDBObjectStore -> AnyPtr -> UndefOr AnyPtr -> PrimIO IDBRequest
@@ -462,13 +462,13 @@ namespace IDBObjectStore
 
 
 namespace IDBOpenDBRequest
-
+  
   export
   %foreign "browser:lambda:x=>x.onblocked"
   prim__onblocked : IDBOpenDBRequest -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onblocked = v}"
   prim__setOnblocked :
@@ -477,7 +477,7 @@ namespace IDBOpenDBRequest
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onupgradeneeded"
   prim__onupgradeneeded :
@@ -485,7 +485,7 @@ namespace IDBOpenDBRequest
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onupgradeneeded = v}"
   prim__setOnupgradeneeded :
@@ -497,53 +497,53 @@ namespace IDBOpenDBRequest
 
 
 namespace IDBRequest
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : IDBRequest -> PrimIO (Nullable DOMException)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : IDBRequest -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : IDBRequest -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsuccess"
   prim__onsuccess : IDBRequest -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsuccess = v}"
   prim__setOnsuccess : IDBRequest -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : IDBRequest -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.result"
   prim__result : IDBRequest -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source :
        IDBRequest
     -> PrimIO (Nullable (Union3 IDBObjectStore IDBIndex IDBCursor))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transaction"
   prim__transaction : IDBRequest -> PrimIO (Nullable IDBTransaction)
@@ -551,50 +551,50 @@ namespace IDBRequest
 
 
 namespace IDBTransaction
-
+  
   export
   %foreign "browser:lambda:x=>x.db"
   prim__db : IDBTransaction -> PrimIO IDBDatabase
 
-
+  
   export
   %foreign "browser:lambda:x=>x.durability"
   prim__durability : IDBTransaction -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.error"
   prim__error : IDBTransaction -> PrimIO (Nullable DOMException)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : IDBTransaction -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.objectStoreNames"
   prim__objectStoreNames : IDBTransaction -> PrimIO DOMStringList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : IDBTransaction -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : IDBTransaction -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncomplete"
   prim__oncomplete : IDBTransaction -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncomplete = v}"
   prim__setOncomplete :
@@ -603,29 +603,29 @@ namespace IDBTransaction
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : IDBTransaction -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : IDBTransaction -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : IDBTransaction -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.commit()"
   prim__commit : IDBTransaction -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.objectStore(a)"
   prim__objectStore : IDBTransaction -> String -> PrimIO IDBObjectStore
@@ -633,7 +633,7 @@ namespace IDBTransaction
 
 
 namespace IDBVersionChangeEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new IDBVersionChangeEvent(a,b)"
   prim__new :
@@ -641,12 +641,12 @@ namespace IDBVersionChangeEvent
     -> UndefOr IDBVersionChangeEventInit
     -> PrimIO IDBVersionChangeEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newVersion"
   prim__newVersion : IDBVersionChangeEvent -> PrimIO (Nullable JSBits64)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldVersion"
   prim__oldVersion : IDBVersionChangeEvent -> PrimIO JSBits64
@@ -660,30 +660,30 @@ namespace IDBVersionChangeEvent
 --------------------------------------------------------------------------------
 
 namespace IDBDatabaseInfo
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({name: a,version: b})"
   prim__new : UndefOr String -> UndefOr JSBits64 -> PrimIO IDBDatabaseInfo
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : IDBDatabaseInfo -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : IDBDatabaseInfo -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.version"
   prim__version : IDBDatabaseInfo -> PrimIO (UndefOr JSBits64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.version = v}"
   prim__setVersion : IDBDatabaseInfo -> UndefOr JSBits64 -> PrimIO ()
@@ -692,30 +692,30 @@ namespace IDBDatabaseInfo
 
 
 namespace IDBIndexParameters
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({unique: a,multiEntry: b})"
   prim__new : UndefOr Boolean -> UndefOr Boolean -> PrimIO IDBIndexParameters
 
-
+  
   export
   %foreign "browser:lambda:x=>x.multiEntry"
   prim__multiEntry : IDBIndexParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.multiEntry = v}"
   prim__setMultiEntry : IDBIndexParameters -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.unique"
   prim__unique : IDBIndexParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.unique = v}"
   prim__setUnique : IDBIndexParameters -> UndefOr Boolean -> PrimIO ()
@@ -724,7 +724,7 @@ namespace IDBIndexParameters
 
 
 namespace IDBObjectStoreParameters
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({keyPath: a,autoIncrement: b})"
   prim__new :
@@ -732,13 +732,13 @@ namespace IDBObjectStoreParameters
     -> UndefOr Boolean
     -> PrimIO IDBObjectStoreParameters
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoIncrement"
   prim__autoIncrement : IDBObjectStoreParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoIncrement = v}"
   prim__setAutoIncrement :
@@ -747,7 +747,7 @@ namespace IDBObjectStoreParameters
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keyPath"
   prim__keyPath :
@@ -755,7 +755,7 @@ namespace IDBObjectStoreParameters
     -> PrimIO (UndefOr (Nullable (Union2 String (Array String))))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.keyPath = v}"
   prim__setKeyPath :
@@ -767,18 +767,18 @@ namespace IDBObjectStoreParameters
 
 
 namespace IDBTransactionOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({durability: a})"
   prim__new : UndefOr String -> PrimIO IDBTransactionOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.durability"
   prim__durability : IDBTransactionOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.durability = v}"
   prim__setDurability : IDBTransactionOptions -> UndefOr String -> PrimIO ()
@@ -787,7 +787,7 @@ namespace IDBTransactionOptions
 
 
 namespace IDBVersionChangeEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({oldVersion: a,newVersion: b})"
   prim__new :
@@ -795,7 +795,7 @@ namespace IDBVersionChangeEventInit
     -> UndefOr (Nullable JSBits64)
     -> PrimIO IDBVersionChangeEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.newVersion"
   prim__newVersion :
@@ -803,7 +803,7 @@ namespace IDBVersionChangeEventInit
     -> PrimIO (UndefOr (Nullable JSBits64))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.newVersion = v}"
   prim__setNewVersion :
@@ -812,16 +812,20 @@ namespace IDBVersionChangeEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oldVersion"
   prim__oldVersion : IDBVersionChangeEventInit -> PrimIO (UndefOr JSBits64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oldVersion = v}"
   prim__setOldVersion :
        IDBVersionChangeEventInit
     -> UndefOr JSBits64
     -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/IndexedDBTypes.idr
+++ b/src/Web/Internal/IndexedDBTypes.idr
@@ -10,140 +10,140 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace IDBRequestReadyState
-
+  
   public export
   data IDBRequestReadyState = Pending | Done
-
-  public export
+  
+  export
   Show IDBRequestReadyState where
     show Pending = "pending"
     show Done = "done"
-
-  public export
+  
+  export
   Eq IDBRequestReadyState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord IDBRequestReadyState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe IDBRequestReadyState
   read "pending" = Just Pending
   read "done" = Just Done
   read _ = Nothing
-
+  
   export
   ToFFI IDBRequestReadyState String where
     toFFI = show
-
+  
   export
   FromFFI IDBRequestReadyState String where
     fromFFI = read
 
 
 namespace IDBTransactionDurability
-
+  
   public export
   data IDBTransactionDurability = Default | Strict | Relaxed
-
-  public export
+  
+  export
   Show IDBTransactionDurability where
     show Default = "default"
     show Strict = "strict"
     show Relaxed = "relaxed"
-
-  public export
+  
+  export
   Eq IDBTransactionDurability where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord IDBTransactionDurability where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe IDBTransactionDurability
   read "default" = Just Default
   read "strict" = Just Strict
   read "relaxed" = Just Relaxed
   read _ = Nothing
-
+  
   export
   ToFFI IDBTransactionDurability String where
     toFFI = show
-
+  
   export
   FromFFI IDBTransactionDurability String where
     fromFFI = read
 
 
 namespace IDBCursorDirection
-
+  
   public export
   data IDBCursorDirection = Next | Nextunique | Prev | Prevunique
-
-  public export
+  
+  export
   Show IDBCursorDirection where
     show Next = "next"
     show Nextunique = "nextunique"
     show Prev = "prev"
     show Prevunique = "prevunique"
-
-  public export
+  
+  export
   Eq IDBCursorDirection where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord IDBCursorDirection where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe IDBCursorDirection
   read "next" = Just Next
   read "nextunique" = Just Nextunique
   read "prev" = Just Prev
   read "prevunique" = Just Prevunique
   read _ = Nothing
-
+  
   export
   ToFFI IDBCursorDirection String where
     toFFI = show
-
+  
   export
   FromFFI IDBCursorDirection String where
     fromFFI = read
 
 
 namespace IDBTransactionMode
-
+  
   public export
   data IDBTransactionMode = Readonly | Readwrite | Versionchange
-
-  public export
+  
+  export
   Show IDBTransactionMode where
     show Readonly = "readonly"
     show Readwrite = "readwrite"
     show Versionchange = "versionchange"
-
-  public export
+  
+  export
   Eq IDBTransactionMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord IDBTransactionMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe IDBTransactionMode
   read "readonly" = Just Readonly
   read "readwrite" = Just Readwrite
   read "versionchange" = Just Versionchange
   read _ = Nothing
-
+  
   export
   ToFFI IDBTransactionMode String where
     toFFI = show
-
+  
   export
   FromFFI IDBTransactionMode String where
     fromFFI = read
@@ -330,3 +330,6 @@ ToFFI IDBVersionChangeEventInit IDBVersionChangeEventInit where toFFI = id
 
 export
 FromFFI IDBVersionChangeEventInit IDBVersionChangeEventInit where fromFFI = Just
+
+
+

--- a/src/Web/Internal/MediasourcePrim.idr
+++ b/src/Web/Internal/MediasourcePrim.idr
@@ -11,40 +11,40 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace MediaSource
-
+  
   export
   %foreign "browser:lambda:()=> new MediaSource()"
   prim__new : PrimIO MediaSource
 
-
+  
   export
   %foreign "browser:lambda:(a)=>MediaSource.isTypeSupported(a)"
   prim__isTypeSupported : String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.activeSourceBuffers"
   prim__activeSourceBuffers : MediaSource -> PrimIO SourceBufferList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.duration"
   prim__duration : MediaSource -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.duration = v}"
   prim__setDuration : MediaSource -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsourceclose"
   prim__onsourceclose : MediaSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsourceclose = v}"
   prim__setOnsourceclose :
@@ -53,13 +53,13 @@ namespace MediaSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsourceended"
   prim__onsourceended : MediaSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsourceended = v}"
   prim__setOnsourceended :
@@ -68,13 +68,13 @@ namespace MediaSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onsourceopen"
   prim__onsourceopen : MediaSource -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onsourceopen = v}"
   prim__setOnsourceopen :
@@ -83,37 +83,37 @@ namespace MediaSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : MediaSource -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sourceBuffers"
   prim__sourceBuffers : MediaSource -> PrimIO SourceBufferList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.addSourceBuffer(a)"
   prim__addSourceBuffer : MediaSource -> String -> PrimIO SourceBuffer
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clearLiveSeekableRange()"
   prim__clearLiveSeekableRange : MediaSource -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.endOfStream(a)"
   prim__endOfStream : MediaSource -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeSourceBuffer(a)"
   prim__removeSourceBuffer : MediaSource -> SourceBuffer -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setLiveSeekableRange(a,b)"
   prim__setLiveSeekableRange : MediaSource -> Double -> Double -> PrimIO ()
@@ -121,95 +121,95 @@ namespace MediaSource
 
 
 namespace SourceBuffer
-
+  
   export
   %foreign "browser:lambda:x=>x.appendWindowEnd"
   prim__appendWindowEnd : SourceBuffer -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.appendWindowEnd = v}"
   prim__setAppendWindowEnd : SourceBuffer -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.appendWindowStart"
   prim__appendWindowStart : SourceBuffer -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.appendWindowStart = v}"
   prim__setAppendWindowStart : SourceBuffer -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.audioTracks"
   prim__audioTracks : SourceBuffer -> PrimIO AudioTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.buffered"
   prim__buffered : SourceBuffer -> PrimIO TimeRanges
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : SourceBuffer -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mode = v}"
   prim__setMode : SourceBuffer -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort : SourceBuffer -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort : SourceBuffer -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror : SourceBuffer -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror : SourceBuffer -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onupdate"
   prim__onupdate : SourceBuffer -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onupdate = v}"
   prim__setOnupdate : SourceBuffer -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onupdateend"
   prim__onupdateend : SourceBuffer -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onupdateend = v}"
   prim__setOnupdateend :
@@ -218,13 +218,13 @@ namespace SourceBuffer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onupdatestart"
   prim__onupdatestart : SourceBuffer -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onupdatestart = v}"
   prim__setOnupdatestart :
@@ -233,39 +233,39 @@ namespace SourceBuffer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textTracks"
   prim__textTracks : SourceBuffer -> PrimIO TextTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timestampOffset"
   prim__timestampOffset : SourceBuffer -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.timestampOffset = v}"
   prim__setTimestampOffset : SourceBuffer -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.updating"
   prim__updating : SourceBuffer -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.videoTracks"
   prim__videoTracks : SourceBuffer -> PrimIO VideoTrackList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : SourceBuffer -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendBuffer(a)"
   prim__appendBuffer :
@@ -284,7 +284,7 @@ namespace SourceBuffer
          ArrayBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.remove(a,b)"
   prim__remove : SourceBuffer -> Double -> Double -> PrimIO ()
@@ -292,17 +292,17 @@ namespace SourceBuffer
 
 
 namespace SourceBufferList
-
+  
   export
   %foreign "browser:lambda:(o,x)=>o[x]"
   prim__get : SourceBufferList -> Bits32 -> PrimIO SourceBuffer
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SourceBufferList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onaddsourcebuffer"
   prim__onaddsourcebuffer :
@@ -310,7 +310,7 @@ namespace SourceBufferList
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onaddsourcebuffer = v}"
   prim__setOnaddsourcebuffer :
@@ -319,7 +319,7 @@ namespace SourceBufferList
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onremovesourcebuffer"
   prim__onremovesourcebuffer :
@@ -327,10 +327,16 @@ namespace SourceBufferList
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onremovesourcebuffer = v}"
   prim__setOnremovesourcebuffer :
        SourceBufferList
     -> Nullable EventHandlerNonNull
     -> PrimIO ()
+
+
+
+
+
+

--- a/src/Web/Internal/MediasourceTypes.idr
+++ b/src/Web/Internal/MediasourceTypes.idr
@@ -10,101 +10,101 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace ReadyState
-
+  
   public export
   data ReadyState = Closed | Open | Ended
-
-  public export
+  
+  export
   Show ReadyState where
     show Closed = "closed"
     show Open = "open"
     show Ended = "ended"
-
-  public export
+  
+  export
   Eq ReadyState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ReadyState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ReadyState
   read "closed" = Just Closed
   read "open" = Just Open
   read "ended" = Just Ended
   read _ = Nothing
-
+  
   export
   ToFFI ReadyState String where
     toFFI = show
-
+  
   export
   FromFFI ReadyState String where
     fromFFI = read
 
 
 namespace EndOfStreamError
-
+  
   public export
   data EndOfStreamError = Network | Decode
-
-  public export
+  
+  export
   Show EndOfStreamError where
     show Network = "network"
     show Decode = "decode"
-
-  public export
+  
+  export
   Eq EndOfStreamError where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord EndOfStreamError where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe EndOfStreamError
   read "network" = Just Network
   read "decode" = Just Decode
   read _ = Nothing
-
+  
   export
   ToFFI EndOfStreamError String where
     toFFI = show
-
+  
   export
   FromFFI EndOfStreamError String where
     fromFFI = read
 
 
 namespace AppendMode
-
+  
   public export
   data AppendMode = Segments | Sequence
-
-  public export
+  
+  export
   Show AppendMode where
     show Segments = "segments"
     show Sequence = "sequence"
-
-  public export
+  
+  export
   Eq AppendMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord AppendMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe AppendMode
   read "segments" = Just Segments
   read "sequence" = Just Sequence
   read _ = Nothing
-
+  
   export
   ToFFI AppendMode String where
     toFFI = show
-
+  
   export
   FromFFI AppendMode String where
     fromFFI = read
@@ -150,3 +150,7 @@ FromFFI SourceBufferList SourceBufferList where fromFFI = Just
 export
 SafeCast SourceBufferList where
   safeCast = unsafeCastOnPrototypeName "SourceBufferList"
+
+
+
+

--- a/src/Web/Internal/MediastreamPrim.idr
+++ b/src/Web/Internal/MediastreamPrim.idr
@@ -11,7 +11,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace ConstrainablePattern
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.applyConstraints(a)"
   prim__applyConstraints :
@@ -19,17 +19,17 @@ namespace ConstrainablePattern
     -> UndefOr Constraints
     -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getCapabilities()"
   prim__getCapabilities : ConstrainablePattern -> PrimIO Capabilities
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getConstraints()"
   prim__getConstraints : ConstrainablePattern -> PrimIO Constraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSettings()"
   prim__getSettings : ConstrainablePattern -> PrimIO Settings
@@ -37,7 +37,7 @@ namespace ConstrainablePattern
 
 
 namespace InputDeviceInfo
-
+  
   export
   %foreign "browser:lambda:x=>x.getCapabilities()"
   prim__getCapabilities : InputDeviceInfo -> PrimIO MediaTrackCapabilities
@@ -45,27 +45,27 @@ namespace InputDeviceInfo
 
 
 namespace MediaDeviceInfo
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId : MediaDeviceInfo -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.groupId"
   prim__groupId : MediaDeviceInfo -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : MediaDeviceInfo -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : MediaDeviceInfo -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : MediaDeviceInfo -> PrimIO Object
@@ -73,13 +73,13 @@ namespace MediaDeviceInfo
 
 
 namespace MediaDevices
-
+  
   export
   %foreign "browser:lambda:x=>x.ondevicechange"
   prim__ondevicechange : MediaDevices -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ondevicechange = v}"
   prim__setOndevicechange :
@@ -88,21 +88,21 @@ namespace MediaDevices
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enumerateDevices()"
   prim__enumerateDevices :
        MediaDevices
     -> PrimIO (Promise (Array MediaDeviceInfo))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSupportedConstraints()"
   prim__getSupportedConstraints :
        MediaDevices
     -> PrimIO MediaTrackSupportedConstraints
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getUserMedia(a)"
   prim__getUserMedia :
@@ -113,50 +113,50 @@ namespace MediaDevices
 
 
 namespace MediaStream
-
+  
   export
   %foreign "browser:lambda:()=> new MediaStream()"
   prim__new : PrimIO MediaStream
 
-
+  
   export
   %foreign "browser:lambda:(a)=> new MediaStream(a)"
   prim__new1 : MediaStream -> PrimIO MediaStream
 
-
+  
   export
   %foreign "browser:lambda:(a)=> new MediaStream(a)"
   prim__new2 : Array MediaStreamTrack -> PrimIO MediaStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.active"
   prim__active : MediaStream -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : MediaStream -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onaddtrack"
   prim__onaddtrack : MediaStream -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onaddtrack = v}"
   prim__setOnaddtrack : MediaStream -> Nullable EventHandlerNonNull -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onremovetrack"
   prim__onremovetrack : MediaStream -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onremovetrack = v}"
   prim__setOnremovetrack :
@@ -165,22 +165,22 @@ namespace MediaStream
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.addTrack(a)"
   prim__addTrack : MediaStream -> MediaStreamTrack -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clone()"
   prim__clone : MediaStream -> PrimIO MediaStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAudioTracks()"
   prim__getAudioTracks : MediaStream -> PrimIO (Array MediaStreamTrack)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getTrackById(a)"
   prim__getTrackById :
@@ -188,17 +188,17 @@ namespace MediaStream
     -> String
     -> PrimIO (Nullable MediaStreamTrack)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getTracks()"
   prim__getTracks : MediaStream -> PrimIO (Array MediaStreamTrack)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getVideoTracks()"
   prim__getVideoTracks : MediaStream -> PrimIO (Array MediaStreamTrack)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeTrack(a)"
   prim__removeTrack : MediaStream -> MediaStreamTrack -> PrimIO ()
@@ -206,45 +206,45 @@ namespace MediaStream
 
 
 namespace MediaStreamTrack
-
+  
   export
   %foreign "browser:lambda:x=>x.enabled"
   prim__enabled : MediaStreamTrack -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.enabled = v}"
   prim__setEnabled : MediaStreamTrack -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : MediaStreamTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.kind"
   prim__kind : MediaStreamTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.label"
   prim__label : MediaStreamTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.muted"
   prim__muted : MediaStreamTrack -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onended"
   prim__onended : MediaStreamTrack -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onended = v}"
   prim__setOnended :
@@ -253,13 +253,13 @@ namespace MediaStreamTrack
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmute"
   prim__onmute : MediaStreamTrack -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmute = v}"
   prim__setOnmute :
@@ -268,13 +268,13 @@ namespace MediaStreamTrack
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onunmute"
   prim__onunmute : MediaStreamTrack -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onunmute = v}"
   prim__setOnunmute :
@@ -283,12 +283,12 @@ namespace MediaStreamTrack
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : MediaStreamTrack -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.applyConstraints(a)"
   prim__applyConstraints :
@@ -296,27 +296,27 @@ namespace MediaStreamTrack
     -> UndefOr MediaTrackConstraints
     -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clone()"
   prim__clone : MediaStreamTrack -> PrimIO MediaStreamTrack
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getCapabilities()"
   prim__getCapabilities : MediaStreamTrack -> PrimIO MediaTrackCapabilities
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getConstraints()"
   prim__getConstraints : MediaStreamTrack -> PrimIO MediaTrackConstraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSettings()"
   prim__getSettings : MediaStreamTrack -> PrimIO MediaTrackSettings
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stop()"
   prim__stop : MediaStreamTrack -> PrimIO ()
@@ -324,7 +324,7 @@ namespace MediaStreamTrack
 
 
 namespace MediaStreamTrackEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new MediaStreamTrackEvent(a,b)"
   prim__new :
@@ -332,7 +332,7 @@ namespace MediaStreamTrackEvent
     -> MediaStreamTrackEventInit
     -> PrimIO MediaStreamTrackEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track : MediaStreamTrackEvent -> PrimIO MediaStreamTrack
@@ -340,12 +340,12 @@ namespace MediaStreamTrackEvent
 
 
 namespace OverconstrainedError
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new OverconstrainedError(a,b)"
   prim__new : String -> UndefOr String -> PrimIO OverconstrainedError
 
-
+  
   export
   %foreign "browser:lambda:x=>x.constraint"
   prim__constraint : OverconstrainedError -> PrimIO String
@@ -359,7 +359,7 @@ namespace OverconstrainedError
 --------------------------------------------------------------------------------
 
 namespace Capabilities
-
+  
   export
   %foreign "browser:lambda:()=> ({})"
   prim__new : PrimIO Capabilities
@@ -367,7 +367,7 @@ namespace Capabilities
 
 
 namespace ConstrainBooleanParameters
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({exact: a,ideal: b})"
   prim__new :
@@ -375,25 +375,25 @@ namespace ConstrainBooleanParameters
     -> UndefOr Boolean
     -> PrimIO ConstrainBooleanParameters
 
-
+  
   export
   %foreign "browser:lambda:x=>x.exact"
   prim__exact : ConstrainBooleanParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.exact = v}"
   prim__setExact : ConstrainBooleanParameters -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ideal"
   prim__ideal : ConstrainBooleanParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ideal = v}"
   prim__setIdeal : ConstrainBooleanParameters -> UndefOr Boolean -> PrimIO ()
@@ -402,7 +402,7 @@ namespace ConstrainBooleanParameters
 
 
 namespace ConstrainDOMStringParameters
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({exact: a,ideal: b})"
   prim__new :
@@ -410,7 +410,7 @@ namespace ConstrainDOMStringParameters
     -> UndefOr (Union2 String (Array String))
     -> PrimIO ConstrainDOMStringParameters
 
-
+  
   export
   %foreign "browser:lambda:x=>x.exact"
   prim__exact :
@@ -418,7 +418,7 @@ namespace ConstrainDOMStringParameters
     -> PrimIO (UndefOr (Union2 String (Array String)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.exact = v}"
   prim__setExact :
@@ -427,7 +427,7 @@ namespace ConstrainDOMStringParameters
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ideal"
   prim__ideal :
@@ -435,7 +435,7 @@ namespace ConstrainDOMStringParameters
     -> PrimIO (UndefOr (Union2 String (Array String)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ideal = v}"
   prim__setIdeal :
@@ -447,30 +447,30 @@ namespace ConstrainDOMStringParameters
 
 
 namespace ConstrainDoubleRange
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({exact: a,ideal: b})"
   prim__new : UndefOr Double -> UndefOr Double -> PrimIO ConstrainDoubleRange
 
-
+  
   export
   %foreign "browser:lambda:x=>x.exact"
   prim__exact : ConstrainDoubleRange -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.exact = v}"
   prim__setExact : ConstrainDoubleRange -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ideal"
   prim__ideal : ConstrainDoubleRange -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ideal = v}"
   prim__setIdeal : ConstrainDoubleRange -> UndefOr Double -> PrimIO ()
@@ -479,30 +479,30 @@ namespace ConstrainDoubleRange
 
 
 namespace ConstrainULongRange
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({exact: a,ideal: b})"
   prim__new : UndefOr Bits32 -> UndefOr Bits32 -> PrimIO ConstrainULongRange
 
-
+  
   export
   %foreign "browser:lambda:x=>x.exact"
   prim__exact : ConstrainULongRange -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.exact = v}"
   prim__setExact : ConstrainULongRange -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ideal"
   prim__ideal : ConstrainULongRange -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ideal = v}"
   prim__setIdeal : ConstrainULongRange -> UndefOr Bits32 -> PrimIO ()
@@ -511,7 +511,7 @@ namespace ConstrainULongRange
 
 
 namespace ConstraintSet
-
+  
   export
   %foreign "browser:lambda:()=> ({})"
   prim__new : PrimIO ConstraintSet
@@ -519,18 +519,18 @@ namespace ConstraintSet
 
 
 namespace Constraints
-
+  
   export
   %foreign "browser:lambda:(a)=> ({advanced: a})"
   prim__new : UndefOr (Array ConstraintSet) -> PrimIO Constraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.advanced"
   prim__advanced : Constraints -> PrimIO (UndefOr (Array ConstraintSet))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.advanced = v}"
   prim__setAdvanced : Constraints -> UndefOr (Array ConstraintSet) -> PrimIO ()
@@ -539,30 +539,30 @@ namespace Constraints
 
 
 namespace DoubleRange
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({max: a,min: b})"
   prim__new : UndefOr Double -> UndefOr Double -> PrimIO DoubleRange
 
-
+  
   export
   %foreign "browser:lambda:x=>x.max"
   prim__max : DoubleRange -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.max = v}"
   prim__setMax : DoubleRange -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.min"
   prim__min : DoubleRange -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.min = v}"
   prim__setMin : DoubleRange -> UndefOr Double -> PrimIO ()
@@ -571,7 +571,7 @@ namespace DoubleRange
 
 
 namespace MediaStreamConstraints
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({video: a,audio: b})"
   prim__new :
@@ -579,7 +579,7 @@ namespace MediaStreamConstraints
     -> UndefOr (Union2 Boolean MediaTrackConstraints)
     -> PrimIO MediaStreamConstraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.audio"
   prim__audio :
@@ -587,7 +587,7 @@ namespace MediaStreamConstraints
     -> PrimIO (UndefOr (Union2 Boolean MediaTrackConstraints))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.audio = v}"
   prim__setAudio :
@@ -596,7 +596,7 @@ namespace MediaStreamConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.video"
   prim__video :
@@ -604,7 +604,7 @@ namespace MediaStreamConstraints
     -> PrimIO (UndefOr (Union2 Boolean MediaTrackConstraints))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.video = v}"
   prim__setVideo :
@@ -616,18 +616,18 @@ namespace MediaStreamConstraints
 
 
 namespace MediaStreamTrackEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({track: a})"
   prim__new : MediaStreamTrack -> PrimIO MediaStreamTrackEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.track"
   prim__track : MediaStreamTrackEventInit -> PrimIO MediaStreamTrack
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.track = v}"
   prim__setTrack : MediaStreamTrackEventInit -> MediaStreamTrack -> PrimIO ()
@@ -636,7 +636,7 @@ namespace MediaStreamTrackEventInit
 
 
 namespace MediaTrackCapabilities
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)=> ({width: a,height: b,aspectRatio: c,frameRate: d,facingMode: e,resizeMode: f,sampleRate: g,sampleSize: h,echoCancellation: i,autoGainControl: j,noiseSuppression: k,latency: l,channelCount: m,deviceId: n,groupId: o})"
   prim__new :
@@ -657,13 +657,13 @@ namespace MediaTrackCapabilities
     -> UndefOr String
     -> PrimIO MediaTrackCapabilities
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aspectRatio"
   prim__aspectRatio : MediaTrackCapabilities -> PrimIO (UndefOr DoubleRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.aspectRatio = v}"
   prim__setAspectRatio :
@@ -672,7 +672,7 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoGainControl"
   prim__autoGainControl :
@@ -680,7 +680,7 @@ namespace MediaTrackCapabilities
     -> PrimIO (UndefOr (Array Boolean))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoGainControl = v}"
   prim__setAutoGainControl :
@@ -689,13 +689,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.channelCount"
   prim__channelCount : MediaTrackCapabilities -> PrimIO (UndefOr ULongRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.channelCount = v}"
   prim__setChannelCount :
@@ -704,19 +704,19 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId : MediaTrackCapabilities -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deviceId = v}"
   prim__setDeviceId : MediaTrackCapabilities -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.echoCancellation"
   prim__echoCancellation :
@@ -724,7 +724,7 @@ namespace MediaTrackCapabilities
     -> PrimIO (UndefOr (Array Boolean))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.echoCancellation = v}"
   prim__setEchoCancellation :
@@ -733,13 +733,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.facingMode"
   prim__facingMode : MediaTrackCapabilities -> PrimIO (UndefOr (Array String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.facingMode = v}"
   prim__setFacingMode :
@@ -748,13 +748,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameRate"
   prim__frameRate : MediaTrackCapabilities -> PrimIO (UndefOr DoubleRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameRate = v}"
   prim__setFrameRate :
@@ -763,43 +763,43 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.groupId"
   prim__groupId : MediaTrackCapabilities -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.groupId = v}"
   prim__setGroupId : MediaTrackCapabilities -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : MediaTrackCapabilities -> PrimIO (UndefOr ULongRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : MediaTrackCapabilities -> UndefOr ULongRange -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.latency"
   prim__latency : MediaTrackCapabilities -> PrimIO (UndefOr DoubleRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.latency = v}"
   prim__setLatency : MediaTrackCapabilities -> UndefOr DoubleRange -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noiseSuppression"
   prim__noiseSuppression :
@@ -807,7 +807,7 @@ namespace MediaTrackCapabilities
     -> PrimIO (UndefOr (Array Boolean))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noiseSuppression = v}"
   prim__setNoiseSuppression :
@@ -816,13 +816,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeMode"
   prim__resizeMode : MediaTrackCapabilities -> PrimIO (UndefOr (Array String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeMode = v}"
   prim__setResizeMode :
@@ -831,13 +831,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleRate"
   prim__sampleRate : MediaTrackCapabilities -> PrimIO (UndefOr ULongRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleRate = v}"
   prim__setSampleRate :
@@ -846,13 +846,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleSize"
   prim__sampleSize : MediaTrackCapabilities -> PrimIO (UndefOr ULongRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleSize = v}"
   prim__setSampleSize :
@@ -861,13 +861,13 @@ namespace MediaTrackCapabilities
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : MediaTrackCapabilities -> PrimIO (UndefOr ULongRange)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : MediaTrackCapabilities -> UndefOr ULongRange -> PrimIO ()
@@ -876,7 +876,7 @@ namespace MediaTrackCapabilities
 
 
 namespace MediaTrackConstraintSet
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)=> ({width: a,height: b,aspectRatio: c,frameRate: d,facingMode: e,resizeMode: f,sampleRate: g,sampleSize: h,echoCancellation: i,autoGainControl: j,noiseSuppression: k,latency: l,channelCount: m,deviceId: n,groupId: o})"
   prim__new :
@@ -897,7 +897,7 @@ namespace MediaTrackConstraintSet
     -> UndefOr (Union3 String (Array String) ConstrainDOMStringParameters)
     -> PrimIO MediaTrackConstraintSet
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aspectRatio"
   prim__aspectRatio :
@@ -905,7 +905,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Double ConstrainDoubleRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.aspectRatio = v}"
   prim__setAspectRatio :
@@ -914,7 +914,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoGainControl"
   prim__autoGainControl :
@@ -922,7 +922,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Boolean ConstrainBooleanParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoGainControl = v}"
   prim__setAutoGainControl :
@@ -931,7 +931,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.channelCount"
   prim__channelCount :
@@ -939,7 +939,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Bits32 ConstrainULongRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.channelCount = v}"
   prim__setChannelCount :
@@ -948,7 +948,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId :
@@ -957,7 +957,7 @@ namespace MediaTrackConstraintSet
          (UndefOr (Union3 String (Array String) ConstrainDOMStringParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deviceId = v}"
   prim__setDeviceId :
@@ -966,7 +966,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.echoCancellation"
   prim__echoCancellation :
@@ -974,7 +974,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Boolean ConstrainBooleanParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.echoCancellation = v}"
   prim__setEchoCancellation :
@@ -983,7 +983,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.facingMode"
   prim__facingMode :
@@ -992,7 +992,7 @@ namespace MediaTrackConstraintSet
          (UndefOr (Union3 String (Array String) ConstrainDOMStringParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.facingMode = v}"
   prim__setFacingMode :
@@ -1001,7 +1001,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameRate"
   prim__frameRate :
@@ -1009,7 +1009,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Double ConstrainDoubleRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameRate = v}"
   prim__setFrameRate :
@@ -1018,7 +1018,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.groupId"
   prim__groupId :
@@ -1027,7 +1027,7 @@ namespace MediaTrackConstraintSet
          (UndefOr (Union3 String (Array String) ConstrainDOMStringParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.groupId = v}"
   prim__setGroupId :
@@ -1036,7 +1036,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height :
@@ -1044,7 +1044,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Bits32 ConstrainULongRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight :
@@ -1053,7 +1053,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.latency"
   prim__latency :
@@ -1061,7 +1061,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Double ConstrainDoubleRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.latency = v}"
   prim__setLatency :
@@ -1070,7 +1070,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noiseSuppression"
   prim__noiseSuppression :
@@ -1078,7 +1078,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Boolean ConstrainBooleanParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noiseSuppression = v}"
   prim__setNoiseSuppression :
@@ -1087,7 +1087,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeMode"
   prim__resizeMode :
@@ -1096,7 +1096,7 @@ namespace MediaTrackConstraintSet
          (UndefOr (Union3 String (Array String) ConstrainDOMStringParameters))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeMode = v}"
   prim__setResizeMode :
@@ -1105,7 +1105,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleRate"
   prim__sampleRate :
@@ -1113,7 +1113,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Bits32 ConstrainULongRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleRate = v}"
   prim__setSampleRate :
@@ -1122,7 +1122,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleSize"
   prim__sampleSize :
@@ -1130,7 +1130,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Bits32 ConstrainULongRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleSize = v}"
   prim__setSampleSize :
@@ -1139,7 +1139,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width :
@@ -1147,7 +1147,7 @@ namespace MediaTrackConstraintSet
     -> PrimIO (UndefOr (Union2 Bits32 ConstrainULongRange))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth :
@@ -1159,14 +1159,14 @@ namespace MediaTrackConstraintSet
 
 
 namespace MediaTrackConstraints
-
+  
   export
   %foreign "browser:lambda:(a)=> ({advanced: a})"
   prim__new :
        UndefOr (Array MediaTrackConstraintSet)
     -> PrimIO MediaTrackConstraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.advanced"
   prim__advanced :
@@ -1174,7 +1174,7 @@ namespace MediaTrackConstraints
     -> PrimIO (UndefOr (Array MediaTrackConstraintSet))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.advanced = v}"
   prim__setAdvanced :
@@ -1186,7 +1186,7 @@ namespace MediaTrackConstraints
 
 
 namespace MediaTrackSettings
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)=> ({width: a,height: b,aspectRatio: c,frameRate: d,facingMode: e,resizeMode: f,sampleRate: g,sampleSize: h,echoCancellation: i,autoGainControl: j,noiseSuppression: k,latency: l,channelCount: m,deviceId: n,groupId: o})"
   prim__new :
@@ -1207,181 +1207,181 @@ namespace MediaTrackSettings
     -> UndefOr String
     -> PrimIO MediaTrackSettings
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aspectRatio"
   prim__aspectRatio : MediaTrackSettings -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.aspectRatio = v}"
   prim__setAspectRatio : MediaTrackSettings -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoGainControl"
   prim__autoGainControl : MediaTrackSettings -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoGainControl = v}"
   prim__setAutoGainControl : MediaTrackSettings -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.channelCount"
   prim__channelCount : MediaTrackSettings -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.channelCount = v}"
   prim__setChannelCount : MediaTrackSettings -> UndefOr Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId : MediaTrackSettings -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deviceId = v}"
   prim__setDeviceId : MediaTrackSettings -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.echoCancellation"
   prim__echoCancellation : MediaTrackSettings -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.echoCancellation = v}"
   prim__setEchoCancellation : MediaTrackSettings -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.facingMode"
   prim__facingMode : MediaTrackSettings -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.facingMode = v}"
   prim__setFacingMode : MediaTrackSettings -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameRate"
   prim__frameRate : MediaTrackSettings -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameRate = v}"
   prim__setFrameRate : MediaTrackSettings -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.groupId"
   prim__groupId : MediaTrackSettings -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.groupId = v}"
   prim__setGroupId : MediaTrackSettings -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : MediaTrackSettings -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight : MediaTrackSettings -> UndefOr Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.latency"
   prim__latency : MediaTrackSettings -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.latency = v}"
   prim__setLatency : MediaTrackSettings -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noiseSuppression"
   prim__noiseSuppression : MediaTrackSettings -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noiseSuppression = v}"
   prim__setNoiseSuppression : MediaTrackSettings -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeMode"
   prim__resizeMode : MediaTrackSettings -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeMode = v}"
   prim__setResizeMode : MediaTrackSettings -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleRate"
   prim__sampleRate : MediaTrackSettings -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleRate = v}"
   prim__setSampleRate : MediaTrackSettings -> UndefOr Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleSize"
   prim__sampleSize : MediaTrackSettings -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleSize = v}"
   prim__setSampleSize : MediaTrackSettings -> UndefOr Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : MediaTrackSettings -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth : MediaTrackSettings -> UndefOr Int32 -> PrimIO ()
@@ -1390,7 +1390,7 @@ namespace MediaTrackSettings
 
 
 namespace MediaTrackSupportedConstraints
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)=> ({width: a,height: b,aspectRatio: c,frameRate: d,facingMode: e,resizeMode: f,sampleRate: g,sampleSize: h,echoCancellation: i,autoGainControl: j,noiseSuppression: k,latency: l,channelCount: m,deviceId: n,groupId: o})"
   prim__new :
@@ -1411,13 +1411,13 @@ namespace MediaTrackSupportedConstraints
     -> UndefOr Boolean
     -> PrimIO MediaTrackSupportedConstraints
 
-
+  
   export
   %foreign "browser:lambda:x=>x.aspectRatio"
   prim__aspectRatio : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.aspectRatio = v}"
   prim__setAspectRatio :
@@ -1426,7 +1426,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoGainControl"
   prim__autoGainControl :
@@ -1434,7 +1434,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoGainControl = v}"
   prim__setAutoGainControl :
@@ -1443,7 +1443,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.channelCount"
   prim__channelCount :
@@ -1451,7 +1451,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.channelCount = v}"
   prim__setChannelCount :
@@ -1460,13 +1460,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deviceId = v}"
   prim__setDeviceId :
@@ -1475,7 +1475,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.echoCancellation"
   prim__echoCancellation :
@@ -1483,7 +1483,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.echoCancellation = v}"
   prim__setEchoCancellation :
@@ -1492,13 +1492,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.facingMode"
   prim__facingMode : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.facingMode = v}"
   prim__setFacingMode :
@@ -1507,13 +1507,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.frameRate"
   prim__frameRate : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.frameRate = v}"
   prim__setFrameRate :
@@ -1522,13 +1522,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.groupId"
   prim__groupId : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.groupId = v}"
   prim__setGroupId :
@@ -1537,13 +1537,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.height = v}"
   prim__setHeight :
@@ -1552,13 +1552,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.latency"
   prim__latency : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.latency = v}"
   prim__setLatency :
@@ -1567,7 +1567,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.noiseSuppression"
   prim__noiseSuppression :
@@ -1575,7 +1575,7 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.noiseSuppression = v}"
   prim__setNoiseSuppression :
@@ -1584,13 +1584,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resizeMode"
   prim__resizeMode : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resizeMode = v}"
   prim__setResizeMode :
@@ -1599,13 +1599,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleRate"
   prim__sampleRate : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleRate = v}"
   prim__setSampleRate :
@@ -1614,13 +1614,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sampleSize"
   prim__sampleSize : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sampleSize = v}"
   prim__setSampleSize :
@@ -1629,13 +1629,13 @@ namespace MediaTrackSupportedConstraints
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : MediaTrackSupportedConstraints -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.width = v}"
   prim__setWidth :
@@ -1647,7 +1647,7 @@ namespace MediaTrackSupportedConstraints
 
 
 namespace Settings
-
+  
   export
   %foreign "browser:lambda:()=> ({})"
   prim__new : PrimIO Settings
@@ -1655,30 +1655,30 @@ namespace Settings
 
 
 namespace ULongRange
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({max: a,min: b})"
   prim__new : UndefOr Bits32 -> UndefOr Bits32 -> PrimIO ULongRange
 
-
+  
   export
   %foreign "browser:lambda:x=>x.max"
   prim__max : ULongRange -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.max = v}"
   prim__setMax : ULongRange -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.min"
   prim__min : ULongRange -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.min = v}"
   prim__setMin : ULongRange -> UndefOr Bits32 -> PrimIO ()
@@ -1692,7 +1692,7 @@ namespace ULongRange
 --------------------------------------------------------------------------------
 
 namespace NavigatorUserMediaErrorCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toNavigatorUserMediaErrorCallback :
@@ -1702,9 +1702,11 @@ namespace NavigatorUserMediaErrorCallback
 
 
 namespace NavigatorUserMediaSuccessCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toNavigatorUserMediaSuccessCallback :
        (MediaStream -> IO ())
     -> PrimIO NavigatorUserMediaSuccessCallback
+
+

--- a/src/Web/Internal/MediastreamTypes.idr
+++ b/src/Web/Internal/MediastreamTypes.idr
@@ -10,138 +10,138 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace MediaStreamTrackState
-
+  
   public export
   data MediaStreamTrackState = Live | Ended
-
-  public export
+  
+  export
   Show MediaStreamTrackState where
     show Live = "live"
     show Ended = "ended"
-
-  public export
+  
+  export
   Eq MediaStreamTrackState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord MediaStreamTrackState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe MediaStreamTrackState
   read "live" = Just Live
   read "ended" = Just Ended
   read _ = Nothing
-
+  
   export
   ToFFI MediaStreamTrackState String where
     toFFI = show
-
+  
   export
   FromFFI MediaStreamTrackState String where
     fromFFI = read
 
 
 namespace VideoFacingModeEnum
-
+  
   public export
   data VideoFacingModeEnum = User | Environment | Left | Right
-
-  public export
+  
+  export
   Show VideoFacingModeEnum where
     show User = "user"
     show Environment = "environment"
     show Left = "left"
     show Right = "right"
-
-  public export
+  
+  export
   Eq VideoFacingModeEnum where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord VideoFacingModeEnum where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe VideoFacingModeEnum
   read "user" = Just User
   read "environment" = Just Environment
   read "left" = Just Left
   read "right" = Just Right
   read _ = Nothing
-
+  
   export
   ToFFI VideoFacingModeEnum String where
     toFFI = show
-
+  
   export
   FromFFI VideoFacingModeEnum String where
     fromFFI = read
 
 
 namespace VideoResizeModeEnum
-
+  
   public export
   data VideoResizeModeEnum = None | CropAndScale
-
-  public export
+  
+  export
   Show VideoResizeModeEnum where
     show None = "none"
     show CropAndScale = "crop-and-scale"
-
-  public export
+  
+  export
   Eq VideoResizeModeEnum where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord VideoResizeModeEnum where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe VideoResizeModeEnum
   read "none" = Just None
   read "crop-and-scale" = Just CropAndScale
   read _ = Nothing
-
+  
   export
   ToFFI VideoResizeModeEnum String where
     toFFI = show
-
+  
   export
   FromFFI VideoResizeModeEnum String where
     fromFFI = read
 
 
 namespace MediaDeviceKind
-
+  
   public export
   data MediaDeviceKind = Audioinput | Audiooutput | Videoinput
-
-  public export
+  
+  export
   Show MediaDeviceKind where
     show Audioinput = "audioinput"
     show Audiooutput = "audiooutput"
     show Videoinput = "videoinput"
-
-  public export
+  
+  export
   Eq MediaDeviceKind where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord MediaDeviceKind where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe MediaDeviceKind
   read "audioinput" = Just Audioinput
   read "audiooutput" = Just Audiooutput
   read "videoinput" = Just Videoinput
   read _ = Nothing
-
+  
   export
   ToFFI MediaDeviceKind String where
     toFFI = show
-
+  
   export
   FromFFI MediaDeviceKind String where
     fromFFI = read
@@ -410,3 +410,4 @@ ToFFI NavigatorUserMediaSuccessCallback NavigatorUserMediaSuccessCallback where 
 
 export
 FromFFI NavigatorUserMediaSuccessCallback NavigatorUserMediaSuccessCallback where fromFFI = Just
+

--- a/src/Web/Internal/PermissionsPrim.idr
+++ b/src/Web/Internal/PermissionsPrim.idr
@@ -11,13 +11,13 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace PermissionStatus
-
+  
   export
   %foreign "browser:lambda:x=>x.onchange"
   prim__onchange : PermissionStatus -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onchange = v}"
   prim__setOnchange :
@@ -26,7 +26,7 @@ namespace PermissionStatus
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : PermissionStatus -> PrimIO String
@@ -34,7 +34,7 @@ namespace PermissionStatus
 
 
 namespace Permissions
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.query(a)"
   prim__query : Permissions -> Object -> PrimIO (Promise PermissionStatus)
@@ -48,12 +48,12 @@ namespace Permissions
 --------------------------------------------------------------------------------
 
 namespace CameraDevicePermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({panTiltZoom: a})"
   prim__new : UndefOr Boolean -> PrimIO CameraDevicePermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.panTiltZoom"
   prim__panTiltZoom :
@@ -61,7 +61,7 @@ namespace CameraDevicePermissionDescriptor
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.panTiltZoom = v}"
   prim__setPanTiltZoom :
@@ -73,18 +73,18 @@ namespace CameraDevicePermissionDescriptor
 
 
 namespace DevicePermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({deviceId: a})"
   prim__new : UndefOr String -> PrimIO DevicePermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deviceId"
   prim__deviceId : DevicePermissionDescriptor -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deviceId = v}"
   prim__setDeviceId : DevicePermissionDescriptor -> UndefOr String -> PrimIO ()
@@ -93,38 +93,38 @@ namespace DevicePermissionDescriptor
 
 
 namespace MidiPermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({sysex: a})"
   prim__new : UndefOr Boolean -> PrimIO MidiPermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sysex"
   prim__sysex : MidiPermissionDescriptor -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.sysex = v}"
-  prim__setSysex : MidiPermissionDescriptor -> UndefOr Boolean -> PrimIO () -- gitleaks:allow
+  prim__setSysex : MidiPermissionDescriptor -> UndefOr Boolean -> PrimIO ()
 
 
 
 
 namespace PermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({name: a})"
   prim__new : String -> PrimIO PermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : PermissionDescriptor -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.name = v}"
   prim__setName : PermissionDescriptor -> String -> PrimIO ()
@@ -133,7 +133,7 @@ namespace PermissionDescriptor
 
 
 namespace PermissionSetParameters
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({descriptor: a,state: b,oneRealm: c})"
   prim__new :
@@ -142,13 +142,13 @@ namespace PermissionSetParameters
     -> UndefOr Boolean
     -> PrimIO PermissionSetParameters
 
-
+  
   export
   %foreign "browser:lambda:x=>x.descriptor"
   prim__descriptor : PermissionSetParameters -> PrimIO PermissionDescriptor
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.descriptor = v}"
   prim__setDescriptor :
@@ -157,25 +157,25 @@ namespace PermissionSetParameters
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oneRealm"
   prim__oneRealm : PermissionSetParameters -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oneRealm = v}"
   prim__setOneRealm : PermissionSetParameters -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : PermissionSetParameters -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.state = v}"
   prim__setState : PermissionSetParameters -> String -> PrimIO ()
@@ -184,21 +184,25 @@ namespace PermissionSetParameters
 
 
 namespace PushPermissionDescriptor
-
+  
   export
   %foreign "browser:lambda:(a)=> ({userVisibleOnly: a})"
   prim__new : UndefOr Boolean -> PrimIO PushPermissionDescriptor
 
-
+  
   export
   %foreign "browser:lambda:x=>x.userVisibleOnly"
   prim__userVisibleOnly : PushPermissionDescriptor -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.userVisibleOnly = v}"
   prim__setUserVisibleOnly :
        PushPermissionDescriptor
     -> UndefOr Boolean
     -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/PermissionsTypes.idr
+++ b/src/Web/Internal/PermissionsTypes.idr
@@ -10,42 +10,42 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace PermissionState
-
+  
   public export
   data PermissionState = Granted | Denied | Prompt
-
-  public export
+  
+  export
   Show PermissionState where
     show Granted = "granted"
     show Denied = "denied"
     show Prompt = "prompt"
-
-  public export
+  
+  export
   Eq PermissionState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord PermissionState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe PermissionState
   read "granted" = Just Granted
   read "denied" = Just Denied
   read "prompt" = Just Prompt
   read _ = Nothing
-
+  
   export
   ToFFI PermissionState String where
     toFFI = show
-
+  
   export
   FromFFI PermissionState String where
     fromFFI = read
 
 
 namespace PermissionName
-
+  
   public export
   data PermissionName =
       Geolocation
@@ -68,8 +68,8 @@ namespace PermissionName
     | ClipboardWrite
     | DisplayCapture
     | Nfc
-
-  public export
+  
+  export
   Show PermissionName where
     show Geolocation = "geolocation"
     show Notifications = "notifications"
@@ -91,16 +91,16 @@ namespace PermissionName
     show ClipboardWrite = "clipboard-write"
     show DisplayCapture = "display-capture"
     show Nfc = "nfc"
-
-  public export
+  
+  export
   Eq PermissionName where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord PermissionName where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe PermissionName
   read "geolocation" = Just Geolocation
   read "notifications" = Just Notifications
@@ -123,11 +123,11 @@ namespace PermissionName
   read "display-capture" = Just DisplayCapture
   read "nfc" = Just Nfc
   read _ = Nothing
-
+  
   export
   ToFFI PermissionName String where
     toFFI = show
-
+  
   export
   FromFFI PermissionName String where
     fromFFI = read
@@ -214,3 +214,6 @@ ToFFI PushPermissionDescriptor PushPermissionDescriptor where toFFI = id
 
 export
 FromFFI PushPermissionDescriptor PushPermissionDescriptor where fromFFI = Just
+
+
+

--- a/src/Web/Internal/ServiceworkerPrim.idr
+++ b/src/Web/Internal/ServiceworkerPrim.idr
@@ -11,7 +11,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Cache
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.addAll(a)"
   prim__addAll :
@@ -19,12 +19,12 @@ namespace Cache
     -> Array (Union2 Request String)
     -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.add(a)"
   prim__add : Cache -> Union2 Request String -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.delete(a,b)"
   prim__delete :
@@ -33,7 +33,7 @@ namespace Cache
     -> UndefOr CacheQueryOptions
     -> PrimIO (Promise Boolean)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.keys(a,b)"
   prim__keys :
@@ -42,7 +42,7 @@ namespace Cache
     -> UndefOr CacheQueryOptions
     -> PrimIO (Promise (Array Request))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.matchAll(a,b)"
   prim__matchAll :
@@ -51,7 +51,7 @@ namespace Cache
     -> UndefOr CacheQueryOptions
     -> PrimIO (Promise (Array Response))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.match(a,b)"
   prim__match :
@@ -60,7 +60,7 @@ namespace Cache
     -> UndefOr CacheQueryOptions
     -> PrimIO (Promise (Union2 Response Undefined))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.put(a,b)"
   prim__put :
@@ -72,22 +72,22 @@ namespace Cache
 
 
 namespace CacheStorage
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.delete(a)"
   prim__delete : CacheStorage -> String -> PrimIO (Promise Boolean)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.has(a)"
   prim__has : CacheStorage -> String -> PrimIO (Promise Boolean)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keys()"
   prim__keys : CacheStorage -> PrimIO (Promise (Array String))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.match(a,b)"
   prim__match :
@@ -96,7 +96,7 @@ namespace CacheStorage
     -> UndefOr MultiCacheQueryOptions
     -> PrimIO (Promise (Union2 Response Undefined))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.open(a)"
   prim__open : CacheStorage -> String -> PrimIO (Promise Cache)
@@ -104,32 +104,32 @@ namespace CacheStorage
 
 
 namespace Client
-
+  
   export
   %foreign "browser:lambda:x=>x.frameType"
   prim__frameType : Client -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.id"
   prim__id : Client -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : Client -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.url"
   prim__url : Client -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage : Client -> AnyPtr -> Array Object -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -141,17 +141,17 @@ namespace Client
 
 
 namespace Clients
-
+  
   export
   %foreign "browser:lambda:x=>x.claim()"
   prim__claim : Clients -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : Clients -> String -> PrimIO (Promise (Union2 Client Undefined))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.matchAll(a)"
   prim__matchAll :
@@ -159,7 +159,7 @@ namespace Clients
     -> UndefOr ClientQueryOptions
     -> PrimIO (Promise (Array Client))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.openWindow(a)"
   prim__openWindow :
@@ -170,12 +170,12 @@ namespace Clients
 
 
 namespace ExtendableEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ExtendableEvent(a,b)"
   prim__new : String -> UndefOr ExtendableEventInit -> PrimIO ExtendableEvent
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.waitUntil(a)"
   prim__waitUntil : ExtendableEvent -> Promise AnyPtr -> PrimIO ()
@@ -183,7 +183,7 @@ namespace ExtendableEvent
 
 
 namespace ExtendableMessageEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ExtendableMessageEvent(a,b)"
   prim__new :
@@ -191,27 +191,27 @@ namespace ExtendableMessageEvent
     -> UndefOr ExtendableMessageEventInit
     -> PrimIO ExtendableMessageEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : ExtendableMessageEvent -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastEventId"
   prim__lastEventId : ExtendableMessageEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : ExtendableMessageEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ports"
   prim__ports : ExtendableMessageEvent -> PrimIO (Array MessagePort)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source :
@@ -221,42 +221,42 @@ namespace ExtendableMessageEvent
 
 
 namespace FetchEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new FetchEvent(a,b)"
   prim__new : String -> FetchEventInit -> PrimIO FetchEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientId"
   prim__clientId : FetchEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.handled"
   prim__handled : FetchEvent -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preloadResponse"
   prim__preloadResponse : FetchEvent -> PrimIO (Promise AnyPtr)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.replacesClientId"
   prim__replacesClientId : FetchEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.request"
   prim__request : FetchEvent -> PrimIO Request
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resultingClientId"
   prim__resultingClientId : FetchEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.respondWith(a)"
   prim__respondWith : FetchEvent -> Promise Response -> PrimIO ()
@@ -264,24 +264,24 @@ namespace FetchEvent
 
 
 namespace NavigationPreloadManager
-
+  
   export
   %foreign "browser:lambda:x=>x.disable()"
   prim__disable : NavigationPreloadManager -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enable()"
   prim__enable : NavigationPreloadManager -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getState()"
   prim__getState :
        NavigationPreloadManager
     -> PrimIO (Promise NavigationPreloadState)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setHeaderValue(a)"
   prim__setHeaderValue :
@@ -292,13 +292,13 @@ namespace NavigationPreloadManager
 
 
 namespace ServiceWorker
-
+  
   export
   %foreign "browser:lambda:x=>x.onstatechange"
   prim__onstatechange : ServiceWorker -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onstatechange = v}"
   prim__setOnstatechange :
@@ -307,22 +307,22 @@ namespace ServiceWorker
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scriptURL"
   prim__scriptURL : ServiceWorker -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.state"
   prim__state : ServiceWorker -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage : ServiceWorker -> AnyPtr -> Array Object -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.postMessage(a,b)"
   prim__postMessage1 :
@@ -334,12 +334,12 @@ namespace ServiceWorker
 
 
 namespace ServiceWorkerContainer
-
+  
   export
   %foreign "browser:lambda:x=>x.controller"
   prim__controller : ServiceWorkerContainer -> PrimIO (Nullable ServiceWorker)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oncontrollerchange"
   prim__oncontrollerchange :
@@ -347,7 +347,7 @@ namespace ServiceWorkerContainer
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oncontrollerchange = v}"
   prim__setOncontrollerchange :
@@ -356,7 +356,7 @@ namespace ServiceWorkerContainer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage :
@@ -364,7 +364,7 @@ namespace ServiceWorkerContainer
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage :
@@ -373,7 +373,7 @@ namespace ServiceWorkerContainer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror :
@@ -381,7 +381,7 @@ namespace ServiceWorkerContainer
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -390,14 +390,14 @@ namespace ServiceWorkerContainer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ready"
   prim__ready :
        ServiceWorkerContainer
     -> PrimIO (Promise ServiceWorkerRegistration)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getRegistration(a)"
   prim__getRegistration :
@@ -405,14 +405,14 @@ namespace ServiceWorkerContainer
     -> UndefOr String
     -> PrimIO (Promise (Union2 ServiceWorkerRegistration Undefined))
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getRegistrations()"
   prim__getRegistrations :
        ServiceWorkerContainer
     -> PrimIO (Promise (Array ServiceWorkerRegistration))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.register(a,b)"
   prim__register :
@@ -421,7 +421,7 @@ namespace ServiceWorkerContainer
     -> UndefOr RegistrationOptions
     -> PrimIO (Promise ServiceWorkerRegistration)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startMessages()"
   prim__startMessages : ServiceWorkerContainer -> PrimIO ()
@@ -429,12 +429,12 @@ namespace ServiceWorkerContainer
 
 
 namespace ServiceWorkerGlobalScope
-
+  
   export
   %foreign "browser:lambda:x=>x.clients"
   prim__clients : ServiceWorkerGlobalScope -> PrimIO Clients
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onactivate"
   prim__onactivate :
@@ -442,7 +442,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onactivate = v}"
   prim__setOnactivate :
@@ -451,7 +451,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onfetch"
   prim__onfetch :
@@ -459,7 +459,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onfetch = v}"
   prim__setOnfetch :
@@ -468,7 +468,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.oninstall"
   prim__oninstall :
@@ -476,7 +476,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.oninstall = v}"
   prim__setOninstall :
@@ -485,7 +485,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessage"
   prim__onmessage :
@@ -493,7 +493,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessage = v}"
   prim__setOnmessage :
@@ -502,7 +502,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onmessageerror"
   prim__onmessageerror :
@@ -510,7 +510,7 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onmessageerror = v}"
   prim__setOnmessageerror :
@@ -519,19 +519,19 @@ namespace ServiceWorkerGlobalScope
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.registration"
   prim__registration :
        ServiceWorkerGlobalScope
     -> PrimIO ServiceWorkerRegistration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.serviceWorker"
   prim__serviceWorker : ServiceWorkerGlobalScope -> PrimIO ServiceWorker
 
-
+  
   export
   %foreign "browser:lambda:x=>x.skipWaiting()"
   prim__skipWaiting : ServiceWorkerGlobalScope -> PrimIO (Promise Undefined)
@@ -539,26 +539,26 @@ namespace ServiceWorkerGlobalScope
 
 
 namespace ServiceWorkerRegistration
-
+  
   export
   %foreign "browser:lambda:x=>x.active"
   prim__active : ServiceWorkerRegistration -> PrimIO (Nullable ServiceWorker)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.installing"
   prim__installing :
        ServiceWorkerRegistration
     -> PrimIO (Nullable ServiceWorker)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.navigationPreload"
   prim__navigationPreload :
        ServiceWorkerRegistration
     -> PrimIO NavigationPreloadManager
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onupdatefound"
   prim__onupdatefound :
@@ -566,7 +566,7 @@ namespace ServiceWorkerRegistration
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onupdatefound = v}"
   prim__setOnupdatefound :
@@ -575,27 +575,27 @@ namespace ServiceWorkerRegistration
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scope"
   prim__scope : ServiceWorkerRegistration -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.updateViaCache"
   prim__updateViaCache : ServiceWorkerRegistration -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.waiting"
   prim__waiting : ServiceWorkerRegistration -> PrimIO (Nullable ServiceWorker)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.unregister()"
   prim__unregister : ServiceWorkerRegistration -> PrimIO (Promise Boolean)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.update()"
   prim__update : ServiceWorkerRegistration -> PrimIO (Promise Undefined)
@@ -603,27 +603,27 @@ namespace ServiceWorkerRegistration
 
 
 namespace WindowClient
-
+  
   export
   %foreign "browser:lambda:x=>x.ancestorOrigins"
   prim__ancestorOrigins : WindowClient -> PrimIO (Array String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.focused"
   prim__focused : WindowClient -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.visibilityState"
   prim__visibilityState : WindowClient -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.focus()"
   prim__focus : WindowClient -> PrimIO (Promise WindowClient)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.navigate(a)"
   prim__navigate :
@@ -640,7 +640,7 @@ namespace WindowClient
 --------------------------------------------------------------------------------
 
 namespace CacheQueryOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({ignoreSearch: a,ignoreMethod: b,ignoreVary: c})"
   prim__new :
@@ -649,37 +649,37 @@ namespace CacheQueryOptions
     -> UndefOr Boolean
     -> PrimIO CacheQueryOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ignoreMethod"
   prim__ignoreMethod : CacheQueryOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ignoreMethod = v}"
   prim__setIgnoreMethod : CacheQueryOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ignoreSearch"
   prim__ignoreSearch : CacheQueryOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ignoreSearch = v}"
   prim__setIgnoreSearch : CacheQueryOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ignoreVary"
   prim__ignoreVary : CacheQueryOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ignoreVary = v}"
   prim__setIgnoreVary : CacheQueryOptions -> UndefOr Boolean -> PrimIO ()
@@ -688,18 +688,18 @@ namespace CacheQueryOptions
 
 
 namespace ClientQueryOptions
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({includeUncontrolled: a,type: b})"
   prim__new : UndefOr Boolean -> UndefOr String -> PrimIO ClientQueryOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.includeUncontrolled"
   prim__includeUncontrolled : ClientQueryOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.includeUncontrolled = v}"
   prim__setIncludeUncontrolled :
@@ -708,13 +708,13 @@ namespace ClientQueryOptions
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : ClientQueryOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : ClientQueryOptions -> UndefOr String -> PrimIO ()
@@ -723,7 +723,7 @@ namespace ClientQueryOptions
 
 
 namespace ExtendableEventInit
-
+  
   export
   %foreign "browser:lambda:()=> ({})"
   prim__new : PrimIO ExtendableEventInit
@@ -731,7 +731,7 @@ namespace ExtendableEventInit
 
 
 namespace ExtendableMessageEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({data: a,origin: b,lastEventId: c,source: d,ports: e})"
   prim__new :
@@ -742,25 +742,25 @@ namespace ExtendableMessageEventInit
     -> UndefOr (Array MessagePort)
     -> PrimIO ExtendableMessageEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : ExtendableMessageEventInit -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : ExtendableMessageEventInit -> UndefOr AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lastEventId"
   prim__lastEventId : ExtendableMessageEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lastEventId = v}"
   prim__setLastEventId :
@@ -769,19 +769,19 @@ namespace ExtendableMessageEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : ExtendableMessageEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.origin = v}"
   prim__setOrigin : ExtendableMessageEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ports"
   prim__ports :
@@ -789,7 +789,7 @@ namespace ExtendableMessageEventInit
     -> PrimIO (UndefOr (Array MessagePort))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ports = v}"
   prim__setPorts :
@@ -798,7 +798,7 @@ namespace ExtendableMessageEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.source"
   prim__source :
@@ -806,7 +806,7 @@ namespace ExtendableMessageEventInit
     -> PrimIO (UndefOr (Nullable (Union3 Client ServiceWorker MessagePort)))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.source = v}"
   prim__setSource :
@@ -818,7 +818,7 @@ namespace ExtendableMessageEventInit
 
 
 namespace FetchEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f)=> ({request: a,preloadResponse: b,clientId: c,resultingClientId: d,replacesClientId: e,handled: f})"
   prim__new :
@@ -830,37 +830,37 @@ namespace FetchEventInit
     -> UndefOr (Promise Undefined)
     -> PrimIO FetchEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientId"
   prim__clientId : FetchEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clientId = v}"
   prim__setClientId : FetchEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.handled"
   prim__handled : FetchEventInit -> PrimIO (UndefOr (Promise Undefined))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.handled = v}"
   prim__setHandled : FetchEventInit -> UndefOr (Promise Undefined) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preloadResponse"
   prim__preloadResponse : FetchEventInit -> PrimIO (UndefOr (Promise AnyPtr))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preloadResponse = v}"
   prim__setPreloadResponse :
@@ -869,37 +869,37 @@ namespace FetchEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.replacesClientId"
   prim__replacesClientId : FetchEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.replacesClientId = v}"
   prim__setReplacesClientId : FetchEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.request"
   prim__request : FetchEventInit -> PrimIO Request
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.request = v}"
   prim__setRequest : FetchEventInit -> Request -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resultingClientId"
   prim__resultingClientId : FetchEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.resultingClientId = v}"
   prim__setResultingClientId : FetchEventInit -> UndefOr String -> PrimIO ()
@@ -908,18 +908,18 @@ namespace FetchEventInit
 
 
 namespace MultiCacheQueryOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({cacheName: a})"
   prim__new : UndefOr String -> PrimIO MultiCacheQueryOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cacheName"
   prim__cacheName : MultiCacheQueryOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cacheName = v}"
   prim__setCacheName : MultiCacheQueryOptions -> UndefOr String -> PrimIO ()
@@ -928,7 +928,7 @@ namespace MultiCacheQueryOptions
 
 
 namespace NavigationPreloadState
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({enabled: a,headerValue: b})"
   prim__new :
@@ -936,25 +936,25 @@ namespace NavigationPreloadState
     -> UndefOr ByteString
     -> PrimIO NavigationPreloadState
 
-
+  
   export
   %foreign "browser:lambda:x=>x.enabled"
   prim__enabled : NavigationPreloadState -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.enabled = v}"
   prim__setEnabled : NavigationPreloadState -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.headerValue"
   prim__headerValue : NavigationPreloadState -> PrimIO (UndefOr ByteString)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.headerValue = v}"
   prim__setHeaderValue :
@@ -966,7 +966,7 @@ namespace NavigationPreloadState
 
 
 namespace RegistrationOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({scope: a,type: b,updateViaCache: c})"
   prim__new :
@@ -975,37 +975,41 @@ namespace RegistrationOptions
     -> UndefOr String
     -> PrimIO RegistrationOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.scope"
   prim__scope : RegistrationOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.scope = v}"
   prim__setScope : RegistrationOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : RegistrationOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : RegistrationOptions -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.updateViaCache"
   prim__updateViaCache : RegistrationOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.updateViaCache = v}"
   prim__setUpdateViaCache : RegistrationOptions -> UndefOr String -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/ServiceworkerTypes.idr
+++ b/src/Web/Internal/ServiceworkerTypes.idr
@@ -10,7 +10,7 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace ServiceWorkerState
-
+  
   public export
   data ServiceWorkerState =
       Parsed
@@ -19,8 +19,8 @@ namespace ServiceWorkerState
     | Activating
     | Activated
     | Redundant
-
-  public export
+  
+  export
   Show ServiceWorkerState where
     show Parsed = "parsed"
     show Installing = "installing"
@@ -28,16 +28,16 @@ namespace ServiceWorkerState
     show Activating = "activating"
     show Activated = "activated"
     show Redundant = "redundant"
-
-  public export
+  
+  export
   Eq ServiceWorkerState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ServiceWorkerState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ServiceWorkerState
   read "parsed" = Just Parsed
   read "installing" = Just Installing
@@ -46,120 +46,120 @@ namespace ServiceWorkerState
   read "activated" = Just Activated
   read "redundant" = Just Redundant
   read _ = Nothing
-
+  
   export
   ToFFI ServiceWorkerState String where
     toFFI = show
-
+  
   export
   FromFFI ServiceWorkerState String where
     fromFFI = read
 
 
 namespace ServiceWorkerUpdateViaCache
-
+  
   public export
   data ServiceWorkerUpdateViaCache = Imports | All | None
-
-  public export
+  
+  export
   Show ServiceWorkerUpdateViaCache where
     show Imports = "imports"
     show All = "all"
     show None = "none"
-
-  public export
+  
+  export
   Eq ServiceWorkerUpdateViaCache where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ServiceWorkerUpdateViaCache where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ServiceWorkerUpdateViaCache
   read "imports" = Just Imports
   read "all" = Just All
   read "none" = Just None
   read _ = Nothing
-
+  
   export
   ToFFI ServiceWorkerUpdateViaCache String where
     toFFI = show
-
+  
   export
   FromFFI ServiceWorkerUpdateViaCache String where
     fromFFI = read
 
 
 namespace FrameType
-
+  
   public export
   data FrameType = Auxiliary | TopLevel | Nested | None
-
-  public export
+  
+  export
   Show FrameType where
     show Auxiliary = "auxiliary"
     show TopLevel = "top-level"
     show Nested = "nested"
     show None = "none"
-
-  public export
+  
+  export
   Eq FrameType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord FrameType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe FrameType
   read "auxiliary" = Just Auxiliary
   read "top-level" = Just TopLevel
   read "nested" = Just Nested
   read "none" = Just None
   read _ = Nothing
-
+  
   export
   ToFFI FrameType String where
     toFFI = show
-
+  
   export
   FromFFI FrameType String where
     fromFFI = read
 
 
 namespace ClientType
-
+  
   public export
   data ClientType = Window | Worker | Sharedworker | All
-
-  public export
+  
+  export
   Show ClientType where
     show Window = "window"
     show Worker = "worker"
     show Sharedworker = "sharedworker"
     show All = "all"
-
-  public export
+  
+  export
   Eq ClientType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ClientType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ClientType
   read "window" = Just Window
   read "worker" = Just Worker
   read "sharedworker" = Just Sharedworker
   read "all" = Just All
   read _ = Nothing
-
+  
   export
   ToFFI ClientType String where
     toFFI = show
-
+  
   export
   FromFFI ClientType String where
     fromFFI = read
@@ -394,3 +394,6 @@ ToFFI RegistrationOptions RegistrationOptions where toFFI = id
 
 export
 FromFFI RegistrationOptions RegistrationOptions where fromFFI = Just
+
+
+

--- a/src/Web/Internal/StreamsPrim.idr
+++ b/src/Web/Internal/StreamsPrim.idr
@@ -11,17 +11,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace ByteLengthQueuingStrategy
-
+  
   export
   %foreign "browser:lambda:(a)=> new ByteLengthQueuingStrategy(a)"
   prim__new : QueuingStrategyInit -> PrimIO ByteLengthQueuingStrategy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.highWaterMark"
   prim__highWaterMark : ByteLengthQueuingStrategy -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : ByteLengthQueuingStrategy -> PrimIO Function
@@ -29,17 +29,17 @@ namespace ByteLengthQueuingStrategy
 
 
 namespace CountQueuingStrategy
-
+  
   export
   %foreign "browser:lambda:(a)=> new CountQueuingStrategy(a)"
   prim__new : QueuingStrategyInit -> PrimIO CountQueuingStrategy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.highWaterMark"
   prim__highWaterMark : CountQueuingStrategy -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : CountQueuingStrategy -> PrimIO Function
@@ -47,24 +47,24 @@ namespace CountQueuingStrategy
 
 
 namespace ReadableByteStreamController
-
+  
   export
   %foreign "browser:lambda:x=>x.byobRequest"
   prim__byobRequest :
        ReadableByteStreamController
     -> PrimIO (Nullable ReadableStreamBYOBRequest)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.desiredSize"
   prim__desiredSize : ReadableByteStreamController -> PrimIO (Nullable Double)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : ReadableByteStreamController -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.enqueue(a)"
   prim__enqueue :
@@ -82,7 +82,7 @@ namespace ReadableByteStreamController
          DataView
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.error(a)"
   prim__error : ReadableByteStreamController -> UndefOr AnyPtr -> PrimIO ()
@@ -90,22 +90,22 @@ namespace ReadableByteStreamController
 
 
 namespace ReadableStream
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ReadableStream(a,b)"
   prim__new : UndefOr Object -> UndefOr QueuingStrategy -> PrimIO ReadableStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.locked"
   prim__locked : ReadableStream -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.cancel(a)"
   prim__cancel : ReadableStream -> UndefOr AnyPtr -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getReader(a)"
   prim__getReader :
@@ -113,7 +113,7 @@ namespace ReadableStream
     -> UndefOr ReadableStreamGetReaderOptions
     -> PrimIO (Union2 ReadableStreamDefaultReader ReadableStreamBYOBReader)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.pipeThrough(a,b)"
   prim__pipeThrough :
@@ -122,7 +122,7 @@ namespace ReadableStream
     -> UndefOr StreamPipeOptions
     -> PrimIO ReadableStream
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.pipeTo(a,b)"
   prim__pipeTo :
@@ -131,7 +131,7 @@ namespace ReadableStream
     -> UndefOr StreamPipeOptions
     -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.tee()"
   prim__tee : ReadableStream -> PrimIO (Array ReadableStream)
@@ -139,12 +139,12 @@ namespace ReadableStream
 
 
 namespace ReadableStreamBYOBReader
-
+  
   export
   %foreign "browser:lambda:(a)=> new ReadableStreamBYOBReader(a)"
   prim__new : ReadableStream -> PrimIO ReadableStreamBYOBReader
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.read(a)"
   prim__read :
@@ -162,7 +162,7 @@ namespace ReadableStreamBYOBReader
          DataView
     -> PrimIO (Promise ReadableStreamBYOBReadResult)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.releaseLock()"
   prim__releaseLock : ReadableStreamBYOBReader -> PrimIO ()
@@ -170,7 +170,7 @@ namespace ReadableStreamBYOBReader
 
 
 namespace ReadableStreamBYOBRequest
-
+  
   export
   %foreign "browser:lambda:x=>x.view"
   prim__view :
@@ -189,12 +189,12 @@ namespace ReadableStreamBYOBRequest
                Float64Array
                DataView))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.respond(a)"
   prim__respond : ReadableStreamBYOBRequest -> JSBits64 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.respondWithNewView(a)"
   prim__respondWithNewView :
@@ -215,24 +215,24 @@ namespace ReadableStreamBYOBRequest
 
 
 namespace ReadableStreamDefaultController
-
+  
   export
   %foreign "browser:lambda:x=>x.desiredSize"
   prim__desiredSize :
        ReadableStreamDefaultController
     -> PrimIO (Nullable Double)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : ReadableStreamDefaultController -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.enqueue(a)"
   prim__enqueue : ReadableStreamDefaultController -> UndefOr AnyPtr -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.error(a)"
   prim__error : ReadableStreamDefaultController -> UndefOr AnyPtr -> PrimIO ()
@@ -240,19 +240,19 @@ namespace ReadableStreamDefaultController
 
 
 namespace ReadableStreamDefaultReader
-
+  
   export
   %foreign "browser:lambda:(a)=> new ReadableStreamDefaultReader(a)"
   prim__new : ReadableStream -> PrimIO ReadableStreamDefaultReader
 
-
+  
   export
   %foreign "browser:lambda:x=>x.read()"
   prim__read :
        ReadableStreamDefaultReader
     -> PrimIO (Promise ReadableStreamDefaultReadResult)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.releaseLock()"
   prim__releaseLock : ReadableStreamDefaultReader -> PrimIO ()
@@ -260,7 +260,7 @@ namespace ReadableStreamDefaultReader
 
 
 namespace TransformStream
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> new TransformStream(a,b,c)"
   prim__new :
@@ -269,12 +269,12 @@ namespace TransformStream
     -> UndefOr QueuingStrategy
     -> PrimIO TransformStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readable"
   prim__readable : TransformStream -> PrimIO ReadableStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.writable"
   prim__writable : TransformStream -> PrimIO WritableStream
@@ -282,14 +282,14 @@ namespace TransformStream
 
 
 namespace TransformStreamDefaultController
-
+  
   export
   %foreign "browser:lambda:x=>x.desiredSize"
   prim__desiredSize :
        TransformStreamDefaultController
     -> PrimIO (Nullable Double)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.enqueue(a)"
   prim__enqueue :
@@ -297,12 +297,12 @@ namespace TransformStreamDefaultController
     -> UndefOr AnyPtr
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.error(a)"
   prim__error : TransformStreamDefaultController -> UndefOr AnyPtr -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.terminate()"
   prim__terminate : TransformStreamDefaultController -> PrimIO ()
@@ -310,27 +310,27 @@ namespace TransformStreamDefaultController
 
 
 namespace WritableStream
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new WritableStream(a,b)"
   prim__new : UndefOr Object -> UndefOr QueuingStrategy -> PrimIO WritableStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.locked"
   prim__locked : WritableStream -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.abort(a)"
   prim__abort : WritableStream -> UndefOr AnyPtr -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : WritableStream -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getWriter()"
   prim__getWriter : WritableStream -> PrimIO WritableStreamDefaultWriter
@@ -338,7 +338,7 @@ namespace WritableStream
 
 
 namespace WritableStreamDefaultController
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.error(a)"
   prim__error : WritableStreamDefaultController -> UndefOr AnyPtr -> PrimIO ()
@@ -346,27 +346,27 @@ namespace WritableStreamDefaultController
 
 
 namespace WritableStreamDefaultWriter
-
+  
   export
   %foreign "browser:lambda:(a)=> new WritableStreamDefaultWriter(a)"
   prim__new : WritableStream -> PrimIO WritableStreamDefaultWriter
 
-
+  
   export
   %foreign "browser:lambda:x=>x.closed"
   prim__closed : WritableStreamDefaultWriter -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.desiredSize"
   prim__desiredSize : WritableStreamDefaultWriter -> PrimIO (Nullable Double)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ready"
   prim__ready : WritableStreamDefaultWriter -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.abort(a)"
   prim__abort :
@@ -374,17 +374,17 @@ namespace WritableStreamDefaultWriter
     -> UndefOr AnyPtr
     -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close()"
   prim__close : WritableStreamDefaultWriter -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.releaseLock()"
   prim__releaseLock : WritableStreamDefaultWriter -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.write(a)"
   prim__write :
@@ -400,12 +400,12 @@ namespace WritableStreamDefaultWriter
 --------------------------------------------------------------------------------
 
 namespace GenericTransformStream
-
+  
   export
   %foreign "browser:lambda:x=>x.readable"
   prim__readable : GenericTransformStream -> PrimIO ReadableStream
 
-
+  
   export
   %foreign "browser:lambda:x=>x.writable"
   prim__writable : GenericTransformStream -> PrimIO WritableStream
@@ -413,12 +413,12 @@ namespace GenericTransformStream
 
 
 namespace ReadableStreamGenericReader
-
+  
   export
   %foreign "browser:lambda:x=>x.closed"
   prim__closed : ReadableStreamGenericReader -> PrimIO (Promise Undefined)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.cancel(a)"
   prim__cancel :
@@ -434,7 +434,7 @@ namespace ReadableStreamGenericReader
 --------------------------------------------------------------------------------
 
 namespace QueuingStrategy
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({highWaterMark: a,size: b})"
   prim__new :
@@ -442,25 +442,25 @@ namespace QueuingStrategy
     -> UndefOr QueuingStrategySize
     -> PrimIO QueuingStrategy
 
-
+  
   export
   %foreign "browser:lambda:x=>x.highWaterMark"
   prim__highWaterMark : QueuingStrategy -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.highWaterMark = v}"
   prim__setHighWaterMark : QueuingStrategy -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : QueuingStrategy -> PrimIO (UndefOr QueuingStrategySize)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.size = v}"
   prim__setSize : QueuingStrategy -> UndefOr QueuingStrategySize -> PrimIO ()
@@ -469,18 +469,18 @@ namespace QueuingStrategy
 
 
 namespace QueuingStrategyInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({highWaterMark: a})"
   prim__new : Double -> PrimIO QueuingStrategyInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.highWaterMark"
   prim__highWaterMark : QueuingStrategyInit -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.highWaterMark = v}"
   prim__setHighWaterMark : QueuingStrategyInit -> Double -> PrimIO ()
@@ -489,7 +489,7 @@ namespace QueuingStrategyInit
 
 
 namespace ReadableStreamBYOBReadResult
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({value: a,done: b})"
   prim__new :
@@ -508,19 +508,19 @@ namespace ReadableStreamBYOBReadResult
     -> UndefOr Boolean
     -> PrimIO ReadableStreamBYOBReadResult
 
-
+  
   export
   %foreign "browser:lambda:x=>x.done"
   prim__done : ReadableStreamBYOBReadResult -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.done = v}"
   prim__setDone : ReadableStreamBYOBReadResult -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value :
@@ -540,7 +540,7 @@ namespace ReadableStreamBYOBReadResult
                DataView))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue :
@@ -563,7 +563,7 @@ namespace ReadableStreamBYOBReadResult
 
 
 namespace ReadableStreamDefaultReadResult
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({value: a,done: b})"
   prim__new :
@@ -571,13 +571,13 @@ namespace ReadableStreamDefaultReadResult
     -> UndefOr Boolean
     -> PrimIO ReadableStreamDefaultReadResult
 
-
+  
   export
   %foreign "browser:lambda:x=>x.done"
   prim__done : ReadableStreamDefaultReadResult -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.done = v}"
   prim__setDone :
@@ -586,13 +586,13 @@ namespace ReadableStreamDefaultReadResult
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : ReadableStreamDefaultReadResult -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue :
@@ -604,18 +604,18 @@ namespace ReadableStreamDefaultReadResult
 
 
 namespace ReadableStreamGetReaderOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({mode: a})"
   prim__new : UndefOr String -> PrimIO ReadableStreamGetReaderOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.mode"
   prim__mode : ReadableStreamGetReaderOptions -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.mode = v}"
   prim__setMode : ReadableStreamGetReaderOptions -> UndefOr String -> PrimIO ()
@@ -624,12 +624,12 @@ namespace ReadableStreamGetReaderOptions
 
 
 namespace ReadableStreamIteratorOptions
-
+  
   export
   %foreign "browser:lambda:(a)=> ({preventCancel: a})"
   prim__new : UndefOr Boolean -> PrimIO ReadableStreamIteratorOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventCancel"
   prim__preventCancel :
@@ -637,7 +637,7 @@ namespace ReadableStreamIteratorOptions
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preventCancel = v}"
   prim__setPreventCancel :
@@ -649,30 +649,30 @@ namespace ReadableStreamIteratorOptions
 
 
 namespace ReadableWritablePair
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({readable: a,writable: b})"
   prim__new : ReadableStream -> WritableStream -> PrimIO ReadableWritablePair
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readable"
   prim__readable : ReadableWritablePair -> PrimIO ReadableStream
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.readable = v}"
   prim__setReadable : ReadableWritablePair -> ReadableStream -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.writable"
   prim__writable : ReadableWritablePair -> PrimIO WritableStream
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.writable = v}"
   prim__setWritable : ReadableWritablePair -> WritableStream -> PrimIO ()
@@ -681,7 +681,7 @@ namespace ReadableWritablePair
 
 
 namespace StreamPipeOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({preventClose: a,preventAbort: b,preventCancel: c,signal: d})"
   prim__new :
@@ -691,49 +691,49 @@ namespace StreamPipeOptions
     -> UndefOr AbortSignal
     -> PrimIO StreamPipeOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventAbort"
   prim__preventAbort : StreamPipeOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preventAbort = v}"
   prim__setPreventAbort : StreamPipeOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventCancel"
   prim__preventCancel : StreamPipeOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preventCancel = v}"
   prim__setPreventCancel : StreamPipeOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preventClose"
   prim__preventClose : StreamPipeOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preventClose = v}"
   prim__setPreventClose : StreamPipeOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.signal"
   prim__signal : StreamPipeOptions -> PrimIO (UndefOr AbortSignal)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.signal = v}"
   prim__setSignal : StreamPipeOptions -> UndefOr AbortSignal -> PrimIO ()
@@ -742,7 +742,7 @@ namespace StreamPipeOptions
 
 
 namespace Transformer
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({start: a,transform: b,flush: c,readableType: d,writableType: e})"
   prim__new :
@@ -753,49 +753,49 @@ namespace Transformer
     -> UndefOr AnyPtr
     -> PrimIO Transformer
 
-
+  
   export
   %foreign "browser:lambda:x=>x.flush"
   prim__flush : Transformer -> PrimIO (UndefOr TransformerFlushCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.flush = v}"
   prim__setFlush : Transformer -> UndefOr TransformerFlushCallback -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readableType"
   prim__readableType : Transformer -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.readableType = v}"
   prim__setReadableType : Transformer -> UndefOr AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start"
   prim__start : Transformer -> PrimIO (UndefOr TransformerStartCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.start = v}"
   prim__setStart : Transformer -> UndefOr TransformerStartCallback -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.transform"
   prim__transform : Transformer -> PrimIO (UndefOr TransformerTransformCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.transform = v}"
   prim__setTransform :
@@ -804,13 +804,13 @@ namespace Transformer
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.writableType"
   prim__writableType : Transformer -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.writableType = v}"
   prim__setWritableType : Transformer -> UndefOr AnyPtr -> PrimIO ()
@@ -819,7 +819,7 @@ namespace Transformer
 
 
 namespace UnderlyingSink
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({start: a,write: b,close: c,abort: d,type: e})"
   prim__new :
@@ -830,13 +830,13 @@ namespace UnderlyingSink
     -> UndefOr AnyPtr
     -> PrimIO UnderlyingSink
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort"
   prim__abort : UnderlyingSink -> PrimIO (UndefOr UnderlyingSinkAbortCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.abort = v}"
   prim__setAbort :
@@ -845,13 +845,13 @@ namespace UnderlyingSink
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.close"
   prim__close : UnderlyingSink -> PrimIO (UndefOr UnderlyingSinkCloseCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.close = v}"
   prim__setClose :
@@ -860,13 +860,13 @@ namespace UnderlyingSink
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start"
   prim__start : UnderlyingSink -> PrimIO (UndefOr UnderlyingSinkStartCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.start = v}"
   prim__setStart :
@@ -875,25 +875,25 @@ namespace UnderlyingSink
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : UnderlyingSink -> PrimIO (UndefOr AnyPtr)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : UnderlyingSink -> UndefOr AnyPtr -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.write"
   prim__write : UnderlyingSink -> PrimIO (UndefOr UnderlyingSinkWriteCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.write = v}"
   prim__setWrite :
@@ -905,7 +905,7 @@ namespace UnderlyingSink
 
 
 namespace UnderlyingSource
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({start: a,pull: b,cancel: c,type: d,autoAllocateChunkSize: e})"
   prim__new :
@@ -916,13 +916,13 @@ namespace UnderlyingSource
     -> UndefOr JSBits64
     -> PrimIO UnderlyingSource
 
-
+  
   export
   %foreign "browser:lambda:x=>x.autoAllocateChunkSize"
   prim__autoAllocateChunkSize : UnderlyingSource -> PrimIO (UndefOr JSBits64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.autoAllocateChunkSize = v}"
   prim__setAutoAllocateChunkSize :
@@ -931,7 +931,7 @@ namespace UnderlyingSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cancel"
   prim__cancel :
@@ -939,7 +939,7 @@ namespace UnderlyingSource
     -> PrimIO (UndefOr UnderlyingSourceCancelCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.cancel = v}"
   prim__setCancel :
@@ -948,13 +948,13 @@ namespace UnderlyingSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pull"
   prim__pull : UnderlyingSource -> PrimIO (UndefOr UnderlyingSourcePullCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pull = v}"
   prim__setPull :
@@ -963,7 +963,7 @@ namespace UnderlyingSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.start"
   prim__start :
@@ -971,7 +971,7 @@ namespace UnderlyingSource
     -> PrimIO (UndefOr UnderlyingSourceStartCallback)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.start = v}"
   prim__setStart :
@@ -980,13 +980,13 @@ namespace UnderlyingSource
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : UnderlyingSource -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : UnderlyingSource -> UndefOr String -> PrimIO ()
@@ -1000,7 +1000,7 @@ namespace UnderlyingSource
 --------------------------------------------------------------------------------
 
 namespace QueuingStrategySize
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toQueuingStrategySize :
@@ -1010,7 +1010,7 @@ namespace QueuingStrategySize
 
 
 namespace TransformerFlushCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toTransformerFlushCallback :
@@ -1020,7 +1020,7 @@ namespace TransformerFlushCallback
 
 
 namespace TransformerStartCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toTransformerStartCallback :
@@ -1030,7 +1030,7 @@ namespace TransformerStartCallback
 
 
 namespace TransformerTransformCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a,b)=>x(a,b)()"
   prim__toTransformerTransformCallback :
@@ -1040,7 +1040,7 @@ namespace TransformerTransformCallback
 
 
 namespace UnderlyingSinkAbortCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUnderlyingSinkAbortCallback :
@@ -1050,7 +1050,7 @@ namespace UnderlyingSinkAbortCallback
 
 
 namespace UnderlyingSinkCloseCallback
-
+  
   export
   %foreign "browser:lambda:x=>()=>x()()"
   prim__toUnderlyingSinkCloseCallback :
@@ -1060,7 +1060,7 @@ namespace UnderlyingSinkCloseCallback
 
 
 namespace UnderlyingSinkStartCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUnderlyingSinkStartCallback :
@@ -1070,7 +1070,7 @@ namespace UnderlyingSinkStartCallback
 
 
 namespace UnderlyingSinkWriteCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a,b)=>x(a,b)()"
   prim__toUnderlyingSinkWriteCallback :
@@ -1080,7 +1080,7 @@ namespace UnderlyingSinkWriteCallback
 
 
 namespace UnderlyingSourceCancelCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUnderlyingSourceCancelCallback :
@@ -1090,7 +1090,7 @@ namespace UnderlyingSourceCancelCallback
 
 
 namespace UnderlyingSourcePullCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUnderlyingSourcePullCallback :
@@ -1102,7 +1102,7 @@ namespace UnderlyingSourcePullCallback
 
 
 namespace UnderlyingSourceStartCallback
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toUnderlyingSourceStartCallback :
@@ -1110,3 +1110,5 @@ namespace UnderlyingSourceStartCallback
        -> IO AnyPtr
        )
     -> PrimIO UnderlyingSourceStartCallback
+
+

--- a/src/Web/Internal/StreamsTypes.idr
+++ b/src/Web/Internal/StreamsTypes.idr
@@ -10,62 +10,62 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace ReadableStreamReaderMode
-
+  
   public export
   data ReadableStreamReaderMode = Byob
-
-  public export
+  
+  export
   Show ReadableStreamReaderMode where
     show Byob = "byob"
-
-  public export
+  
+  export
   Eq ReadableStreamReaderMode where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ReadableStreamReaderMode where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ReadableStreamReaderMode
   read "byob" = Just Byob
   read _ = Nothing
-
+  
   export
   ToFFI ReadableStreamReaderMode String where
     toFFI = show
-
+  
   export
   FromFFI ReadableStreamReaderMode String where
     fromFFI = read
 
 
 namespace ReadableStreamType
-
+  
   public export
   data ReadableStreamType = Bytes
-
-  public export
+  
+  export
   Show ReadableStreamType where
     show Bytes = "bytes"
-
-  public export
+  
+  export
   Eq ReadableStreamType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord ReadableStreamType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe ReadableStreamType
   read "bytes" = Just Bytes
   read _ = Nothing
-
+  
   export
   ToFFI ReadableStreamType String where
     toFFI = show
-
+  
   export
   FromFFI ReadableStreamType String where
     fromFFI = read
@@ -438,3 +438,4 @@ ToFFI UnderlyingSourceStartCallback UnderlyingSourceStartCallback where toFFI = 
 
 export
 FromFFI UnderlyingSourceStartCallback UnderlyingSourceStartCallback where fromFFI = Just
+

--- a/src/Web/Internal/SvgPrim.idr
+++ b/src/Web/Internal/SvgPrim.idr
@@ -12,95 +12,95 @@ import Web.Internal.Types
 
 
 namespace SVGAElement
-
+  
   export
   %foreign "browser:lambda:x=>x.download"
   prim__download : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.download = v}"
   prim__setDownload : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hreflang"
   prim__hreflang : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hreflang = v}"
   prim__setHreflang : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ping"
   prim__ping : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ping = v}"
   prim__setPing : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.referrerPolicy"
   prim__referrerPolicy : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.referrerPolicy = v}"
   prim__setReferrerPolicy : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rel"
   prim__rel : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.rel = v}"
   prim__setRel : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relList"
   prim__relList : SVGAElement -> PrimIO DOMTokenList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.target"
   prim__target : SVGAElement -> PrimIO SVGAnimatedString
 
-
+  
   export
   %foreign "browser:lambda:x=>x.text"
   prim__text : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.text = v}"
   prim__setText : SVGAElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : SVGAElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : SVGAElement -> String -> PrimIO ()
@@ -109,53 +109,53 @@ namespace SVGAElement
 
 
 namespace SVGAngle
-
+  
   export
   %foreign "browser:lambda:x=>x.unitType"
   prim__unitType : SVGAngle -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : SVGAngle -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : SVGAngle -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueAsString"
   prim__valueAsString : SVGAngle -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueAsString = v}"
   prim__setValueAsString : SVGAngle -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueInSpecifiedUnits"
   prim__valueInSpecifiedUnits : SVGAngle -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueInSpecifiedUnits = v}"
   prim__setValueInSpecifiedUnits : SVGAngle -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.convertToSpecifiedUnits(a)"
   prim__convertToSpecifiedUnits : SVGAngle -> Bits16 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.newValueSpecifiedUnits(a,b)"
   prim__newValueSpecifiedUnits : SVGAngle -> Bits16 -> Double -> PrimIO ()
@@ -163,12 +163,12 @@ namespace SVGAngle
 
 
 namespace SVGAnimatedAngle
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedAngle -> PrimIO SVGAngle
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedAngle -> PrimIO SVGAngle
@@ -176,18 +176,18 @@ namespace SVGAnimatedAngle
 
 
 namespace SVGAnimatedBoolean
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedBoolean -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedBoolean -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.baseVal = v}"
   prim__setBaseVal : SVGAnimatedBoolean -> Boolean -> PrimIO ()
@@ -196,18 +196,18 @@ namespace SVGAnimatedBoolean
 
 
 namespace SVGAnimatedEnumeration
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedEnumeration -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedEnumeration -> PrimIO Bits16
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.baseVal = v}"
   prim__setBaseVal : SVGAnimatedEnumeration -> Bits16 -> PrimIO ()
@@ -216,18 +216,18 @@ namespace SVGAnimatedEnumeration
 
 
 namespace SVGAnimatedInteger
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedInteger -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedInteger -> PrimIO Int32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.baseVal = v}"
   prim__setBaseVal : SVGAnimatedInteger -> Int32 -> PrimIO ()
@@ -236,12 +236,12 @@ namespace SVGAnimatedInteger
 
 
 namespace SVGAnimatedLength
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedLength -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedLength -> PrimIO SVGLength
@@ -249,12 +249,12 @@ namespace SVGAnimatedLength
 
 
 namespace SVGAnimatedLengthList
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedLengthList -> PrimIO SVGLengthList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedLengthList -> PrimIO SVGLengthList
@@ -262,18 +262,18 @@ namespace SVGAnimatedLengthList
 
 
 namespace SVGAnimatedNumber
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedNumber -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedNumber -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.baseVal = v}"
   prim__setBaseVal : SVGAnimatedNumber -> Double -> PrimIO ()
@@ -282,12 +282,12 @@ namespace SVGAnimatedNumber
 
 
 namespace SVGAnimatedNumberList
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedNumberList -> PrimIO SVGNumberList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedNumberList -> PrimIO SVGNumberList
@@ -295,14 +295,14 @@ namespace SVGAnimatedNumberList
 
 
 namespace SVGAnimatedPreserveAspectRatio
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal :
        SVGAnimatedPreserveAspectRatio
     -> PrimIO SVGPreserveAspectRatio
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal :
@@ -312,12 +312,12 @@ namespace SVGAnimatedPreserveAspectRatio
 
 
 namespace SVGAnimatedRect
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedRect -> PrimIO DOMRectReadOnly
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedRect -> PrimIO DOMRect
@@ -325,18 +325,18 @@ namespace SVGAnimatedRect
 
 
 namespace SVGAnimatedString
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedString -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedString -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.baseVal = v}"
   prim__setBaseVal : SVGAnimatedString -> String -> PrimIO ()
@@ -345,12 +345,12 @@ namespace SVGAnimatedString
 
 
 namespace SVGAnimatedTransformList
-
+  
   export
   %foreign "browser:lambda:x=>x.animVal"
   prim__animVal : SVGAnimatedTransformList -> PrimIO SVGTransformList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.baseVal"
   prim__baseVal : SVGAnimatedTransformList -> PrimIO SVGTransformList
@@ -358,17 +358,17 @@ namespace SVGAnimatedTransformList
 
 
 namespace SVGCircleElement
-
+  
   export
   %foreign "browser:lambda:x=>x.cx"
   prim__cx : SVGCircleElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cy"
   prim__cy : SVGCircleElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.r"
   prim__r : SVGCircleElement -> PrimIO SVGAnimatedLength
@@ -378,17 +378,17 @@ namespace SVGCircleElement
 
 
 namespace SVGElement
-
+  
   export
   %foreign "browser:lambda:x=>x.className"
   prim__className : SVGElement -> PrimIO SVGAnimatedString
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ownerSVGElement"
   prim__ownerSVGElement : SVGElement -> PrimIO (Nullable SVGSVGElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.viewportElement"
   prim__viewportElement : SVGElement -> PrimIO (Nullable SVGElement)
@@ -396,22 +396,22 @@ namespace SVGElement
 
 
 namespace SVGEllipseElement
-
+  
   export
   %foreign "browser:lambda:x=>x.cx"
   prim__cx : SVGEllipseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cy"
   prim__cy : SVGEllipseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rx"
   prim__rx : SVGEllipseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ry"
   prim__ry : SVGEllipseElement -> PrimIO SVGAnimatedLength
@@ -419,22 +419,22 @@ namespace SVGEllipseElement
 
 
 namespace SVGForeignObjectElement
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGForeignObjectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGForeignObjectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGForeignObjectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGForeignObjectElement -> PrimIO SVGAnimatedLength
@@ -443,22 +443,22 @@ namespace SVGForeignObjectElement
 
 
 namespace SVGGeometryElement
-
+  
   export
   %foreign "browser:lambda:x=>x.pathLength"
   prim__pathLength : SVGGeometryElement -> PrimIO SVGAnimatedNumber
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getPointAtLength(a)"
   prim__getPointAtLength : SVGGeometryElement -> Double -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getTotalLength()"
   prim__getTotalLength : SVGGeometryElement -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isPointInFill(a)"
   prim__isPointInFill :
@@ -466,7 +466,7 @@ namespace SVGGeometryElement
     -> UndefOr DOMPointInit
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isPointInStroke(a)"
   prim__isPointInStroke :
@@ -477,19 +477,19 @@ namespace SVGGeometryElement
 
 
 namespace SVGGradientElement
-
+  
   export
   %foreign "browser:lambda:x=>x.gradientTransform"
   prim__gradientTransform :
        SVGGradientElement
     -> PrimIO SVGAnimatedTransformList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.gradientUnits"
   prim__gradientUnits : SVGGradientElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.spreadMethod"
   prim__spreadMethod : SVGGradientElement -> PrimIO SVGAnimatedEnumeration
@@ -497,12 +497,12 @@ namespace SVGGradientElement
 
 
 namespace SVGGraphicsElement
-
+  
   export
   %foreign "browser:lambda:x=>x.transform"
   prim__transform : SVGGraphicsElement -> PrimIO SVGAnimatedTransformList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getBBox(a)"
   prim__getBBox :
@@ -510,12 +510,12 @@ namespace SVGGraphicsElement
     -> UndefOr SVGBoundingBoxOptions
     -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getCTM()"
   prim__getCTM : SVGGraphicsElement -> PrimIO (Nullable DOMMatrix)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getScreenCTM()"
   prim__getScreenCTM : SVGGraphicsElement -> PrimIO (Nullable DOMMatrix)
@@ -523,41 +523,41 @@ namespace SVGGraphicsElement
 
 
 namespace SVGImageElement
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : SVGImageElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : SVGImageElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGImageElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preserveAspectRatio"
   prim__preserveAspectRatio :
        SVGImageElement
     -> PrimIO SVGAnimatedPreserveAspectRatio
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGImageElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGImageElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGImageElement -> PrimIO SVGAnimatedLength
@@ -565,53 +565,53 @@ namespace SVGImageElement
 
 
 namespace SVGLength
-
+  
   export
   %foreign "browser:lambda:x=>x.unitType"
   prim__unitType : SVGLength -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : SVGLength -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : SVGLength -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueAsString"
   prim__valueAsString : SVGLength -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueAsString = v}"
   prim__setValueAsString : SVGLength -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.valueInSpecifiedUnits"
   prim__valueInSpecifiedUnits : SVGLength -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.valueInSpecifiedUnits = v}"
   prim__setValueInSpecifiedUnits : SVGLength -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.convertToSpecifiedUnits(a)"
   prim__convertToSpecifiedUnits : SVGLength -> Bits16 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.newValueSpecifiedUnits(a,b)"
   prim__newValueSpecifiedUnits : SVGLength -> Bits16 -> Double -> PrimIO ()
@@ -619,42 +619,42 @@ namespace SVGLength
 
 
 namespace SVGLengthList
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : SVGLengthList -> Bits32 -> SVGLength -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SVGLengthList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberOfItems"
   prim__numberOfItems : SVGLengthList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendItem(a)"
   prim__appendItem : SVGLengthList -> SVGLength -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : SVGLengthList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : SVGLengthList -> Bits32 -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.initialize(a)"
   prim__initialize : SVGLengthList -> SVGLength -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertItemBefore(a,b)"
   prim__insertItemBefore :
@@ -663,12 +663,12 @@ namespace SVGLengthList
     -> Bits32
     -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeItem(a)"
   prim__removeItem : SVGLengthList -> Bits32 -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceItem(a,b)"
   prim__replaceItem : SVGLengthList -> SVGLength -> Bits32 -> PrimIO SVGLength
@@ -676,22 +676,22 @@ namespace SVGLengthList
 
 
 namespace SVGLineElement
-
+  
   export
   %foreign "browser:lambda:x=>x.x1"
   prim__x1 : SVGLineElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x2"
   prim__x2 : SVGLineElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y1"
   prim__y1 : SVGLineElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y2"
   prim__y2 : SVGLineElement -> PrimIO SVGAnimatedLength
@@ -699,22 +699,22 @@ namespace SVGLineElement
 
 
 namespace SVGLinearGradientElement
-
+  
   export
   %foreign "browser:lambda:x=>x.x1"
   prim__x1 : SVGLinearGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x2"
   prim__x2 : SVGLinearGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y1"
   prim__y1 : SVGLinearGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y2"
   prim__y2 : SVGLinearGradientElement -> PrimIO SVGAnimatedLength
@@ -722,59 +722,59 @@ namespace SVGLinearGradientElement
 
 
 namespace SVGMarkerElement
-
+  
   export
   %foreign "browser:lambda:x=>x.markerHeight"
   prim__markerHeight : SVGMarkerElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.markerUnits"
   prim__markerUnits : SVGMarkerElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.markerWidth"
   prim__markerWidth : SVGMarkerElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.orient"
   prim__orient : SVGMarkerElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.orient = v}"
   prim__setOrient : SVGMarkerElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.orientAngle"
   prim__orientAngle : SVGMarkerElement -> PrimIO SVGAnimatedAngle
 
-
+  
   export
   %foreign "browser:lambda:x=>x.orientType"
   prim__orientType : SVGMarkerElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.refX"
   prim__refX : SVGMarkerElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.refY"
   prim__refY : SVGMarkerElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setOrientToAngle(a)"
   prim__setOrientToAngle : SVGMarkerElement -> SVGAngle -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.setOrientToAuto()"
   prim__setOrientToAuto : SVGMarkerElement -> PrimIO ()
@@ -783,13 +783,13 @@ namespace SVGMarkerElement
 
 
 namespace SVGNumber
-
+  
   export
   %foreign "browser:lambda:x=>x.value"
   prim__value : SVGNumber -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.value = v}"
   prim__setValue : SVGNumber -> Double -> PrimIO ()
@@ -798,42 +798,42 @@ namespace SVGNumber
 
 
 namespace SVGNumberList
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : SVGNumberList -> Bits32 -> SVGNumber -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SVGNumberList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberOfItems"
   prim__numberOfItems : SVGNumberList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendItem(a)"
   prim__appendItem : SVGNumberList -> SVGNumber -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : SVGNumberList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : SVGNumberList -> Bits32 -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.initialize(a)"
   prim__initialize : SVGNumberList -> SVGNumber -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertItemBefore(a,b)"
   prim__insertItemBefore :
@@ -842,12 +842,12 @@ namespace SVGNumberList
     -> Bits32
     -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeItem(a)"
   prim__removeItem : SVGNumberList -> Bits32 -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceItem(a,b)"
   prim__replaceItem : SVGNumberList -> SVGNumber -> Bits32 -> PrimIO SVGNumber
@@ -856,37 +856,37 @@ namespace SVGNumberList
 
 
 namespace SVGPatternElement
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGPatternElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.patternContentUnits"
   prim__patternContentUnits : SVGPatternElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.patternTransform"
   prim__patternTransform : SVGPatternElement -> PrimIO SVGAnimatedTransformList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.patternUnits"
   prim__patternUnits : SVGPatternElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGPatternElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGPatternElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGPatternElement -> PrimIO SVGAnimatedLength
@@ -894,52 +894,52 @@ namespace SVGPatternElement
 
 
 namespace SVGPointList
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : SVGPointList -> Bits32 -> DOMPoint -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SVGPointList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberOfItems"
   prim__numberOfItems : SVGPointList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendItem(a)"
   prim__appendItem : SVGPointList -> DOMPoint -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : SVGPointList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : SVGPointList -> Bits32 -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.initialize(a)"
   prim__initialize : SVGPointList -> DOMPoint -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertItemBefore(a,b)"
   prim__insertItemBefore : SVGPointList -> DOMPoint -> Bits32 -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeItem(a)"
   prim__removeItem : SVGPointList -> Bits32 -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceItem(a,b)"
   prim__replaceItem : SVGPointList -> DOMPoint -> Bits32 -> PrimIO DOMPoint
@@ -949,25 +949,25 @@ namespace SVGPointList
 
 
 namespace SVGPreserveAspectRatio
-
+  
   export
   %foreign "browser:lambda:x=>x.align"
   prim__align : SVGPreserveAspectRatio -> PrimIO Bits16
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.align = v}"
   prim__setAlign : SVGPreserveAspectRatio -> Bits16 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.meetOrSlice"
   prim__meetOrSlice : SVGPreserveAspectRatio -> PrimIO Bits16
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.meetOrSlice = v}"
   prim__setMeetOrSlice : SVGPreserveAspectRatio -> Bits16 -> PrimIO ()
@@ -976,32 +976,32 @@ namespace SVGPreserveAspectRatio
 
 
 namespace SVGRadialGradientElement
-
+  
   export
   %foreign "browser:lambda:x=>x.cx"
   prim__cx : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.cy"
   prim__cy : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fr"
   prim__fr : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fx"
   prim__fx : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fy"
   prim__fy : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.r"
   prim__r : SVGRadialGradientElement -> PrimIO SVGAnimatedLength
@@ -1009,32 +1009,32 @@ namespace SVGRadialGradientElement
 
 
 namespace SVGRectElement
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGRectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rx"
   prim__rx : SVGRectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ry"
   prim__ry : SVGRectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGRectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGRectElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGRectElement -> PrimIO SVGAnimatedLength
@@ -1042,44 +1042,44 @@ namespace SVGRectElement
 
 
 namespace SVGSVGElement
-
+  
   export
   %foreign "browser:lambda:x=>x.currentScale"
   prim__currentScale : SVGSVGElement -> PrimIO Double
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.currentScale = v}"
   prim__setCurrentScale : SVGSVGElement -> Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.currentTranslate"
   prim__currentTranslate : SVGSVGElement -> PrimIO DOMPointReadOnly
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGSVGElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGSVGElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGSVGElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGSVGElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.checkEnclosure(a,b)"
   prim__checkEnclosure :
@@ -1088,7 +1088,7 @@ namespace SVGSVGElement
     -> DOMRectReadOnly
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.checkIntersection(a,b)"
   prim__checkIntersection :
@@ -1097,37 +1097,37 @@ namespace SVGSVGElement
     -> DOMRectReadOnly
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGAngle()"
   prim__createSVGAngle : SVGSVGElement -> PrimIO SVGAngle
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGLength()"
   prim__createSVGLength : SVGSVGElement -> PrimIO SVGLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGMatrix()"
   prim__createSVGMatrix : SVGSVGElement -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGNumber()"
   prim__createSVGNumber : SVGSVGElement -> PrimIO SVGNumber
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGPoint()"
   prim__createSVGPoint : SVGSVGElement -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGRect()"
   prim__createSVGRect : SVGSVGElement -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createSVGTransformFromMatrix(a)"
   prim__createSVGTransformFromMatrix :
@@ -1135,27 +1135,27 @@ namespace SVGSVGElement
     -> UndefOr DOMMatrix2DInit
     -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSVGTransform()"
   prim__createSVGTransform : SVGSVGElement -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deselectAll()"
   prim__deselectAll : SVGSVGElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.forceRedraw()"
   prim__forceRedraw : SVGSVGElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getElementById(a)"
   prim__getElementById : SVGSVGElement -> String -> PrimIO Element
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getEnclosureList(a,b)"
   prim__getEnclosureList :
@@ -1164,7 +1164,7 @@ namespace SVGSVGElement
     -> Nullable SVGElement
     -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getIntersectionList(a,b)"
   prim__getIntersectionList :
@@ -1173,17 +1173,17 @@ namespace SVGSVGElement
     -> Nullable SVGElement
     -> PrimIO NodeList
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.suspendRedraw(a)"
   prim__suspendRedraw : SVGSVGElement -> Bits32 -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.unsuspendRedrawAll()"
   prim__unsuspendRedrawAll : SVGSVGElement -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.unsuspendRedraw(a)"
   prim__unsuspendRedraw : SVGSVGElement -> Bits32 -> PrimIO ()
@@ -1191,25 +1191,25 @@ namespace SVGSVGElement
 
 
 namespace SVGScriptElement
-
+  
   export
   %foreign "browser:lambda:x=>x.crossOrigin"
   prim__crossOrigin : SVGScriptElement -> PrimIO (Nullable String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.crossOrigin = v}"
   prim__setCrossOrigin : SVGScriptElement -> Nullable String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : SVGScriptElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : SVGScriptElement -> String -> PrimIO ()
@@ -1218,7 +1218,7 @@ namespace SVGScriptElement
 
 
 namespace SVGStopElement
-
+  
   export
   %foreign "browser:lambda:x=>x.offset"
   prim__offset : SVGStopElement -> PrimIO SVGAnimatedNumber
@@ -1226,52 +1226,52 @@ namespace SVGStopElement
 
 
 namespace SVGStringList
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : SVGStringList -> Bits32 -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SVGStringList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberOfItems"
   prim__numberOfItems : SVGStringList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendItem(a)"
   prim__appendItem : SVGStringList -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : SVGStringList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : SVGStringList -> Bits32 -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.initialize(a)"
   prim__initialize : SVGStringList -> String -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertItemBefore(a,b)"
   prim__insertItemBefore : SVGStringList -> String -> Bits32 -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeItem(a)"
   prim__removeItem : SVGStringList -> Bits32 -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceItem(a,b)"
   prim__replaceItem : SVGStringList -> String -> Bits32 -> PrimIO String
@@ -1279,37 +1279,37 @@ namespace SVGStringList
 
 
 namespace SVGStyleElement
-
+  
   export
   %foreign "browser:lambda:x=>x.media"
   prim__media : SVGStyleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.media = v}"
   prim__setMedia : SVGStyleElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.title"
   prim__title : SVGStyleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.title = v}"
   prim__setTitle : SVGStyleElement -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : SVGStyleElement -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.type = v}"
   prim__setType : SVGStyleElement -> String -> PrimIO ()
@@ -1321,17 +1321,17 @@ namespace SVGStyleElement
 
 
 namespace SVGTextContentElement
-
+  
   export
   %foreign "browser:lambda:x=>x.lengthAdjust"
   prim__lengthAdjust : SVGTextContentElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.textLength"
   prim__textLength : SVGTextContentElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getCharNumAtPosition(a)"
   prim__getCharNumAtPosition :
@@ -1339,12 +1339,12 @@ namespace SVGTextContentElement
     -> UndefOr DOMPointInit
     -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getComputedTextLength()"
   prim__getComputedTextLength : SVGTextContentElement -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getEndPositionOfChar(a)"
   prim__getEndPositionOfChar :
@@ -1352,22 +1352,22 @@ namespace SVGTextContentElement
     -> Bits32
     -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getExtentOfChar(a)"
   prim__getExtentOfChar : SVGTextContentElement -> Bits32 -> PrimIO DOMRect
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getNumberOfChars()"
   prim__getNumberOfChars : SVGTextContentElement -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getRotationOfChar(a)"
   prim__getRotationOfChar : SVGTextContentElement -> Bits32 -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getStartPositionOfChar(a)"
   prim__getStartPositionOfChar :
@@ -1375,7 +1375,7 @@ namespace SVGTextContentElement
     -> Bits32
     -> PrimIO DOMPoint
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getSubStringLength(a,b)"
   prim__getSubStringLength :
@@ -1384,7 +1384,7 @@ namespace SVGTextContentElement
     -> Bits32
     -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.selectSubString(a,b)"
   prim__selectSubString : SVGTextContentElement -> Bits32 -> Bits32 -> PrimIO ()
@@ -1393,17 +1393,17 @@ namespace SVGTextContentElement
 
 
 namespace SVGTextPathElement
-
+  
   export
   %foreign "browser:lambda:x=>x.method"
   prim__method : SVGTextPathElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.spacing"
   prim__spacing : SVGTextPathElement -> PrimIO SVGAnimatedEnumeration
 
-
+  
   export
   %foreign "browser:lambda:x=>x.startOffset"
   prim__startOffset : SVGTextPathElement -> PrimIO SVGAnimatedLength
@@ -1411,27 +1411,27 @@ namespace SVGTextPathElement
 
 
 namespace SVGTextPositioningElement
-
+  
   export
   %foreign "browser:lambda:x=>x.dx"
   prim__dx : SVGTextPositioningElement -> PrimIO SVGAnimatedLengthList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.dy"
   prim__dy : SVGTextPositioningElement -> PrimIO SVGAnimatedLengthList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rotate"
   prim__rotate : SVGTextPositioningElement -> PrimIO SVGAnimatedNumberList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGTextPositioningElement -> PrimIO SVGAnimatedLengthList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGTextPositioningElement -> PrimIO SVGAnimatedLengthList
@@ -1440,47 +1440,47 @@ namespace SVGTextPositioningElement
 
 
 namespace SVGTransform
-
+  
   export
   %foreign "browser:lambda:x=>x.angle"
   prim__angle : SVGTransform -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.matrix"
   prim__matrix : SVGTransform -> PrimIO DOMMatrix
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : SVGTransform -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setMatrix(a)"
   prim__setMatrix : SVGTransform -> UndefOr DOMMatrix2DInit -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.setRotate(a,b,c)"
   prim__setRotate : SVGTransform -> Double -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setScale(a,b)"
   prim__setScale : SVGTransform -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setSkewX(a)"
   prim__setSkewX : SVGTransform -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.setSkewY(a)"
   prim__setSkewY : SVGTransform -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setTranslate(a,b)"
   prim__setTranslate : SVGTransform -> Double -> Double -> PrimIO ()
@@ -1488,37 +1488,37 @@ namespace SVGTransform
 
 
 namespace SVGTransformList
-
+  
   export
   %foreign "browser:lambda:(o,x,v)=>o[x] = v"
   prim__set : SVGTransformList -> Bits32 -> SVGTransform -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.length"
   prim__length : SVGTransformList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.numberOfItems"
   prim__numberOfItems : SVGTransformList -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.appendItem(a)"
   prim__appendItem : SVGTransformList -> SVGTransform -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clear()"
   prim__clear : SVGTransformList -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.consolidate()"
   prim__consolidate : SVGTransformList -> PrimIO (Nullable SVGTransform)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createSVGTransformFromMatrix(a)"
   prim__createSVGTransformFromMatrix :
@@ -1526,17 +1526,17 @@ namespace SVGTransformList
     -> UndefOr DOMMatrix2DInit
     -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getItem(a)"
   prim__getItem : SVGTransformList -> Bits32 -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.initialize(a)"
   prim__initialize : SVGTransformList -> SVGTransform -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.insertItemBefore(a,b)"
   prim__insertItemBefore :
@@ -1545,12 +1545,12 @@ namespace SVGTransformList
     -> Bits32
     -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.removeItem(a)"
   prim__removeItem : SVGTransformList -> Bits32 -> PrimIO SVGTransform
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.replaceItem(a,b)"
   prim__replaceItem :
@@ -1563,32 +1563,32 @@ namespace SVGTransformList
 
 
 namespace SVGUseElement
-
+  
   export
   %foreign "browser:lambda:x=>x.animatedInstanceRoot"
   prim__animatedInstanceRoot : SVGUseElement -> PrimIO (Nullable SVGElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.height"
   prim__height : SVGUseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.instanceRoot"
   prim__instanceRoot : SVGUseElement -> PrimIO (Nullable SVGElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.width"
   prim__width : SVGUseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : SVGUseElement -> PrimIO SVGAnimatedLength
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : SVGUseElement -> PrimIO SVGAnimatedLength
@@ -1598,12 +1598,12 @@ namespace SVGUseElement
 
 
 namespace ShadowAnimation
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ShadowAnimation(a,b)"
   prim__new : Animation -> Animatable -> PrimIO ShadowAnimation
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sourceAnimation"
   prim__sourceAnimation : ShadowAnimation -> PrimIO Animation
@@ -1616,7 +1616,7 @@ namespace ShadowAnimation
 --------------------------------------------------------------------------------
 
 namespace GetSVGDocument
-
+  
   export
   %foreign "browser:lambda:x=>x.getSVGDocument()"
   prim__getSVGDocument : GetSVGDocument -> PrimIO Document
@@ -1624,12 +1624,12 @@ namespace GetSVGDocument
 
 
 namespace SVGAnimatedPoints
-
+  
   export
   %foreign "browser:lambda:x=>x.animatedPoints"
   prim__animatedPoints : SVGAnimatedPoints -> PrimIO SVGPointList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.points"
   prim__points : SVGAnimatedPoints -> PrimIO SVGPointList
@@ -1637,14 +1637,14 @@ namespace SVGAnimatedPoints
 
 
 namespace SVGElementInstance
-
+  
   export
   %foreign "browser:lambda:x=>x.correspondingElement"
   prim__correspondingElement :
        SVGElementInstance
     -> PrimIO (Nullable SVGElement)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.correspondingUseElement"
   prim__correspondingUseElement :
@@ -1654,14 +1654,14 @@ namespace SVGElementInstance
 
 
 namespace SVGFitToViewBox
-
+  
   export
   %foreign "browser:lambda:x=>x.preserveAspectRatio"
   prim__preserveAspectRatio :
        SVGFitToViewBox
     -> PrimIO SVGAnimatedPreserveAspectRatio
 
-
+  
   export
   %foreign "browser:lambda:x=>x.viewBox"
   prim__viewBox : SVGFitToViewBox -> PrimIO SVGAnimatedRect
@@ -1669,12 +1669,12 @@ namespace SVGFitToViewBox
 
 
 namespace SVGTests
-
+  
   export
   %foreign "browser:lambda:x=>x.requiredExtensions"
   prim__requiredExtensions : SVGTests -> PrimIO SVGStringList
 
-
+  
   export
   %foreign "browser:lambda:x=>x.systemLanguage"
   prim__systemLanguage : SVGTests -> PrimIO SVGStringList
@@ -1682,7 +1682,7 @@ namespace SVGTests
 
 
 namespace SVGURIReference
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : SVGURIReference -> PrimIO SVGAnimatedString
@@ -1695,7 +1695,7 @@ namespace SVGURIReference
 --------------------------------------------------------------------------------
 
 namespace SVGBoundingBoxOptions
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({fill: a,stroke: b,markers: c,clipped: d})"
   prim__new :
@@ -1705,49 +1705,53 @@ namespace SVGBoundingBoxOptions
     -> UndefOr Boolean
     -> PrimIO SVGBoundingBoxOptions
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clipped"
   prim__clipped : SVGBoundingBoxOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clipped = v}"
   prim__setClipped : SVGBoundingBoxOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.fill"
   prim__fill : SVGBoundingBoxOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.fill = v}"
   prim__setFill : SVGBoundingBoxOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.markers"
   prim__markers : SVGBoundingBoxOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.markers = v}"
   prim__setMarkers : SVGBoundingBoxOptions -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stroke"
   prim__stroke : SVGBoundingBoxOptions -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.stroke = v}"
   prim__setStroke : SVGBoundingBoxOptions -> UndefOr Boolean -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/SvgTypes.idr
+++ b/src/Web/Internal/SvgTypes.idr
@@ -819,3 +819,5 @@ ToFFI SVGURIReference SVGURIReference where toFFI = id
 
 export
 FromFFI SVGURIReference SVGURIReference where fromFFI = Just
+
+

--- a/src/Web/Internal/Types.idr
+++ b/src/Web/Internal/Types.idr
@@ -31,5030 +31,10562 @@ import public Web.Internal.XhrTypes as Types
 --          Inheritance
 --------------------------------------------------------------------------------
 
-public export
-JSType AbortController where
-  parents = [Object]
+export %inline
+Cast AbortController Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast AbortSignal EventTarget where cast = believe_me
 
-public export
-JSType AbortSignal where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast AbortSignal Object where cast = believe_me
 
 
-public export
-JSType AbstractRange where
-  parents = [Object]
+export %inline
+Cast AbstractRange Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Animation EventTarget where cast = believe_me
 
-public export
-JSType Animation where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast Animation Object where cast = believe_me
 
 
-public export
-JSType AnimationEffect where
-  parents = [Object]
+export %inline
+Cast AnimationEffect Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast AnimationPlaybackEvent Event where cast = believe_me
 
-public export
-JSType AnimationPlaybackEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast AnimationPlaybackEvent Object where cast = believe_me
 
 
-public export
-JSType AnimationTimeline where
-  parents = [Object]
+export %inline
+Cast AnimationTimeline Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Attr Node where cast = believe_me
 
-public export
-JSType Attr where
-  parents = [Node, EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast Attr EventTarget where cast = believe_me
 
 
-public export
-JSType AudioTrack where
-  parents = [Object]
+export %inline
+Cast Attr Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast AudioTrack Object where cast = believe_me
 
-public export
-JSType AudioTrackList where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast AudioTrackList EventTarget where cast = believe_me
 
 
-public export
-JSType BarProp where
-  parents = [Object]
+export %inline
+Cast AudioTrackList Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast BarProp Object where cast = believe_me
 
-public export
-JSType BeforeUnloadEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast BeforeUnloadEvent Event where cast = believe_me
 
 
-public export
-JSType Blob where
-  parents = [Object]
+export %inline
+Cast BeforeUnloadEvent Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Blob Object where cast = believe_me
 
-public export
-JSType BroadcastChannel where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast BroadcastChannel EventTarget where cast = believe_me
 
 
-public export
-JSType ByteLengthQueuingStrategy where
-  parents = [Object]
+export %inline
+Cast BroadcastChannel Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast ByteLengthQueuingStrategy Object where cast = believe_me
 
-public export
-JSType CDATASection where
-  parents = [Text, CharacterData, Node, EventTarget, Object]
 
-  mixins = [ChildNode, GeometryUtils, NonDocumentTypeChildNode, Slottable]
+export %inline
+Cast CDATASection Text where cast = believe_me
 
 
-public export
-JSType CSSGroupingRule where
-  parents = [CSSRule, Object]
+export %inline
+Cast CDATASection CharacterData where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CDATASection Node where cast = believe_me
 
-public export
-JSType CSSImportRule where
-  parents = [CSSRule, Object]
 
-  mixins = []
+export %inline
+Cast CDATASection EventTarget where cast = believe_me
 
 
-public export
-JSType CSSMarginRule where
-  parents = [CSSRule, Object]
+export %inline
+Cast CDATASection Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CDATASection ChildNode where cast = believe_me
 
-public export
-JSType CSSNamespaceRule where
-  parents = [CSSRule, Object]
 
-  mixins = []
+export %inline
+Cast CDATASection GeometryUtils where cast = believe_me
 
 
-public export
-JSType CSSPageRule where
-  parents = [CSSGroupingRule, CSSRule, Object]
+export %inline
+Cast CDATASection NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CDATASection Slottable where cast = believe_me
 
-public export
-JSType CSSPseudoElement where
-  parents = [EventTarget, Object]
 
-  mixins = [Animatable, GeometryUtils]
+export %inline
+Cast CSSGroupingRule CSSRule where cast = believe_me
 
 
-public export
-JSType CSSRule where
-  parents = [Object]
+export %inline
+Cast CSSGroupingRule Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSImportRule CSSRule where cast = believe_me
 
-public export
-JSType CSSRuleList where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CSSImportRule Object where cast = believe_me
 
 
-public export
-JSType CSSStyleDeclaration where
-  parents = [Object]
+export %inline
+Cast CSSMarginRule CSSRule where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSMarginRule Object where cast = believe_me
 
-public export
-JSType CSSStyleRule where
-  parents = [CSSRule, Object]
 
-  mixins = []
+export %inline
+Cast CSSNamespaceRule CSSRule where cast = believe_me
 
 
-public export
-JSType CSSStyleSheet where
-  parents = [StyleSheet, Object]
+export %inline
+Cast CSSNamespaceRule Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSPageRule CSSGroupingRule where cast = believe_me
 
-public export
-JSType Cache where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CSSPageRule CSSRule where cast = believe_me
 
 
-public export
-JSType CacheStorage where
-  parents = [Object]
+export %inline
+Cast CSSPageRule Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSPseudoElement EventTarget where cast = believe_me
 
-public export
-JSType CanvasGradient where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CSSPseudoElement Object where cast = believe_me
 
 
-public export
-JSType CanvasPattern where
-  parents = [Object]
+export %inline
+Cast CSSPseudoElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSPseudoElement GeometryUtils where cast = believe_me
 
-public export
-JSType CanvasRenderingContext2D where
-  parents = [Object]
 
-  mixins =
-    [ CanvasCompositing
-    , CanvasDrawImage
-    , CanvasDrawPath
-    , CanvasFillStrokeStyles
-    , CanvasFilters
-    , CanvasImageData
-    , CanvasImageSmoothing
-    , CanvasPath
-    , CanvasPathDrawingStyles
-    , CanvasRect
-    , CanvasShadowStyles
-    , CanvasState
-    , CanvasText
-    , CanvasTextDrawingStyles
-    , CanvasTransform
-    , CanvasUserInterface
-    ]
+export %inline
+Cast CSSRule Object where cast = believe_me
 
 
-public export
-JSType CaretPosition where
-  parents = [Object]
+export %inline
+Cast CSSRuleList Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSStyleDeclaration Object where cast = believe_me
 
-public export
-JSType CharacterData where
-  parents = [Node, EventTarget, Object]
 
-  mixins = [ChildNode, NonDocumentTypeChildNode]
+export %inline
+Cast CSSStyleRule CSSRule where cast = believe_me
 
 
-public export
-JSType Client where
-  parents = [Object]
+export %inline
+Cast CSSStyleRule Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CSSStyleSheet StyleSheet where cast = believe_me
 
-public export
-JSType Clients where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CSSStyleSheet Object where cast = believe_me
 
 
-public export
-JSType Clipboard where
-  parents = [EventTarget, Object]
+export %inline
+Cast Cache Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CacheStorage Object where cast = believe_me
 
-public export
-JSType ClipboardEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast CanvasGradient Object where cast = believe_me
 
 
-public export
-JSType ClipboardItem where
-  parents = [Object]
+export %inline
+Cast CanvasPattern Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CanvasRenderingContext2D Object where cast = believe_me
 
-public export
-JSType CloseEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasCompositing where cast = believe_me
 
 
-public export
-JSType Comment where
-  parents = [CharacterData, Node, EventTarget, Object]
+export %inline
+Cast CanvasRenderingContext2D CanvasDrawImage where cast = believe_me
 
-  mixins = [ChildNode, NonDocumentTypeChildNode]
 
+export %inline
+Cast CanvasRenderingContext2D CanvasDrawPath where cast = believe_me
 
-public export
-JSType CompositionEvent where
-  parents = [UIEvent, Event, Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasFillStrokeStyles where cast = believe_me
 
 
-public export
-JSType ConstrainablePattern where
-  parents = [Object]
+export %inline
+Cast CanvasRenderingContext2D CanvasFilters where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CanvasRenderingContext2D CanvasImageData where cast = believe_me
 
-public export
-JSType CountQueuingStrategy where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasImageSmoothing where cast = believe_me
 
 
-public export
-JSType CustomElementRegistry where
-  parents = [Object]
+export %inline
+Cast CanvasRenderingContext2D CanvasPath where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CanvasRenderingContext2D CanvasPathDrawingStyles where cast = believe_me
 
-public export
-JSType CustomEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasRect where cast = believe_me
 
 
-public export
-JSType DOMException where
-  parents = [Object]
+export %inline
+Cast CanvasRenderingContext2D CanvasShadowStyles where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CanvasRenderingContext2D CanvasState where cast = believe_me
 
-public export
-JSType DOMImplementation where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasText where cast = believe_me
 
 
-public export
-JSType DOMMatrix where
-  parents = [DOMMatrixReadOnly, Object]
+export %inline
+Cast CanvasRenderingContext2D CanvasTextDrawingStyles where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CanvasRenderingContext2D CanvasTransform where cast = believe_me
 
-public export
-JSType DOMMatrixReadOnly where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CanvasRenderingContext2D CanvasUserInterface where cast = believe_me
 
 
-public export
-JSType DOMParser where
-  parents = [Object]
+export %inline
+Cast CaretPosition Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CharacterData Node where cast = believe_me
 
-public export
-JSType DOMPoint where
-  parents = [DOMPointReadOnly, Object]
 
-  mixins = []
+export %inline
+Cast CharacterData EventTarget where cast = believe_me
 
 
-public export
-JSType DOMPointReadOnly where
-  parents = [Object]
+export %inline
+Cast CharacterData Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CharacterData ChildNode where cast = believe_me
 
-public export
-JSType DOMQuad where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CharacterData NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType DOMRect where
-  parents = [DOMRectReadOnly, Object]
+export %inline
+Cast Client Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Clients Object where cast = believe_me
 
-public export
-JSType DOMRectList where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast Clipboard EventTarget where cast = believe_me
 
 
-public export
-JSType DOMRectReadOnly where
-  parents = [Object]
+export %inline
+Cast Clipboard Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast ClipboardEvent Event where cast = believe_me
 
-public export
-JSType DOMStringList where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast ClipboardEvent Object where cast = believe_me
 
 
-public export
-JSType DOMStringMap where
-  parents = [Object]
+export %inline
+Cast ClipboardItem Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CloseEvent Event where cast = believe_me
 
-public export
-JSType DOMTokenList where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast CloseEvent Object where cast = believe_me
 
 
-public export
-JSType DataTransfer where
-  parents = [Object]
+export %inline
+Cast Comment CharacterData where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Comment Node where cast = believe_me
 
-public export
-JSType DataTransferItem where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast Comment EventTarget where cast = believe_me
 
 
-public export
-JSType DataTransferItemList where
-  parents = [Object]
+export %inline
+Cast Comment Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Comment ChildNode where cast = believe_me
 
-public export
-JSType DedicatedWorkerGlobalScope where
-  parents = [WorkerGlobalScope, EventTarget, Object]
 
-  mixins = [WindowOrWorkerGlobalScope]
+export %inline
+Cast Comment NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType Document where
-  parents = [Node, EventTarget, Object]
+export %inline
+Cast CompositionEvent UIEvent where cast = believe_me
 
-  mixins =
-    [ DocumentAndElementEventHandlers
-    , DocumentOrShadowRoot
-    , GeometryUtils
-    , GlobalEventHandlers
-    , NonElementParentNode
-    , ParentNode
-    , XPathEvaluatorBase
-    ]
 
+export %inline
+Cast CompositionEvent Event where cast = believe_me
 
-public export
-JSType DocumentFragment where
-  parents = [Node, EventTarget, Object]
 
-  mixins = [NonElementParentNode, ParentNode]
+export %inline
+Cast CompositionEvent Object where cast = believe_me
 
 
-public export
-JSType DocumentTimeline where
-  parents = [AnimationTimeline, Object]
+export %inline
+Cast ConstrainablePattern Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CountQueuingStrategy Object where cast = believe_me
 
-public export
-JSType DocumentType where
-  parents = [Node, EventTarget, Object]
 
-  mixins = [ChildNode]
+export %inline
+Cast CustomElementRegistry Object where cast = believe_me
 
 
-public export
-JSType DragEvent where
-  parents = [MouseEvent, UIEvent, Event, Object]
+export %inline
+Cast CustomEvent Event where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast CustomEvent Object where cast = believe_me
 
-public export
-JSType Element where
-  parents = [Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , GeometryUtils
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast DOMException Object where cast = believe_me
 
 
-public export
-JSType ElementInternals where
-  parents = [Object]
+export %inline
+Cast DOMImplementation Object where cast = believe_me
 
-  mixins = [ARIAMixin]
 
+export %inline
+Cast DOMMatrix DOMMatrixReadOnly where cast = believe_me
 
-public export
-JSType ErrorEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast DOMMatrix Object where cast = believe_me
 
 
-public export
-JSType Event where
-  parents = [Object]
+export %inline
+Cast DOMMatrixReadOnly Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DOMParser Object where cast = believe_me
 
-public export
-JSType EventSource where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast DOMPoint DOMPointReadOnly where cast = believe_me
 
 
-public export
-JSType EventTarget where
-  parents = [Object]
+export %inline
+Cast DOMPoint Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DOMPointReadOnly Object where cast = believe_me
 
-public export
-JSType ExtendableEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast DOMQuad Object where cast = believe_me
 
 
-public export
-JSType ExtendableMessageEvent where
-  parents = [ExtendableEvent, Event, Object]
+export %inline
+Cast DOMRect DOMRectReadOnly where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DOMRect Object where cast = believe_me
 
-public export
-JSType External where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast DOMRectList Object where cast = believe_me
 
 
-public export
-JSType FetchEvent where
-  parents = [ExtendableEvent, Event, Object]
+export %inline
+Cast DOMRectReadOnly Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DOMStringList Object where cast = believe_me
 
-public export
-JSType File where
-  parents = [Blob, Object]
 
-  mixins = []
+export %inline
+Cast DOMStringMap Object where cast = believe_me
 
 
-public export
-JSType FileList where
-  parents = [Object]
+export %inline
+Cast DOMTokenList Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DataTransfer Object where cast = believe_me
 
-public export
-JSType FileReader where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast DataTransferItem Object where cast = believe_me
 
 
-public export
-JSType FileReaderSync where
-  parents = [Object]
+export %inline
+Cast DataTransferItemList Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DedicatedWorkerGlobalScope WorkerGlobalScope where cast = believe_me
 
-public export
-JSType FocusEvent where
-  parents = [UIEvent, Event, Object]
 
-  mixins = []
+export %inline
+Cast DedicatedWorkerGlobalScope EventTarget where cast = believe_me
 
 
-public export
-JSType FormData where
-  parents = [Object]
+export %inline
+Cast DedicatedWorkerGlobalScope Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast DedicatedWorkerGlobalScope WindowOrWorkerGlobalScope where cast = believe_me
 
-public export
-JSType FormDataEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast Document Node where cast = believe_me
 
 
-public export
-JSType HTMLAllCollection where
-  parents = [Object]
+export %inline
+Cast Document EventTarget where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast Document Object where cast = believe_me
 
-public export
-JSType HTMLAnchorElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLHyperlinkElementUtils
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Document DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType HTMLAreaElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Document DocumentOrShadowRoot where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLHyperlinkElementUtils
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast Document GeometryUtils where cast = believe_me
 
-public export
-JSType HTMLAudioElement where
-  parents = [HTMLMediaElement, HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Document GlobalEventHandlers where cast = believe_me
 
 
-public export
-JSType HTMLBRElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Document NonElementParentNode where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast Document ParentNode where cast = believe_me
 
-public export
-JSType HTMLBaseElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Document XPathEvaluatorBase where cast = believe_me
 
 
-public export
-JSType HTMLBodyElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast DocumentFragment Node where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    , WindowEventHandlers
-    ]
 
+export %inline
+Cast DocumentFragment EventTarget where cast = believe_me
 
-public export
-JSType HTMLButtonElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast DocumentFragment Object where cast = believe_me
 
 
-public export
-JSType HTMLCanvasElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast DocumentFragment NonElementParentNode where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast DocumentFragment ParentNode where cast = believe_me
 
-public export
-JSType HTMLCollection where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast DocumentTimeline AnimationTimeline where cast = believe_me
 
 
-public export
-JSType HTMLDListElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast DocumentTimeline Object where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast DocumentType Node where cast = believe_me
 
-public export
-JSType HTMLDataElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast DocumentType EventTarget where cast = believe_me
 
 
-public export
-JSType HTMLDataListElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast DocumentType Object where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast DocumentType ChildNode where cast = believe_me
 
-public export
-JSType HTMLDetailsElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast DragEvent MouseEvent where cast = believe_me
 
 
-public export
-JSType HTMLDialogElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast DragEvent UIEvent where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast DragEvent Event where cast = believe_me
 
-public export
-JSType HTMLDirectoryElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast DragEvent Object where cast = believe_me
 
 
-public export
-JSType HTMLDivElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Element Node where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast Element EventTarget where cast = believe_me
 
-public export
-JSType HTMLElement where
-  parents = [Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Element Object where cast = believe_me
 
 
-public export
-JSType HTMLEmbedElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Element Animatable where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast Element ChildNode where cast = believe_me
 
-public export
-JSType HTMLFieldSetElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Element GeometryUtils where cast = believe_me
 
 
-public export
-JSType HTMLFontElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Element InnerHTML where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast Element NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType HTMLFormControlsCollection where
-  parents = [HTMLCollection, Object]
 
-  mixins = []
+export %inline
+Cast Element ParentNode where cast = believe_me
 
 
-public export
-JSType HTMLFormElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast Element Slottable where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast ElementInternals Object where cast = believe_me
 
-public export
-JSType HTMLFrameElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast ElementInternals ARIAMixin where cast = believe_me
 
 
-public export
-JSType HTMLFrameSetElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast ErrorEvent Event where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    , WindowEventHandlers
-    ]
 
+export %inline
+Cast ErrorEvent Object where cast = believe_me
 
-public export
-JSType HTMLHRElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast Event Object where cast = believe_me
 
 
-public export
-JSType HTMLHeadElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast EventSource EventTarget where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast EventSource Object where cast = believe_me
 
-public export
-JSType HTMLHeadingElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast EventTarget Object where cast = believe_me
 
 
-public export
-JSType HTMLHtmlElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast ExtendableEvent Event where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast ExtendableEvent Object where cast = believe_me
 
-public export
-JSType HTMLIFrameElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast ExtendableMessageEvent ExtendableEvent where cast = believe_me
 
 
-public export
-JSType HTMLImageElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast ExtendableMessageEvent Event where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast ExtendableMessageEvent Object where cast = believe_me
 
-public export
-JSType HTMLInputElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast External Object where cast = believe_me
 
 
-public export
-JSType HTMLLIElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast FetchEvent ExtendableEvent where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast FetchEvent Event where cast = believe_me
 
-public export
-JSType HTMLLabelElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast FetchEvent Object where cast = believe_me
 
 
-public export
-JSType HTMLLegendElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast File Blob where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast File Object where cast = believe_me
 
-public export
-JSType HTMLLinkElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , LinkStyle
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast FileList Object where cast = believe_me
 
 
-public export
-JSType HTMLMapElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast FileReader EventTarget where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast FileReader Object where cast = believe_me
 
-public export
-JSType HTMLMarqueeElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
+export %inline
+Cast FileReaderSync Object where cast = believe_me
 
 
-public export
-JSType HTMLMediaElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
+export %inline
+Cast FocusEvent UIEvent where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
 
+export %inline
+Cast FocusEvent Event where cast = believe_me
 
-public export
-JSType HTMLMenuElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
+export %inline
+Cast FocusEvent Object where cast = believe_me
 
-public export
-JSType HTMLMetaElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLMeterElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLModElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLOListElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLObjectElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLOptGroupElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLOptionElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLOptionsCollection where
-  parents = [HTMLCollection, Object]
-
-  mixins = []
-
-
-public export
-JSType HTMLOutputElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLParagraphElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLParamElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLPictureElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLPreElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLProgressElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLQuoteElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLScriptElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLSelectElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLSlotElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLSourceElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLSpanElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLStyleElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , LinkStyle
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableCaptionElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableCellElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableColElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableRowElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTableSectionElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTemplateElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTextAreaElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTimeElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTitleElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLTrackElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLUListElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLUnknownElement where
-  parents = [HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HTMLVideoElement where
-  parents = [HTMLMediaElement, HTMLElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , ElementContentEditable
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType HashChangeEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType Headers where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType History where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBCursor where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBCursorWithValue where
-  parents = [IDBCursor, Object]
-
-  mixins = []
-
-
-public export
-JSType IDBDatabase where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType IDBFactory where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBIndex where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBKeyRange where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBObjectStore where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType IDBOpenDBRequest where
-  parents = [IDBRequest, EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType IDBRequest where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType IDBTransaction where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType IDBVersionChangeEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType ImageBitmap where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType ImageBitmapRenderingContext where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType ImageData where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType InputDeviceInfo where
-  parents = [MediaDeviceInfo, Object]
-
-  mixins = []
-
-
-public export
-JSType InputEvent where
-  parents = [UIEvent, Event, Object]
-
-  mixins = []
-
-
-public export
-JSType KeyboardEvent where
-  parents = [UIEvent, Event, Object]
-
-  mixins = []
-
-
-public export
-JSType KeyframeEffect where
-  parents = [AnimationEffect, Object]
-
-  mixins = []
-
-
-public export
-JSType Location where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MathMLElement where
-  parents = [Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , Slottable
-    ]
-
-
-public export
-JSType MediaDeviceInfo where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MediaDevices where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaError where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MediaList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MediaQueryList where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaQueryListEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaSource where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaStream where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaStreamTrack where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MediaStreamTrackEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType MessageChannel where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MessageEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType MessagePort where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType MimeType where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MimeTypeArray where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MouseEvent where
-  parents = [UIEvent, Event, Object]
-
-  mixins = []
-
-
-public export
-JSType MutationObserver where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType MutationRecord where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType NamedNodeMap where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType NavigationPreloadManager where
-  parents = [Object]
+export %inline
+Cast FormData Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast FormDataEvent Event where cast = believe_me
 
-public export
-JSType Navigator where
-  parents = [Object]
 
-  mixins =
-    [ NavigatorConcurrentHardware
-    , NavigatorContentUtils
-    , NavigatorCookies
-    , NavigatorID
-    , NavigatorLanguage
-    , NavigatorOnLine
-    , NavigatorPlugins
-    ]
+export %inline
+Cast FormDataEvent Object where cast = believe_me
 
 
-public export
-JSType Node where
-  parents = [EventTarget, Object]
+export %inline
+Cast HTMLAllCollection Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAnchorElement HTMLElement where cast = believe_me
 
-public export
-JSType NodeIterator where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAnchorElement Element where cast = believe_me
 
 
-public export
-JSType NodeList where
-  parents = [Object]
+export %inline
+Cast HTMLAnchorElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAnchorElement EventTarget where cast = believe_me
 
-public export
-JSType OffscreenCanvas where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAnchorElement Object where cast = believe_me
 
 
-public export
-JSType OffscreenCanvasRenderingContext2D where
-  parents = [Object]
+export %inline
+Cast HTMLAnchorElement Animatable where cast = believe_me
 
-  mixins =
-    [ CanvasCompositing
-    , CanvasDrawImage
-    , CanvasDrawPath
-    , CanvasFillStrokeStyles
-    , CanvasFilters
-    , CanvasImageData
-    , CanvasImageSmoothing
-    , CanvasPath
-    , CanvasPathDrawingStyles
-    , CanvasRect
-    , CanvasShadowStyles
-    , CanvasState
-    , CanvasText
-    , CanvasTextDrawingStyles
-    , CanvasTransform
-    ]
 
+export %inline
+Cast HTMLAnchorElement ChildNode where cast = believe_me
 
-public export
-JSType OverconstrainedError where
-  parents = [DOMException, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAnchorElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType PageTransitionEvent where
-  parents = [Event, Object]
+export %inline
+Cast HTMLAnchorElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAnchorElement ElementContentEditable where cast = believe_me
 
-public export
-JSType Path2D where
-  parents = [Object]
 
-  mixins = [CanvasPath]
+export %inline
+Cast HTMLAnchorElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType Performance where
-  parents = [EventTarget, Object]
+export %inline
+Cast HTMLAnchorElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAnchorElement HTMLHyperlinkElementUtils where cast = believe_me
 
-public export
-JSType PermissionStatus where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAnchorElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType Permissions where
-  parents = [Object]
+export %inline
+Cast HTMLAnchorElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAnchorElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType Plugin where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAnchorElement ParentNode where cast = believe_me
 
 
-public export
-JSType PluginArray where
-  parents = [Object]
+export %inline
+Cast HTMLAnchorElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAreaElement HTMLElement where cast = believe_me
 
-public export
-JSType PopStateEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAreaElement Element where cast = believe_me
 
 
-public export
-JSType ProcessingInstruction where
-  parents = [CharacterData, Node, EventTarget, Object]
+export %inline
+Cast HTMLAreaElement Node where cast = believe_me
 
-  mixins = [ChildNode, LinkStyle, NonDocumentTypeChildNode]
 
+export %inline
+Cast HTMLAreaElement EventTarget where cast = believe_me
 
-public export
-JSType ProgressEvent where
-  parents = [Event, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAreaElement Object where cast = believe_me
 
 
-public export
-JSType PromiseRejectionEvent where
-  parents = [Event, Object]
+export %inline
+Cast HTMLAreaElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAreaElement ChildNode where cast = believe_me
 
-public export
-JSType RadioNodeList where
-  parents = [NodeList, Object]
 
-  mixins = []
+export %inline
+Cast HTMLAreaElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType Range where
-  parents = [AbstractRange, Object]
+export %inline
+Cast HTMLAreaElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAreaElement ElementContentEditable where cast = believe_me
 
-public export
-JSType ReadableByteStreamController where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAreaElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType ReadableStream where
-  parents = [Object]
+export %inline
+Cast HTMLAreaElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAreaElement HTMLHyperlinkElementUtils where cast = believe_me
 
-public export
-JSType ReadableStreamBYOBReader where
-  parents = [Object]
 
-  mixins = [ReadableStreamGenericReader]
+export %inline
+Cast HTMLAreaElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType ReadableStreamBYOBRequest where
-  parents = [Object]
+export %inline
+Cast HTMLAreaElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAreaElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType ReadableStreamDefaultController where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAreaElement ParentNode where cast = believe_me
 
 
-public export
-JSType ReadableStreamDefaultReader where
-  parents = [Object]
+export %inline
+Cast HTMLAreaElement Slottable where cast = believe_me
 
-  mixins = [ReadableStreamGenericReader]
 
+export %inline
+Cast HTMLAudioElement HTMLMediaElement where cast = believe_me
 
-public export
-JSType Request where
-  parents = [Object]
 
-  mixins = [Body]
+export %inline
+Cast HTMLAudioElement HTMLElement where cast = believe_me
 
 
-public export
-JSType Response where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement Element where cast = believe_me
 
-  mixins = [Body]
 
+export %inline
+Cast HTMLAudioElement Node where cast = believe_me
 
-public export
-JSType SVGAElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLHyperlinkElementUtils
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , SVGURIReference
-    , Slottable
-    ]
+export %inline
+Cast HTMLAudioElement EventTarget where cast = believe_me
 
 
-public export
-JSType SVGAngle where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAudioElement Animatable where cast = believe_me
 
-public export
-JSType SVGAnimatedAngle where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAudioElement ChildNode where cast = believe_me
 
 
-public export
-JSType SVGAnimatedBoolean where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAudioElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType SVGAnimatedEnumeration where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAudioElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType SVGAnimatedInteger where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAudioElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType SVGAnimatedLength where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAudioElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType SVGAnimatedLengthList where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLAudioElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType SVGAnimatedNumber where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLAudioElement ParentNode where cast = believe_me
 
 
-public export
-JSType SVGAnimatedNumberList where
-  parents = [Object]
+export %inline
+Cast HTMLAudioElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBRElement HTMLElement where cast = believe_me
 
-public export
-JSType SVGAnimatedPreserveAspectRatio where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBRElement Element where cast = believe_me
 
 
-public export
-JSType SVGAnimatedRect where
-  parents = [Object]
+export %inline
+Cast HTMLBRElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBRElement EventTarget where cast = believe_me
 
-public export
-JSType SVGAnimatedString where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBRElement Object where cast = believe_me
 
 
-public export
-JSType SVGAnimatedTransformList where
-  parents = [Object]
+export %inline
+Cast HTMLBRElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBRElement ChildNode where cast = believe_me
 
-public export
-JSType SVGCircleElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
+export %inline
+Cast HTMLBRElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType SVGDefsElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
+export %inline
+Cast HTMLBRElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
 
+export %inline
+Cast HTMLBRElement ElementContentEditable where cast = believe_me
 
-public export
-JSType SVGDescElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
+export %inline
+Cast HTMLBRElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType SVGElement where
-  parents = [Element, Node, EventTarget, Object]
+export %inline
+Cast HTMLBRElement GlobalEventHandlers where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
 
+export %inline
+Cast HTMLBRElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType SVGEllipseElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
+export %inline
+Cast HTMLBRElement InnerHTML where cast = believe_me
 
 
-public export
-JSType SVGForeignObjectElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
+export %inline
+Cast HTMLBRElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
 
+export %inline
+Cast HTMLBRElement ParentNode where cast = believe_me
 
-public export
-JSType SVGGElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
+export %inline
+Cast HTMLBRElement Slottable where cast = believe_me
 
 
-public export
-JSType SVGGeometryElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
+export %inline
+Cast HTMLBaseElement HTMLElement where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
 
+export %inline
+Cast HTMLBaseElement Element where cast = believe_me
 
-public export
-JSType SVGGradientElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGURIReference
-    , Slottable
-    ]
+export %inline
+Cast HTMLBaseElement Node where cast = believe_me
 
 
-public export
-JSType SVGGraphicsElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
+export %inline
+Cast HTMLBaseElement EventTarget where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
 
+export %inline
+Cast HTMLBaseElement Object where cast = believe_me
 
-public export
-JSType SVGImageElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , SVGURIReference
-    , Slottable
-    ]
+export %inline
+Cast HTMLBaseElement Animatable where cast = believe_me
 
-
-public export
-JSType SVGLength where
-  parents = [Object]
-
-  mixins = []
 
+export %inline
+Cast HTMLBaseElement ChildNode where cast = believe_me
 
-public export
-JSType SVGLengthList where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBaseElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType SVGLineElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
+export %inline
+Cast HTMLBaseElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGLinearGradientElement where
-  parents = [SVGGradientElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGMarkerElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGFitToViewBox
-    , Slottable
-    ]
-
-
-public export
-JSType SVGMetadataElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
-
-
-public export
-JSType SVGNumber where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGNumberList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGPathElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGPatternElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGFitToViewBox
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGPointList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGPolygonElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGAnimatedPoints
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGPolylineElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGAnimatedPoints
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGPreserveAspectRatio where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGRadialGradientElement where
-  parents = [SVGGradientElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGRectElement where
-  parents =
-    [ SVGGeometryElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGSVGElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGFitToViewBox
-    , SVGTests
-    , Slottable
-    , WindowEventHandlers
-    ]
-
-
-public export
-JSType SVGScriptElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGStopElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
-
-
-public export
-JSType SVGStringList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGStyleElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , LinkStyle
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
-
-
-public export
-JSType SVGSwitchElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGSymbolElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGFitToViewBox
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTSpanElement where
-  parents =
-    [ SVGTextPositioningElement
-    , SVGTextContentElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTextContentElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTextElement where
-  parents =
-    [ SVGTextPositioningElement
-    , SVGTextContentElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTextPathElement where
-  parents =
-    [ SVGTextContentElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTextPositioningElement where
-  parents =
-    [ SVGTextContentElement
-    , SVGGraphicsElement
-    , SVGElement
-    , Element
-    , Node
-    , EventTarget
-    , Object
-    ]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTitleElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , Slottable
-    ]
-
-
-public export
-JSType SVGTransform where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGTransformList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGUnitTypes where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SVGUseElement where
-  parents = [SVGGraphicsElement, SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGTests
-    , SVGURIReference
-    , Slottable
-    ]
-
-
-public export
-JSType SVGUseElementShadowRoot where
-  parents = [ShadowRoot, DocumentFragment, Node, EventTarget, Object]
-
-  mixins = [DocumentOrShadowRoot, InnerHTML, NonElementParentNode, ParentNode]
-
-
-public export
-JSType SVGViewElement where
-  parents = [SVGElement, Element, Node, EventTarget, Object]
-
-  mixins =
-    [ Animatable
-    , ChildNode
-    , DocumentAndElementEventHandlers
-    , ElementCSSInlineStyle
-    , GeometryUtils
-    , GlobalEventHandlers
-    , HTMLOrSVGElement
-    , InnerHTML
-    , NonDocumentTypeChildNode
-    , ParentNode
-    , SVGElementInstance
-    , SVGFitToViewBox
-    , Slottable
-    ]
-
-
-public export
-JSType Screen where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType ServiceWorker where
-  parents = [EventTarget, Object]
-
-  mixins = [AbstractWorker]
-
-
-public export
-JSType ServiceWorkerContainer where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType ServiceWorkerGlobalScope where
-  parents = [WorkerGlobalScope, EventTarget, Object]
-
-  mixins = [WindowOrWorkerGlobalScope]
-
-
-public export
-JSType ServiceWorkerRegistration where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType ShadowAnimation where
-  parents = [Animation, EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType ShadowRoot where
-  parents = [DocumentFragment, Node, EventTarget, Object]
-
-  mixins = [DocumentOrShadowRoot, InnerHTML, NonElementParentNode, ParentNode]
-
-
-public export
-JSType SharedWorker where
-  parents = [EventTarget, Object]
-
-  mixins = [AbstractWorker]
-
-
-public export
-JSType SharedWorkerGlobalScope where
-  parents = [WorkerGlobalScope, EventTarget, Object]
-
-  mixins = [WindowOrWorkerGlobalScope]
-
-
-public export
-JSType SourceBuffer where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType SourceBufferList where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType StaticRange where
-  parents = [AbstractRange, Object]
-
-  mixins = []
-
-
-public export
-JSType Storage where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType StorageEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType StyleSheet where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType StyleSheetList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType SubmitEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType Text where
-  parents = [CharacterData, Node, EventTarget, Object]
-
-  mixins = [ChildNode, GeometryUtils, NonDocumentTypeChildNode, Slottable]
-
-
-public export
-JSType TextMetrics where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType TextTrack where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType TextTrackCue where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType TextTrackCueList where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType TextTrackList where
-  parents = [EventTarget, Object]
-
-  mixins = []
-
-
-public export
-JSType TimeRanges where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType TrackEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
-
-public export
-JSType TransformStream where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType TransformStreamDefaultController where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType TreeWalker where
-  parents = [Object]
-
-  mixins = []
-
-
-public export
-JSType UIEvent where
-  parents = [Event, Object]
-
-  mixins = []
-
 
-public export
-JSType URL where
-  parents = [Object]
+export %inline
+Cast HTMLBaseElement ElementContentEditable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBaseElement GeometryUtils where cast = believe_me
 
-public export
-JSType URLSearchParams where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBaseElement GlobalEventHandlers where cast = believe_me
 
 
-public export
-JSType ValidityState where
-  parents = [Object]
+export %inline
+Cast HTMLBaseElement HTMLOrSVGElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBaseElement InnerHTML where cast = believe_me
 
-public export
-JSType VideoTrack where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBaseElement NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType VideoTrackList where
-  parents = [EventTarget, Object]
+export %inline
+Cast HTMLBaseElement ParentNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBaseElement Slottable where cast = believe_me
 
-public export
-JSType VisualViewport where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement HTMLElement where cast = believe_me
 
 
-public export
-JSType WebGL2RenderingContext where
-  parents = [Object]
+export %inline
+Cast HTMLBodyElement Element where cast = believe_me
 
-  mixins =
-    [ WebGL2RenderingContextBase
-    , WebGL2RenderingContextOverloads
-    , WebGLRenderingContextBase
-    ]
 
+export %inline
+Cast HTMLBodyElement Node where cast = believe_me
 
-public export
-JSType WebGLActiveInfo where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement EventTarget where cast = believe_me
 
 
-public export
-JSType WebGLBuffer where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLBodyElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBodyElement Animatable where cast = believe_me
 
-public export
-JSType WebGLFramebuffer where
-  parents = [WebGLObject, Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement ChildNode where cast = believe_me
 
 
-public export
-JSType WebGLObject where
-  parents = [Object]
+export %inline
+Cast HTMLBodyElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBodyElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType WebGLProgram where
-  parents = [WebGLObject, Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType WebGLQuery where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLBodyElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBodyElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType WebGLRenderbuffer where
-  parents = [WebGLObject, Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType WebGLRenderingContext where
-  parents = [Object]
+export %inline
+Cast HTMLBodyElement InnerHTML where cast = believe_me
 
-  mixins = [WebGLRenderingContextBase, WebGLRenderingContextOverloads]
 
+export %inline
+Cast HTMLBodyElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType WebGLSampler where
-  parents = [WebGLObject, Object]
 
-  mixins = []
+export %inline
+Cast HTMLBodyElement ParentNode where cast = believe_me
 
 
-public export
-JSType WebGLShader where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLBodyElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLBodyElement WindowEventHandlers where cast = believe_me
 
-public export
-JSType WebGLShaderPrecisionFormat where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLButtonElement HTMLElement where cast = believe_me
 
 
-public export
-JSType WebGLSync where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLButtonElement Element where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLButtonElement Node where cast = believe_me
 
-public export
-JSType WebGLTexture where
-  parents = [WebGLObject, Object]
 
-  mixins = []
+export %inline
+Cast HTMLButtonElement EventTarget where cast = believe_me
 
 
-public export
-JSType WebGLTransformFeedback where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLButtonElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLButtonElement Animatable where cast = believe_me
 
-public export
-JSType WebGLUniformLocation where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLButtonElement ChildNode where cast = believe_me
 
 
-public export
-JSType WebGLVertexArrayObject where
-  parents = [WebGLObject, Object]
+export %inline
+Cast HTMLButtonElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLButtonElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType WebSocket where
-  parents = [EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLButtonElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType WheelEvent where
-  parents = [MouseEvent, UIEvent, Event, Object]
+export %inline
+Cast HTMLButtonElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLButtonElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType Window where
-  parents = [EventTarget, Object]
 
-  mixins =
-    [ GlobalEventHandlers
-    , WindowEventHandlers
-    , WindowLocalStorage
-    , WindowOrWorkerGlobalScope
-    ]
+export %inline
+Cast HTMLButtonElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType WindowClient where
-  parents = [Client, Object]
+export %inline
+Cast HTMLButtonElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLButtonElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType Worker where
-  parents = [EventTarget, Object]
 
-  mixins = [AbstractWorker]
+export %inline
+Cast HTMLButtonElement ParentNode where cast = believe_me
 
 
-public export
-JSType WorkerGlobalScope where
-  parents = [EventTarget, Object]
+export %inline
+Cast HTMLButtonElement Slottable where cast = believe_me
 
-  mixins = [WindowOrWorkerGlobalScope]
 
+export %inline
+Cast HTMLCanvasElement HTMLElement where cast = believe_me
 
-public export
-JSType WorkerLocation where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement Element where cast = believe_me
 
 
-public export
-JSType WorkerNavigator where
-  parents = [Object]
+export %inline
+Cast HTMLCanvasElement Node where cast = believe_me
 
-  mixins =
-    [ NavigatorConcurrentHardware
-    , NavigatorID
-    , NavigatorLanguage
-    , NavigatorOnLine
-    ]
 
+export %inline
+Cast HTMLCanvasElement EventTarget where cast = believe_me
 
-public export
-JSType Worklet where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement Object where cast = believe_me
 
 
-public export
-JSType WorkletGlobalScope where
-  parents = [Object]
+export %inline
+Cast HTMLCanvasElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLCanvasElement ChildNode where cast = believe_me
 
-public export
-JSType WritableStream where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType WritableStreamDefaultController where
-  parents = [Object]
+export %inline
+Cast HTMLCanvasElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLCanvasElement ElementContentEditable where cast = believe_me
 
-public export
-JSType WritableStreamDefaultWriter where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType XMLDocument where
-  parents = [Document, Node, EventTarget, Object]
+export %inline
+Cast HTMLCanvasElement GlobalEventHandlers where cast = believe_me
 
-  mixins =
-    [ DocumentAndElementEventHandlers
-    , DocumentOrShadowRoot
-    , GeometryUtils
-    , GlobalEventHandlers
-    , NonElementParentNode
-    , ParentNode
-    , XPathEvaluatorBase
-    ]
 
+export %inline
+Cast HTMLCanvasElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType XMLHttpRequest where
-  parents = [XMLHttpRequestEventTarget, EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement InnerHTML where cast = believe_me
 
 
-public export
-JSType XMLHttpRequestEventTarget where
-  parents = [EventTarget, Object]
+export %inline
+Cast HTMLCanvasElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLCanvasElement ParentNode where cast = believe_me
 
-public export
-JSType XMLHttpRequestUpload where
-  parents = [XMLHttpRequestEventTarget, EventTarget, Object]
 
-  mixins = []
+export %inline
+Cast HTMLCanvasElement Slottable where cast = believe_me
 
 
-public export
-JSType XMLSerializer where
-  parents = [Object]
+export %inline
+Cast HTMLCollection Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement HTMLElement where cast = believe_me
 
-public export
-JSType XPathEvaluator where
-  parents = [Object]
 
-  mixins = [XPathEvaluatorBase]
+export %inline
+Cast HTMLDListElement Element where cast = believe_me
 
 
-public export
-JSType XPathExpression where
-  parents = [Object]
+export %inline
+Cast HTMLDListElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement EventTarget where cast = believe_me
 
-public export
-JSType XPathResult where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDListElement Object where cast = believe_me
 
 
-public export
-JSType AddEventListenerOptions where
-  parents = [EventListenerOptions, Object]
+export %inline
+Cast HTMLDListElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement ChildNode where cast = believe_me
 
-public export
-JSType AnimationPlaybackEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDListElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType AssignedNodesOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDListElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement ElementContentEditable where cast = believe_me
 
-public export
-JSType BaseComputedKeyframe where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDListElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType BaseKeyframe where
-  parents = [Object]
+export %inline
+Cast HTMLDListElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType BasePropertyIndexedKeyframe where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDListElement InnerHTML where cast = believe_me
 
 
-public export
-JSType BlobPropertyBag where
-  parents = [Object]
+export %inline
+Cast HTMLDListElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDListElement ParentNode where cast = believe_me
 
-public export
-JSType BoxQuadOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDListElement Slottable where cast = believe_me
 
 
-public export
-JSType CacheQueryOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDataElement HTMLElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement Element where cast = believe_me
 
-public export
-JSType CameraDevicePermissionDescriptor where
-  parents = [DevicePermissionDescriptor, PermissionDescriptor, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataElement Node where cast = believe_me
 
 
-public export
-JSType CanvasRenderingContext2DSettings where
-  parents = [Object]
+export %inline
+Cast HTMLDataElement EventTarget where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement Object where cast = believe_me
 
-public export
-JSType Capabilities where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataElement Animatable where cast = believe_me
 
 
-public export
-JSType CheckVisibilityOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDataElement ChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement DocumentAndElementEventHandlers where cast = believe_me
 
-public export
-JSType ClientQueryOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataElement ElementCSSInlineStyle where cast = believe_me
 
 
-public export
-JSType ClipboardEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDataElement ElementContentEditable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement GeometryUtils where cast = believe_me
 
-public export
-JSType ClipboardItemOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataElement GlobalEventHandlers where cast = believe_me
 
 
-public export
-JSType ClipboardPermissionDescriptor where
-  parents = [PermissionDescriptor, Object]
+export %inline
+Cast HTMLDataElement HTMLOrSVGElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement InnerHTML where cast = believe_me
 
-public export
-JSType CloseEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataElement NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType CompositionEventInit where
-  parents = [UIEventInit, EventInit, Object]
+export %inline
+Cast HTMLDataElement ParentNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataElement Slottable where cast = believe_me
 
-public export
-JSType ComputedEffectTiming where
-  parents = [EffectTiming, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement HTMLElement where cast = believe_me
 
 
-public export
-JSType ConstrainBooleanParameters where
-  parents = [Object]
+export %inline
+Cast HTMLDataListElement Element where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataListElement Node where cast = believe_me
 
-public export
-JSType ConstrainDOMStringParameters where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement EventTarget where cast = believe_me
 
 
-public export
-JSType ConstrainDoubleRange where
-  parents = [DoubleRange, Object]
+export %inline
+Cast HTMLDataListElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataListElement Animatable where cast = believe_me
 
-public export
-JSType ConstrainULongRange where
-  parents = [ULongRange, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement ChildNode where cast = believe_me
 
 
-public export
-JSType ConstraintSet where
-  parents = [Object]
+export %inline
+Cast HTMLDataListElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataListElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType Constraints where
-  parents = [ConstraintSet, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType ConvertCoordinateOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDataListElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataListElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType CustomEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType DOMMatrix2DInit where
-  parents = [Object]
+export %inline
+Cast HTMLDataListElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDataListElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType DOMMatrixInit where
-  parents = [DOMMatrix2DInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDataListElement ParentNode where cast = believe_me
 
 
-public export
-JSType DOMPointInit where
-  parents = [Object]
+export %inline
+Cast HTMLDataListElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement HTMLElement where cast = believe_me
 
-public export
-JSType DOMQuadInit where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement Element where cast = believe_me
 
 
-public export
-JSType DOMRectInit where
-  parents = [Object]
+export %inline
+Cast HTMLDetailsElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement EventTarget where cast = believe_me
 
-public export
-JSType DevicePermissionDescriptor where
-  parents = [PermissionDescriptor, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement Object where cast = believe_me
 
 
-public export
-JSType DocumentTimelineOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDetailsElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement ChildNode where cast = believe_me
 
-public export
-JSType DoubleRange where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType DragEventInit where
-  parents = [MouseEventInit, EventModifierInit, UIEventInit, EventInit, Object]
+export %inline
+Cast HTMLDetailsElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement ElementContentEditable where cast = believe_me
 
-public export
-JSType EffectTiming where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType ElementCreationOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDetailsElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType ElementDefinitionOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement InnerHTML where cast = believe_me
 
 
-public export
-JSType ErrorEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDetailsElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDetailsElement ParentNode where cast = believe_me
 
-public export
-JSType EventInit where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDetailsElement Slottable where cast = believe_me
 
 
-public export
-JSType EventListenerOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDialogElement HTMLElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement Element where cast = believe_me
 
-public export
-JSType EventModifierInit where
-  parents = [UIEventInit, EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDialogElement Node where cast = believe_me
 
 
-public export
-JSType EventSourceInit where
-  parents = [Object]
+export %inline
+Cast HTMLDialogElement EventTarget where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement Object where cast = believe_me
 
-public export
-JSType ExtendableEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDialogElement Animatable where cast = believe_me
 
 
-public export
-JSType ExtendableMessageEventInit where
-  parents = [ExtendableEventInit, EventInit, Object]
+export %inline
+Cast HTMLDialogElement ChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement DocumentAndElementEventHandlers where cast = believe_me
 
-public export
-JSType FetchEventInit where
-  parents = [ExtendableEventInit, EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDialogElement ElementCSSInlineStyle where cast = believe_me
 
 
-public export
-JSType FilePropertyBag where
-  parents = [BlobPropertyBag, Object]
+export %inline
+Cast HTMLDialogElement ElementContentEditable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement GeometryUtils where cast = believe_me
 
-public export
-JSType FocusEventInit where
-  parents = [UIEventInit, EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDialogElement GlobalEventHandlers where cast = believe_me
 
 
-public export
-JSType FocusOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDialogElement HTMLOrSVGElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement InnerHTML where cast = believe_me
 
-public export
-JSType FormDataEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDialogElement NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType GetRootNodeOptions where
-  parents = [Object]
+export %inline
+Cast HTMLDialogElement ParentNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDialogElement Slottable where cast = believe_me
 
-public export
-JSType HashChangeEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement HTMLElement where cast = believe_me
 
 
-public export
-JSType IDBDatabaseInfo where
-  parents = [Object]
+export %inline
+Cast HTMLDirectoryElement Element where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDirectoryElement Node where cast = believe_me
 
-public export
-JSType IDBIndexParameters where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement EventTarget where cast = believe_me
 
 
-public export
-JSType IDBObjectStoreParameters where
-  parents = [Object]
+export %inline
+Cast HTMLDirectoryElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDirectoryElement Animatable where cast = believe_me
 
-public export
-JSType IDBTransactionOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement ChildNode where cast = believe_me
 
 
-public export
-JSType IDBVersionChangeEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDirectoryElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDirectoryElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType ImageBitmapOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType ImageBitmapRenderingContextSettings where
-  parents = [Object]
+export %inline
+Cast HTMLDirectoryElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDirectoryElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType ImageEncodeOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType InputEventInit where
-  parents = [UIEventInit, EventInit, Object]
+export %inline
+Cast HTMLDirectoryElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDirectoryElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType KeyboardEventInit where
-  parents = [EventModifierInit, UIEventInit, EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDirectoryElement ParentNode where cast = believe_me
 
 
-public export
-JSType KeyframeAnimationOptions where
-  parents = [KeyframeEffectOptions, EffectTiming, Object]
+export %inline
+Cast HTMLDirectoryElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement HTMLElement where cast = believe_me
 
-public export
-JSType KeyframeEffectOptions where
-  parents = [EffectTiming, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement Element where cast = believe_me
 
 
-public export
-JSType MediaQueryListEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDivElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement EventTarget where cast = believe_me
 
-public export
-JSType MediaStreamConstraints where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement Object where cast = believe_me
 
 
-public export
-JSType MediaStreamTrackEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDivElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement ChildNode where cast = believe_me
 
-public export
-JSType MediaTrackCapabilities where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType MediaTrackConstraintSet where
-  parents = [Object]
+export %inline
+Cast HTMLDivElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement ElementContentEditable where cast = believe_me
 
-public export
-JSType MediaTrackConstraints where
-  parents = [MediaTrackConstraintSet, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType MediaTrackSettings where
-  parents = [Object]
+export %inline
+Cast HTMLDivElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType MediaTrackSupportedConstraints where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement InnerHTML where cast = believe_me
 
 
-public export
-JSType MessageEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLDivElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLDivElement ParentNode where cast = believe_me
 
-public export
-JSType MidiPermissionDescriptor where
-  parents = [PermissionDescriptor, Object]
 
-  mixins = []
+export %inline
+Cast HTMLDivElement Slottable where cast = believe_me
 
 
-public export
-JSType MouseEventInit where
-  parents = [EventModifierInit, UIEventInit, EventInit, Object]
+export %inline
+Cast HTMLElement Element where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLElement Node where cast = believe_me
 
-public export
-JSType MultiCacheQueryOptions where
-  parents = [CacheQueryOptions, Object]
 
-  mixins = []
+export %inline
+Cast HTMLElement EventTarget where cast = believe_me
 
 
-public export
-JSType MutationObserverInit where
-  parents = [Object]
+export %inline
+Cast HTMLElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLElement Animatable where cast = believe_me
 
-public export
-JSType NavigationPreloadState where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLElement ChildNode where cast = believe_me
 
 
-public export
-JSType OptionalEffectTiming where
-  parents = [Object]
+export %inline
+Cast HTMLElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType PageTransitionEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType PermissionDescriptor where
-  parents = [Object]
+export %inline
+Cast HTMLElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType PermissionSetParameters where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType PopStateEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType PostMessageOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLElement ParentNode where cast = believe_me
 
 
-public export
-JSType ProgressEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement HTMLElement where cast = believe_me
 
-public export
-JSType PromiseRejectionEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement Element where cast = believe_me
 
 
-public export
-JSType PushPermissionDescriptor where
-  parents = [PermissionDescriptor, Object]
+export %inline
+Cast HTMLEmbedElement Node where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement EventTarget where cast = believe_me
 
-public export
-JSType QueuingStrategy where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement Object where cast = believe_me
 
 
-public export
-JSType QueuingStrategyInit where
-  parents = [Object]
+export %inline
+Cast HTMLEmbedElement Animatable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement ChildNode where cast = believe_me
 
-public export
-JSType ReadableStreamBYOBReadResult where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement DocumentAndElementEventHandlers where cast = believe_me
 
 
-public export
-JSType ReadableStreamDefaultReadResult where
-  parents = [Object]
+export %inline
+Cast HTMLEmbedElement ElementCSSInlineStyle where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement ElementContentEditable where cast = believe_me
 
-public export
-JSType ReadableStreamGetReaderOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement GeometryUtils where cast = believe_me
 
 
-public export
-JSType ReadableStreamIteratorOptions where
-  parents = [Object]
+export %inline
+Cast HTMLEmbedElement GlobalEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement HTMLOrSVGElement where cast = believe_me
 
-public export
-JSType ReadableWritablePair where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement InnerHTML where cast = believe_me
 
 
-public export
-JSType RegistrationOptions where
-  parents = [Object]
+export %inline
+Cast HTMLEmbedElement NonDocumentTypeChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLEmbedElement ParentNode where cast = believe_me
 
-public export
-JSType RequestInit where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLEmbedElement Slottable where cast = believe_me
 
 
-public export
-JSType ResponseInit where
-  parents = [Object]
+export %inline
+Cast HTMLFieldSetElement HTMLElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement Element where cast = believe_me
 
-public export
-JSType SVGBoundingBoxOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFieldSetElement Node where cast = believe_me
 
 
-public export
-JSType ScrollIntoViewOptions where
-  parents = [ScrollOptions, Object]
+export %inline
+Cast HTMLFieldSetElement EventTarget where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement Object where cast = believe_me
 
-public export
-JSType ScrollOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFieldSetElement Animatable where cast = believe_me
 
 
-public export
-JSType ScrollToOptions where
-  parents = [ScrollOptions, Object]
+export %inline
+Cast HTMLFieldSetElement ChildNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement DocumentAndElementEventHandlers where cast = believe_me
 
-public export
-JSType Settings where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFieldSetElement ElementCSSInlineStyle where cast = believe_me
 
 
-public export
-JSType ShadowRootInit where
-  parents = [Object]
+export %inline
+Cast HTMLFieldSetElement ElementContentEditable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement GeometryUtils where cast = believe_me
 
-public export
-JSType StaticRangeInit where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFieldSetElement GlobalEventHandlers where cast = believe_me
 
 
-public export
-JSType StorageEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLFieldSetElement HTMLOrSVGElement where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement InnerHTML where cast = believe_me
 
-public export
-JSType StreamPipeOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFieldSetElement NonDocumentTypeChildNode where cast = believe_me
 
 
-public export
-JSType StructuredSerializeOptions where
-  parents = [Object]
+export %inline
+Cast HTMLFieldSetElement ParentNode where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFieldSetElement Slottable where cast = believe_me
 
-public export
-JSType SubmitEventInit where
-  parents = [EventInit, Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement HTMLElement where cast = believe_me
 
 
-public export
-JSType TrackEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLFontElement Element where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFontElement Node where cast = believe_me
 
-public export
-JSType Transformer where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement EventTarget where cast = believe_me
 
 
-public export
-JSType UIEventInit where
-  parents = [EventInit, Object]
+export %inline
+Cast HTMLFontElement Object where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFontElement Animatable where cast = believe_me
 
-public export
-JSType ULongRange where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement ChildNode where cast = believe_me
 
 
-public export
-JSType UnderlyingSink where
-  parents = [Object]
+export %inline
+Cast HTMLFontElement DocumentAndElementEventHandlers where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFontElement ElementCSSInlineStyle where cast = believe_me
 
-public export
-JSType UnderlyingSource where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement ElementContentEditable where cast = believe_me
 
 
-public export
-JSType ValidityStateFlags where
-  parents = [Object]
+export %inline
+Cast HTMLFontElement GeometryUtils where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFontElement GlobalEventHandlers where cast = believe_me
 
-public export
-JSType WebGLContextAttributes where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement HTMLOrSVGElement where cast = believe_me
 
 
-public export
-JSType WheelEventInit where
-  parents = [MouseEventInit, EventModifierInit, UIEventInit, EventInit, Object]
+export %inline
+Cast HTMLFontElement InnerHTML where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFontElement NonDocumentTypeChildNode where cast = believe_me
 
-public export
-JSType WindowPostMessageOptions where
-  parents = [PostMessageOptions, Object]
 
-  mixins = []
+export %inline
+Cast HTMLFontElement ParentNode where cast = believe_me
 
 
-public export
-JSType WorkerOptions where
-  parents = [Object]
+export %inline
+Cast HTMLFontElement Slottable where cast = believe_me
 
-  mixins = []
 
+export %inline
+Cast HTMLFormControlsCollection HTMLCollection where cast = believe_me
 
-public export
-JSType WorkletOptions where
-  parents = [Object]
 
-  mixins = []
+export %inline
+Cast HTMLFormControlsCollection Object where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFormElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLFrameSetElement WindowEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHRElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHeadingElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLHtmlElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLIFrameElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLImageElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLInputElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLIElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLabelElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLegendElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement LinkStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLLinkElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMapElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMarqueeElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMediaElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMenuElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMetaElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLMeterElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLModElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOListElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLObjectElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptGroupElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionsCollection HTMLCollection where cast = believe_me
+
+
+export %inline
+Cast HTMLOptionsCollection Object where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLOutputElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParagraphElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLParamElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPictureElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLPreElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLProgressElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLQuoteElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLScriptElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSelectElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSlotElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSourceElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLSpanElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement LinkStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLStyleElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCaptionElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableCellElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableColElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableRowElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTableSectionElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTemplateElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTextAreaElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTimeElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTitleElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLTrackElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUListElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLUnknownElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement HTMLMediaElement where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement HTMLElement where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement Element where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement Node where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement Object where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement Animatable where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement ElementContentEditable where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast HTMLVideoElement Slottable where cast = believe_me
+
+
+export %inline
+Cast HashChangeEvent Event where cast = believe_me
+
+
+export %inline
+Cast HashChangeEvent Object where cast = believe_me
+
+
+export %inline
+Cast Headers Object where cast = believe_me
+
+
+export %inline
+Cast History Object where cast = believe_me
+
+
+export %inline
+Cast IDBCursor Object where cast = believe_me
+
+
+export %inline
+Cast IDBCursorWithValue IDBCursor where cast = believe_me
+
+
+export %inline
+Cast IDBCursorWithValue Object where cast = believe_me
+
+
+export %inline
+Cast IDBDatabase EventTarget where cast = believe_me
+
+
+export %inline
+Cast IDBDatabase Object where cast = believe_me
+
+
+export %inline
+Cast IDBFactory Object where cast = believe_me
+
+
+export %inline
+Cast IDBIndex Object where cast = believe_me
+
+
+export %inline
+Cast IDBKeyRange Object where cast = believe_me
+
+
+export %inline
+Cast IDBObjectStore Object where cast = believe_me
+
+
+export %inline
+Cast IDBOpenDBRequest IDBRequest where cast = believe_me
+
+
+export %inline
+Cast IDBOpenDBRequest EventTarget where cast = believe_me
+
+
+export %inline
+Cast IDBOpenDBRequest Object where cast = believe_me
+
+
+export %inline
+Cast IDBRequest EventTarget where cast = believe_me
+
+
+export %inline
+Cast IDBRequest Object where cast = believe_me
+
+
+export %inline
+Cast IDBTransaction EventTarget where cast = believe_me
+
+
+export %inline
+Cast IDBTransaction Object where cast = believe_me
+
+
+export %inline
+Cast IDBVersionChangeEvent Event where cast = believe_me
+
+
+export %inline
+Cast IDBVersionChangeEvent Object where cast = believe_me
+
+
+export %inline
+Cast ImageBitmap Object where cast = believe_me
+
+
+export %inline
+Cast ImageBitmapRenderingContext Object where cast = believe_me
+
+
+export %inline
+Cast ImageData Object where cast = believe_me
+
+
+export %inline
+Cast InputDeviceInfo MediaDeviceInfo where cast = believe_me
+
+
+export %inline
+Cast InputDeviceInfo Object where cast = believe_me
+
+
+export %inline
+Cast InputEvent UIEvent where cast = believe_me
+
+
+export %inline
+Cast InputEvent Event where cast = believe_me
+
+
+export %inline
+Cast InputEvent Object where cast = believe_me
+
+
+export %inline
+Cast KeyboardEvent UIEvent where cast = believe_me
+
+
+export %inline
+Cast KeyboardEvent Event where cast = believe_me
+
+
+export %inline
+Cast KeyboardEvent Object where cast = believe_me
+
+
+export %inline
+Cast KeyframeEffect AnimationEffect where cast = believe_me
+
+
+export %inline
+Cast KeyframeEffect Object where cast = believe_me
+
+
+export %inline
+Cast Location Object where cast = believe_me
+
+
+export %inline
+Cast MathMLElement Element where cast = believe_me
+
+
+export %inline
+Cast MathMLElement Node where cast = believe_me
+
+
+export %inline
+Cast MathMLElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast MathMLElement Object where cast = believe_me
+
+
+export %inline
+Cast MathMLElement Animatable where cast = believe_me
+
+
+export %inline
+Cast MathMLElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast MathMLElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast MathMLElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast MathMLElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast MathMLElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast MathMLElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast MathMLElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast MathMLElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast MathMLElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast MathMLElement Slottable where cast = believe_me
+
+
+export %inline
+Cast MediaDeviceInfo Object where cast = believe_me
+
+
+export %inline
+Cast MediaDevices EventTarget where cast = believe_me
+
+
+export %inline
+Cast MediaDevices Object where cast = believe_me
+
+
+export %inline
+Cast MediaError Object where cast = believe_me
+
+
+export %inline
+Cast MediaList Object where cast = believe_me
+
+
+export %inline
+Cast MediaQueryList EventTarget where cast = believe_me
+
+
+export %inline
+Cast MediaQueryList Object where cast = believe_me
+
+
+export %inline
+Cast MediaQueryListEvent Event where cast = believe_me
+
+
+export %inline
+Cast MediaQueryListEvent Object where cast = believe_me
+
+
+export %inline
+Cast MediaSource EventTarget where cast = believe_me
+
+
+export %inline
+Cast MediaSource Object where cast = believe_me
+
+
+export %inline
+Cast MediaStream EventTarget where cast = believe_me
+
+
+export %inline
+Cast MediaStream Object where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrack EventTarget where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrack Object where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrackEvent Event where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrackEvent Object where cast = believe_me
+
+
+export %inline
+Cast MessageChannel Object where cast = believe_me
+
+
+export %inline
+Cast MessageEvent Event where cast = believe_me
+
+
+export %inline
+Cast MessageEvent Object where cast = believe_me
+
+
+export %inline
+Cast MessagePort EventTarget where cast = believe_me
+
+
+export %inline
+Cast MessagePort Object where cast = believe_me
+
+
+export %inline
+Cast MimeType Object where cast = believe_me
+
+
+export %inline
+Cast MimeTypeArray Object where cast = believe_me
+
+
+export %inline
+Cast MouseEvent UIEvent where cast = believe_me
+
+
+export %inline
+Cast MouseEvent Event where cast = believe_me
+
+
+export %inline
+Cast MouseEvent Object where cast = believe_me
+
+
+export %inline
+Cast MutationObserver Object where cast = believe_me
+
+
+export %inline
+Cast MutationRecord Object where cast = believe_me
+
+
+export %inline
+Cast NamedNodeMap Object where cast = believe_me
+
+
+export %inline
+Cast NavigationPreloadManager Object where cast = believe_me
+
+
+export %inline
+Cast Navigator Object where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorConcurrentHardware where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorContentUtils where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorCookies where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorID where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorLanguage where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorOnLine where cast = believe_me
+
+
+export %inline
+Cast Navigator NavigatorPlugins where cast = believe_me
+
+
+export %inline
+Cast Node EventTarget where cast = believe_me
+
+
+export %inline
+Cast Node Object where cast = believe_me
+
+
+export %inline
+Cast NodeIterator Object where cast = believe_me
+
+
+export %inline
+Cast NodeList Object where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvas EventTarget where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvas Object where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D Object where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasCompositing where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasDrawImage where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasDrawPath where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasFillStrokeStyles where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasFilters where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasImageData where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasImageSmoothing where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasPath where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasPathDrawingStyles where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasRect where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasShadowStyles where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasState where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasText where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasTextDrawingStyles where cast = believe_me
+
+
+export %inline
+Cast OffscreenCanvasRenderingContext2D CanvasTransform where cast = believe_me
+
+
+export %inline
+Cast OverconstrainedError DOMException where cast = believe_me
+
+
+export %inline
+Cast OverconstrainedError Object where cast = believe_me
+
+
+export %inline
+Cast PageTransitionEvent Event where cast = believe_me
+
+
+export %inline
+Cast PageTransitionEvent Object where cast = believe_me
+
+
+export %inline
+Cast Path2D Object where cast = believe_me
+
+
+export %inline
+Cast Path2D CanvasPath where cast = believe_me
+
+
+export %inline
+Cast Performance EventTarget where cast = believe_me
+
+
+export %inline
+Cast Performance Object where cast = believe_me
+
+
+export %inline
+Cast PermissionStatus EventTarget where cast = believe_me
+
+
+export %inline
+Cast PermissionStatus Object where cast = believe_me
+
+
+export %inline
+Cast Permissions Object where cast = believe_me
+
+
+export %inline
+Cast Plugin Object where cast = believe_me
+
+
+export %inline
+Cast PluginArray Object where cast = believe_me
+
+
+export %inline
+Cast PopStateEvent Event where cast = believe_me
+
+
+export %inline
+Cast PopStateEvent Object where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction CharacterData where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction Node where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction EventTarget where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction Object where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction ChildNode where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction LinkStyle where cast = believe_me
+
+
+export %inline
+Cast ProcessingInstruction NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast ProgressEvent Event where cast = believe_me
+
+
+export %inline
+Cast ProgressEvent Object where cast = believe_me
+
+
+export %inline
+Cast PromiseRejectionEvent Event where cast = believe_me
+
+
+export %inline
+Cast PromiseRejectionEvent Object where cast = believe_me
+
+
+export %inline
+Cast RadioNodeList NodeList where cast = believe_me
+
+
+export %inline
+Cast RadioNodeList Object where cast = believe_me
+
+
+export %inline
+Cast Range AbstractRange where cast = believe_me
+
+
+export %inline
+Cast Range Object where cast = believe_me
+
+
+export %inline
+Cast ReadableByteStreamController Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStream Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamBYOBReader Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamBYOBReader ReadableStreamGenericReader where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamBYOBRequest Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamDefaultController Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamDefaultReader Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamDefaultReader ReadableStreamGenericReader where cast = believe_me
+
+
+export %inline
+Cast Request Object where cast = believe_me
+
+
+export %inline
+Cast Request Body where cast = believe_me
+
+
+export %inline
+Cast Response Object where cast = believe_me
+
+
+export %inline
+Cast Response Body where cast = believe_me
+
+
+export %inline
+Cast SVGAElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGAElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGAElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGAElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGAElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGAElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGAElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGAElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGAElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGAElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGAElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGAElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGAElement HTMLHyperlinkElementUtils where cast = believe_me
+
+
+export %inline
+Cast SVGAElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGAElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGAElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGAElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGAElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGAElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGAElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGAElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGAngle Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedAngle Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedBoolean Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedEnumeration Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedInteger Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedLength Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedLengthList Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedNumber Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedNumberList Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedPreserveAspectRatio Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedRect Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedString Object where cast = believe_me
+
+
+export %inline
+Cast SVGAnimatedTransformList Object where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGCircleElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGDefsElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGDescElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGEllipseElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGForeignObjectElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGGElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGGElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGGElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGGElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGGElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGGElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGGElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGGElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGGElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGGElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGGElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGGElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGGElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGGeometryElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGGradientElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGGraphicsElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGImageElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGLength Object where cast = believe_me
+
+
+export %inline
+Cast SVGLengthList Object where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGLineElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement SVGGradientElement where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGLinearGradientElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement SVGFitToViewBox where cast = believe_me
+
+
+export %inline
+Cast SVGMarkerElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGMetadataElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGNumber Object where cast = believe_me
+
+
+export %inline
+Cast SVGNumberList Object where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGPathElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement SVGFitToViewBox where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGPatternElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGPointList Object where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGAnimatedPoints where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGPolygonElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGAnimatedPoints where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGPolylineElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGPreserveAspectRatio Object where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement SVGGradientElement where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGRadialGradientElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement SVGGeometryElement where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGRectElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement SVGFitToViewBox where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGSVGElement WindowEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGScriptElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGStopElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGStringList Object where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement LinkStyle where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGStyleElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGSwitchElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement SVGFitToViewBox where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGSymbolElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGTextPositioningElement where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGTextContentElement where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGTSpanElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGTextContentElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGTextPositioningElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGTextContentElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGTextElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGTextContentElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGTextPathElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement SVGTextContentElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGTextPositioningElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGTitleElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGTransform Object where cast = believe_me
+
+
+export %inline
+Cast SVGTransformList Object where cast = believe_me
+
+
+export %inline
+Cast SVGUnitTypes Object where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement SVGGraphicsElement where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement SVGTests where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement SVGURIReference where cast = believe_me
+
+
+export %inline
+Cast SVGUseElement Slottable where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot ShadowRoot where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot DocumentFragment where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot Node where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot Object where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot DocumentOrShadowRoot where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot NonElementParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGUseElementShadowRoot ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement SVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement Element where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement Node where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement EventTarget where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement Object where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement Animatable where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement ChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement ElementCSSInlineStyle where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement HTMLOrSVGElement where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement InnerHTML where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement ParentNode where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement SVGElementInstance where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement SVGFitToViewBox where cast = believe_me
+
+
+export %inline
+Cast SVGViewElement Slottable where cast = believe_me
+
+
+export %inline
+Cast Screen Object where cast = believe_me
+
+
+export %inline
+Cast ServiceWorker EventTarget where cast = believe_me
+
+
+export %inline
+Cast ServiceWorker Object where cast = believe_me
+
+
+export %inline
+Cast ServiceWorker AbstractWorker where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerContainer EventTarget where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerContainer Object where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerGlobalScope WorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerGlobalScope EventTarget where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerGlobalScope Object where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerGlobalScope WindowOrWorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerRegistration EventTarget where cast = believe_me
+
+
+export %inline
+Cast ServiceWorkerRegistration Object where cast = believe_me
+
+
+export %inline
+Cast ShadowAnimation Animation where cast = believe_me
+
+
+export %inline
+Cast ShadowAnimation EventTarget where cast = believe_me
+
+
+export %inline
+Cast ShadowAnimation Object where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot DocumentFragment where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot Node where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot EventTarget where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot Object where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot DocumentOrShadowRoot where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot InnerHTML where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot NonElementParentNode where cast = believe_me
+
+
+export %inline
+Cast ShadowRoot ParentNode where cast = believe_me
+
+
+export %inline
+Cast SharedWorker EventTarget where cast = believe_me
+
+
+export %inline
+Cast SharedWorker Object where cast = believe_me
+
+
+export %inline
+Cast SharedWorker AbstractWorker where cast = believe_me
+
+
+export %inline
+Cast SharedWorkerGlobalScope WorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast SharedWorkerGlobalScope EventTarget where cast = believe_me
+
+
+export %inline
+Cast SharedWorkerGlobalScope Object where cast = believe_me
+
+
+export %inline
+Cast SharedWorkerGlobalScope WindowOrWorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast SourceBuffer EventTarget where cast = believe_me
+
+
+export %inline
+Cast SourceBuffer Object where cast = believe_me
+
+
+export %inline
+Cast SourceBufferList EventTarget where cast = believe_me
+
+
+export %inline
+Cast SourceBufferList Object where cast = believe_me
+
+
+export %inline
+Cast StaticRange AbstractRange where cast = believe_me
+
+
+export %inline
+Cast StaticRange Object where cast = believe_me
+
+
+export %inline
+Cast Storage Object where cast = believe_me
+
+
+export %inline
+Cast StorageEvent Event where cast = believe_me
+
+
+export %inline
+Cast StorageEvent Object where cast = believe_me
+
+
+export %inline
+Cast StyleSheet Object where cast = believe_me
+
+
+export %inline
+Cast StyleSheetList Object where cast = believe_me
+
+
+export %inline
+Cast SubmitEvent Event where cast = believe_me
+
+
+export %inline
+Cast SubmitEvent Object where cast = believe_me
+
+
+export %inline
+Cast Text CharacterData where cast = believe_me
+
+
+export %inline
+Cast Text Node where cast = believe_me
+
+
+export %inline
+Cast Text EventTarget where cast = believe_me
+
+
+export %inline
+Cast Text Object where cast = believe_me
+
+
+export %inline
+Cast Text ChildNode where cast = believe_me
+
+
+export %inline
+Cast Text GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast Text NonDocumentTypeChildNode where cast = believe_me
+
+
+export %inline
+Cast Text Slottable where cast = believe_me
+
+
+export %inline
+Cast TextMetrics Object where cast = believe_me
+
+
+export %inline
+Cast TextTrack EventTarget where cast = believe_me
+
+
+export %inline
+Cast TextTrack Object where cast = believe_me
+
+
+export %inline
+Cast TextTrackCue EventTarget where cast = believe_me
+
+
+export %inline
+Cast TextTrackCue Object where cast = believe_me
+
+
+export %inline
+Cast TextTrackCueList Object where cast = believe_me
+
+
+export %inline
+Cast TextTrackList EventTarget where cast = believe_me
+
+
+export %inline
+Cast TextTrackList Object where cast = believe_me
+
+
+export %inline
+Cast TimeRanges Object where cast = believe_me
+
+
+export %inline
+Cast TrackEvent Event where cast = believe_me
+
+
+export %inline
+Cast TrackEvent Object where cast = believe_me
+
+
+export %inline
+Cast TransformStream Object where cast = believe_me
+
+
+export %inline
+Cast TransformStreamDefaultController Object where cast = believe_me
+
+
+export %inline
+Cast TreeWalker Object where cast = believe_me
+
+
+export %inline
+Cast UIEvent Event where cast = believe_me
+
+
+export %inline
+Cast UIEvent Object where cast = believe_me
+
+
+export %inline
+Cast URL Object where cast = believe_me
+
+
+export %inline
+Cast URLSearchParams Object where cast = believe_me
+
+
+export %inline
+Cast ValidityState Object where cast = believe_me
+
+
+export %inline
+Cast VideoTrack Object where cast = believe_me
+
+
+export %inline
+Cast VideoTrackList EventTarget where cast = believe_me
+
+
+export %inline
+Cast VideoTrackList Object where cast = believe_me
+
+
+export %inline
+Cast VisualViewport EventTarget where cast = believe_me
+
+
+export %inline
+Cast VisualViewport Object where cast = believe_me
+
+
+export %inline
+Cast WebGL2RenderingContext Object where cast = believe_me
+
+
+export %inline
+Cast WebGL2RenderingContext WebGL2RenderingContextBase where cast = believe_me
+
+
+export %inline
+Cast WebGL2RenderingContext WebGL2RenderingContextOverloads where cast = believe_me
+
+
+export %inline
+Cast WebGL2RenderingContext WebGLRenderingContextBase where cast = believe_me
+
+
+export %inline
+Cast WebGLActiveInfo Object where cast = believe_me
+
+
+export %inline
+Cast WebGLBuffer WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLBuffer Object where cast = believe_me
+
+
+export %inline
+Cast WebGLFramebuffer WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLFramebuffer Object where cast = believe_me
+
+
+export %inline
+Cast WebGLObject Object where cast = believe_me
+
+
+export %inline
+Cast WebGLProgram WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLProgram Object where cast = believe_me
+
+
+export %inline
+Cast WebGLQuery WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLQuery Object where cast = believe_me
+
+
+export %inline
+Cast WebGLRenderbuffer WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLRenderbuffer Object where cast = believe_me
+
+
+export %inline
+Cast WebGLRenderingContext Object where cast = believe_me
+
+
+export %inline
+Cast WebGLRenderingContext WebGLRenderingContextBase where cast = believe_me
+
+
+export %inline
+Cast WebGLRenderingContext WebGLRenderingContextOverloads where cast = believe_me
+
+
+export %inline
+Cast WebGLSampler WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLSampler Object where cast = believe_me
+
+
+export %inline
+Cast WebGLShader WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLShader Object where cast = believe_me
+
+
+export %inline
+Cast WebGLShaderPrecisionFormat Object where cast = believe_me
+
+
+export %inline
+Cast WebGLSync WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLSync Object where cast = believe_me
+
+
+export %inline
+Cast WebGLTexture WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLTexture Object where cast = believe_me
+
+
+export %inline
+Cast WebGLTransformFeedback WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLTransformFeedback Object where cast = believe_me
+
+
+export %inline
+Cast WebGLUniformLocation Object where cast = believe_me
+
+
+export %inline
+Cast WebGLVertexArrayObject WebGLObject where cast = believe_me
+
+
+export %inline
+Cast WebGLVertexArrayObject Object where cast = believe_me
+
+
+export %inline
+Cast WebSocket EventTarget where cast = believe_me
+
+
+export %inline
+Cast WebSocket Object where cast = believe_me
+
+
+export %inline
+Cast WheelEvent MouseEvent where cast = believe_me
+
+
+export %inline
+Cast WheelEvent UIEvent where cast = believe_me
+
+
+export %inline
+Cast WheelEvent Event where cast = believe_me
+
+
+export %inline
+Cast WheelEvent Object where cast = believe_me
+
+
+export %inline
+Cast Window EventTarget where cast = believe_me
+
+
+export %inline
+Cast Window Object where cast = believe_me
+
+
+export %inline
+Cast Window GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast Window WindowEventHandlers where cast = believe_me
+
+
+export %inline
+Cast Window WindowLocalStorage where cast = believe_me
+
+
+export %inline
+Cast Window WindowOrWorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast WindowClient Client where cast = believe_me
+
+
+export %inline
+Cast WindowClient Object where cast = believe_me
+
+
+export %inline
+Cast Worker EventTarget where cast = believe_me
+
+
+export %inline
+Cast Worker Object where cast = believe_me
+
+
+export %inline
+Cast Worker AbstractWorker where cast = believe_me
+
+
+export %inline
+Cast WorkerGlobalScope EventTarget where cast = believe_me
+
+
+export %inline
+Cast WorkerGlobalScope Object where cast = believe_me
+
+
+export %inline
+Cast WorkerGlobalScope WindowOrWorkerGlobalScope where cast = believe_me
+
+
+export %inline
+Cast WorkerLocation Object where cast = believe_me
+
+
+export %inline
+Cast WorkerNavigator Object where cast = believe_me
+
+
+export %inline
+Cast WorkerNavigator NavigatorConcurrentHardware where cast = believe_me
+
+
+export %inline
+Cast WorkerNavigator NavigatorID where cast = believe_me
+
+
+export %inline
+Cast WorkerNavigator NavigatorLanguage where cast = believe_me
+
+
+export %inline
+Cast WorkerNavigator NavigatorOnLine where cast = believe_me
+
+
+export %inline
+Cast Worklet Object where cast = believe_me
+
+
+export %inline
+Cast WorkletGlobalScope Object where cast = believe_me
+
+
+export %inline
+Cast WritableStream Object where cast = believe_me
+
+
+export %inline
+Cast WritableStreamDefaultController Object where cast = believe_me
+
+
+export %inline
+Cast WritableStreamDefaultWriter Object where cast = believe_me
+
+
+export %inline
+Cast XMLDocument Document where cast = believe_me
+
+
+export %inline
+Cast XMLDocument Node where cast = believe_me
+
+
+export %inline
+Cast XMLDocument EventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLDocument Object where cast = believe_me
+
+
+export %inline
+Cast XMLDocument DocumentAndElementEventHandlers where cast = believe_me
+
+
+export %inline
+Cast XMLDocument DocumentOrShadowRoot where cast = believe_me
+
+
+export %inline
+Cast XMLDocument GeometryUtils where cast = believe_me
+
+
+export %inline
+Cast XMLDocument GlobalEventHandlers where cast = believe_me
+
+
+export %inline
+Cast XMLDocument NonElementParentNode where cast = believe_me
+
+
+export %inline
+Cast XMLDocument ParentNode where cast = believe_me
+
+
+export %inline
+Cast XMLDocument XPathEvaluatorBase where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequest XMLHttpRequestEventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequest EventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequest Object where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequestEventTarget EventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequestEventTarget Object where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequestUpload XMLHttpRequestEventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequestUpload EventTarget where cast = believe_me
+
+
+export %inline
+Cast XMLHttpRequestUpload Object where cast = believe_me
+
+
+export %inline
+Cast XMLSerializer Object where cast = believe_me
+
+
+export %inline
+Cast XPathEvaluator Object where cast = believe_me
+
+
+export %inline
+Cast XPathEvaluator XPathEvaluatorBase where cast = believe_me
+
+
+export %inline
+Cast XPathExpression Object where cast = believe_me
+
+
+export %inline
+Cast XPathResult Object where cast = believe_me
+
+
+export %inline
+Cast AddEventListenerOptions EventListenerOptions where cast = believe_me
+
+
+export %inline
+Cast AddEventListenerOptions Object where cast = believe_me
+
+
+export %inline
+Cast AnimationPlaybackEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast AnimationPlaybackEventInit Object where cast = believe_me
+
+
+export %inline
+Cast AssignedNodesOptions Object where cast = believe_me
+
+
+export %inline
+Cast BaseComputedKeyframe Object where cast = believe_me
+
+
+export %inline
+Cast BaseKeyframe Object where cast = believe_me
+
+
+export %inline
+Cast BasePropertyIndexedKeyframe Object where cast = believe_me
+
+
+export %inline
+Cast BlobPropertyBag Object where cast = believe_me
+
+
+export %inline
+Cast BoxQuadOptions Object where cast = believe_me
+
+
+export %inline
+Cast CacheQueryOptions Object where cast = believe_me
+
+
+export %inline
+Cast CameraDevicePermissionDescriptor DevicePermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast CameraDevicePermissionDescriptor PermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast CameraDevicePermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast CanvasRenderingContext2DSettings Object where cast = believe_me
+
+
+export %inline
+Cast Capabilities Object where cast = believe_me
+
+
+export %inline
+Cast CheckVisibilityOptions Object where cast = believe_me
+
+
+export %inline
+Cast ClientQueryOptions Object where cast = believe_me
+
+
+export %inline
+Cast ClipboardEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast ClipboardEventInit Object where cast = believe_me
+
+
+export %inline
+Cast ClipboardItemOptions Object where cast = believe_me
+
+
+export %inline
+Cast ClipboardPermissionDescriptor PermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast ClipboardPermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast CloseEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast CloseEventInit Object where cast = believe_me
+
+
+export %inline
+Cast CompositionEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast CompositionEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast CompositionEventInit Object where cast = believe_me
+
+
+export %inline
+Cast ComputedEffectTiming EffectTiming where cast = believe_me
+
+
+export %inline
+Cast ComputedEffectTiming Object where cast = believe_me
+
+
+export %inline
+Cast ConstrainBooleanParameters Object where cast = believe_me
+
+
+export %inline
+Cast ConstrainDOMStringParameters Object where cast = believe_me
+
+
+export %inline
+Cast ConstrainDoubleRange DoubleRange where cast = believe_me
+
+
+export %inline
+Cast ConstrainDoubleRange Object where cast = believe_me
+
+
+export %inline
+Cast ConstrainULongRange ULongRange where cast = believe_me
+
+
+export %inline
+Cast ConstrainULongRange Object where cast = believe_me
+
+
+export %inline
+Cast ConstraintSet Object where cast = believe_me
+
+
+export %inline
+Cast Constraints ConstraintSet where cast = believe_me
+
+
+export %inline
+Cast Constraints Object where cast = believe_me
+
+
+export %inline
+Cast ConvertCoordinateOptions Object where cast = believe_me
+
+
+export %inline
+Cast CustomEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast CustomEventInit Object where cast = believe_me
+
+
+export %inline
+Cast DOMMatrix2DInit Object where cast = believe_me
+
+
+export %inline
+Cast DOMMatrixInit DOMMatrix2DInit where cast = believe_me
+
+
+export %inline
+Cast DOMMatrixInit Object where cast = believe_me
+
+
+export %inline
+Cast DOMPointInit Object where cast = believe_me
+
+
+export %inline
+Cast DOMQuadInit Object where cast = believe_me
+
+
+export %inline
+Cast DOMRectInit Object where cast = believe_me
+
+
+export %inline
+Cast DevicePermissionDescriptor PermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast DevicePermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast DocumentTimelineOptions Object where cast = believe_me
+
+
+export %inline
+Cast DoubleRange Object where cast = believe_me
+
+
+export %inline
+Cast DragEventInit MouseEventInit where cast = believe_me
+
+
+export %inline
+Cast DragEventInit EventModifierInit where cast = believe_me
+
+
+export %inline
+Cast DragEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast DragEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast DragEventInit Object where cast = believe_me
+
+
+export %inline
+Cast EffectTiming Object where cast = believe_me
+
+
+export %inline
+Cast ElementCreationOptions Object where cast = believe_me
+
+
+export %inline
+Cast ElementDefinitionOptions Object where cast = believe_me
+
+
+export %inline
+Cast ErrorEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast ErrorEventInit Object where cast = believe_me
+
+
+export %inline
+Cast EventInit Object where cast = believe_me
+
+
+export %inline
+Cast EventListenerOptions Object where cast = believe_me
+
+
+export %inline
+Cast EventModifierInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast EventModifierInit EventInit where cast = believe_me
+
+
+export %inline
+Cast EventModifierInit Object where cast = believe_me
+
+
+export %inline
+Cast EventSourceInit Object where cast = believe_me
+
+
+export %inline
+Cast ExtendableEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast ExtendableEventInit Object where cast = believe_me
+
+
+export %inline
+Cast ExtendableMessageEventInit ExtendableEventInit where cast = believe_me
+
+
+export %inline
+Cast ExtendableMessageEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast ExtendableMessageEventInit Object where cast = believe_me
+
+
+export %inline
+Cast FetchEventInit ExtendableEventInit where cast = believe_me
+
+
+export %inline
+Cast FetchEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast FetchEventInit Object where cast = believe_me
+
+
+export %inline
+Cast FilePropertyBag BlobPropertyBag where cast = believe_me
+
+
+export %inline
+Cast FilePropertyBag Object where cast = believe_me
+
+
+export %inline
+Cast FocusEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast FocusEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast FocusEventInit Object where cast = believe_me
+
+
+export %inline
+Cast FocusOptions Object where cast = believe_me
+
+
+export %inline
+Cast FormDataEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast FormDataEventInit Object where cast = believe_me
+
+
+export %inline
+Cast GetRootNodeOptions Object where cast = believe_me
+
+
+export %inline
+Cast HashChangeEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast HashChangeEventInit Object where cast = believe_me
+
+
+export %inline
+Cast IDBDatabaseInfo Object where cast = believe_me
+
+
+export %inline
+Cast IDBIndexParameters Object where cast = believe_me
+
+
+export %inline
+Cast IDBObjectStoreParameters Object where cast = believe_me
+
+
+export %inline
+Cast IDBTransactionOptions Object where cast = believe_me
+
+
+export %inline
+Cast IDBVersionChangeEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast IDBVersionChangeEventInit Object where cast = believe_me
+
+
+export %inline
+Cast ImageBitmapOptions Object where cast = believe_me
+
+
+export %inline
+Cast ImageBitmapRenderingContextSettings Object where cast = believe_me
+
+
+export %inline
+Cast ImageEncodeOptions Object where cast = believe_me
+
+
+export %inline
+Cast InputEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast InputEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast InputEventInit Object where cast = believe_me
+
+
+export %inline
+Cast KeyboardEventInit EventModifierInit where cast = believe_me
+
+
+export %inline
+Cast KeyboardEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast KeyboardEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast KeyboardEventInit Object where cast = believe_me
+
+
+export %inline
+Cast KeyframeAnimationOptions KeyframeEffectOptions where cast = believe_me
+
+
+export %inline
+Cast KeyframeAnimationOptions EffectTiming where cast = believe_me
+
+
+export %inline
+Cast KeyframeAnimationOptions Object where cast = believe_me
+
+
+export %inline
+Cast KeyframeEffectOptions EffectTiming where cast = believe_me
+
+
+export %inline
+Cast KeyframeEffectOptions Object where cast = believe_me
+
+
+export %inline
+Cast MediaQueryListEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast MediaQueryListEventInit Object where cast = believe_me
+
+
+export %inline
+Cast MediaStreamConstraints Object where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrackEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast MediaStreamTrackEventInit Object where cast = believe_me
+
+
+export %inline
+Cast MediaTrackCapabilities Object where cast = believe_me
+
+
+export %inline
+Cast MediaTrackConstraintSet Object where cast = believe_me
+
+
+export %inline
+Cast MediaTrackConstraints MediaTrackConstraintSet where cast = believe_me
+
+
+export %inline
+Cast MediaTrackConstraints Object where cast = believe_me
+
+
+export %inline
+Cast MediaTrackSettings Object where cast = believe_me
+
+
+export %inline
+Cast MediaTrackSupportedConstraints Object where cast = believe_me
+
+
+export %inline
+Cast MessageEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast MessageEventInit Object where cast = believe_me
+
+
+export %inline
+Cast MidiPermissionDescriptor PermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast MidiPermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast MouseEventInit EventModifierInit where cast = believe_me
+
+
+export %inline
+Cast MouseEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast MouseEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast MouseEventInit Object where cast = believe_me
+
+
+export %inline
+Cast MultiCacheQueryOptions CacheQueryOptions where cast = believe_me
+
+
+export %inline
+Cast MultiCacheQueryOptions Object where cast = believe_me
+
+
+export %inline
+Cast MutationObserverInit Object where cast = believe_me
+
+
+export %inline
+Cast NavigationPreloadState Object where cast = believe_me
+
+
+export %inline
+Cast OptionalEffectTiming Object where cast = believe_me
+
+
+export %inline
+Cast PageTransitionEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast PageTransitionEventInit Object where cast = believe_me
+
+
+export %inline
+Cast PermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast PermissionSetParameters Object where cast = believe_me
+
+
+export %inline
+Cast PopStateEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast PopStateEventInit Object where cast = believe_me
+
+
+export %inline
+Cast PostMessageOptions Object where cast = believe_me
+
+
+export %inline
+Cast ProgressEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast ProgressEventInit Object where cast = believe_me
+
+
+export %inline
+Cast PromiseRejectionEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast PromiseRejectionEventInit Object where cast = believe_me
+
+
+export %inline
+Cast PushPermissionDescriptor PermissionDescriptor where cast = believe_me
+
+
+export %inline
+Cast PushPermissionDescriptor Object where cast = believe_me
+
+
+export %inline
+Cast QueuingStrategy Object where cast = believe_me
+
+
+export %inline
+Cast QueuingStrategyInit Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamBYOBReadResult Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamDefaultReadResult Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamGetReaderOptions Object where cast = believe_me
+
+
+export %inline
+Cast ReadableStreamIteratorOptions Object where cast = believe_me
+
+
+export %inline
+Cast ReadableWritablePair Object where cast = believe_me
+
+
+export %inline
+Cast RegistrationOptions Object where cast = believe_me
+
+
+export %inline
+Cast RequestInit Object where cast = believe_me
+
+
+export %inline
+Cast ResponseInit Object where cast = believe_me
+
+
+export %inline
+Cast SVGBoundingBoxOptions Object where cast = believe_me
+
+
+export %inline
+Cast ScrollIntoViewOptions ScrollOptions where cast = believe_me
+
+
+export %inline
+Cast ScrollIntoViewOptions Object where cast = believe_me
+
+
+export %inline
+Cast ScrollOptions Object where cast = believe_me
+
+
+export %inline
+Cast ScrollToOptions ScrollOptions where cast = believe_me
+
+
+export %inline
+Cast ScrollToOptions Object where cast = believe_me
+
+
+export %inline
+Cast Settings Object where cast = believe_me
+
+
+export %inline
+Cast ShadowRootInit Object where cast = believe_me
+
+
+export %inline
+Cast StaticRangeInit Object where cast = believe_me
+
+
+export %inline
+Cast StorageEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast StorageEventInit Object where cast = believe_me
+
+
+export %inline
+Cast StreamPipeOptions Object where cast = believe_me
+
+
+export %inline
+Cast StructuredSerializeOptions Object where cast = believe_me
+
+
+export %inline
+Cast SubmitEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast SubmitEventInit Object where cast = believe_me
+
+
+export %inline
+Cast TrackEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast TrackEventInit Object where cast = believe_me
+
+
+export %inline
+Cast Transformer Object where cast = believe_me
+
+
+export %inline
+Cast UIEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast UIEventInit Object where cast = believe_me
+
+
+export %inline
+Cast ULongRange Object where cast = believe_me
+
+
+export %inline
+Cast UnderlyingSink Object where cast = believe_me
+
+
+export %inline
+Cast UnderlyingSource Object where cast = believe_me
+
+
+export %inline
+Cast ValidityStateFlags Object where cast = believe_me
+
+
+export %inline
+Cast WebGLContextAttributes Object where cast = believe_me
+
+
+export %inline
+Cast WheelEventInit MouseEventInit where cast = believe_me
+
+
+export %inline
+Cast WheelEventInit EventModifierInit where cast = believe_me
+
+
+export %inline
+Cast WheelEventInit UIEventInit where cast = believe_me
+
+
+export %inline
+Cast WheelEventInit EventInit where cast = believe_me
+
+
+export %inline
+Cast WheelEventInit Object where cast = believe_me
+
+
+export %inline
+Cast WindowPostMessageOptions PostMessageOptions where cast = believe_me
+
+
+export %inline
+Cast WindowPostMessageOptions Object where cast = believe_me
+
+
+export %inline
+Cast WorkerOptions Object where cast = believe_me
+
+
+export %inline
+Cast WorkletOptions Object where cast = believe_me
+

--- a/src/Web/Internal/UIEventsPrim.idr
+++ b/src/Web/Internal/UIEventsPrim.idr
@@ -11,7 +11,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CompositionEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : CompositionEvent -> PrimIO String
@@ -19,7 +19,7 @@ namespace CompositionEvent
 
 
 namespace FocusEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.relatedTarget"
   prim__relatedTarget : FocusEvent -> PrimIO (Nullable EventTarget)
@@ -27,17 +27,17 @@ namespace FocusEvent
 
 
 namespace InputEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : InputEvent -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inputType"
   prim__inputType : InputEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isComposing"
   prim__isComposing : InputEvent -> PrimIO Boolean
@@ -45,62 +45,62 @@ namespace InputEvent
 
 
 namespace KeyboardEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.altKey"
   prim__altKey : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.charCode"
   prim__charCode : KeyboardEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : KeyboardEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ctrlKey"
   prim__ctrlKey : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isComposing"
   prim__isComposing : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.key"
   prim__key : KeyboardEvent -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.keyCode"
   prim__keyCode : KeyboardEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.location"
   prim__location : KeyboardEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.metaKey"
   prim__metaKey : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.repeat"
   prim__repeat : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shiftKey"
   prim__shiftKey : KeyboardEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getModifierState(a)"
   prim__getModifierState : KeyboardEvent -> String -> PrimIO Boolean
@@ -108,92 +108,92 @@ namespace KeyboardEvent
 
 
 namespace MouseEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.altKey"
   prim__altKey : MouseEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.button"
   prim__button : MouseEvent -> PrimIO Int16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.buttons"
   prim__buttons : MouseEvent -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientX"
   prim__clientX : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientY"
   prim__clientY : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ctrlKey"
   prim__ctrlKey : MouseEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.metaKey"
   prim__metaKey : MouseEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetX"
   prim__offsetX : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.offsetY"
   prim__offsetY : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageX"
   prim__pageX : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pageY"
   prim__pageY : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relatedTarget"
   prim__relatedTarget : MouseEvent -> PrimIO (Nullable EventTarget)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenX"
   prim__screenX : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenY"
   prim__screenY : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shiftKey"
   prim__shiftKey : MouseEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.x"
   prim__x : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.y"
   prim__y : MouseEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getModifierState(a)"
   prim__getModifierState : MouseEvent -> String -> PrimIO Boolean
@@ -201,17 +201,17 @@ namespace MouseEvent
 
 
 namespace UIEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.detail"
   prim__detail : UIEvent -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.view"
   prim__view : UIEvent -> PrimIO (Nullable Window)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.which"
   prim__which : UIEvent -> PrimIO Bits32
@@ -219,22 +219,22 @@ namespace UIEvent
 
 
 namespace WheelEvent
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaMode"
   prim__deltaMode : WheelEvent -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaX"
   prim__deltaX : WheelEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaY"
   prim__deltaY : WheelEvent -> PrimIO Double
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaZ"
   prim__deltaZ : WheelEvent -> PrimIO Double
@@ -248,18 +248,18 @@ namespace WheelEvent
 --------------------------------------------------------------------------------
 
 namespace CompositionEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({data: a})"
   prim__new : UndefOr String -> PrimIO CompositionEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : CompositionEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : CompositionEventInit -> UndefOr String -> PrimIO ()
@@ -268,7 +268,7 @@ namespace CompositionEventInit
 
 
 namespace EventModifierInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i,j,k,l,m,n)=> ({ctrlKey: a,shiftKey: b,altKey: c,metaKey: d,modifierAltGraph: e,modifierCapsLock: f,modifierFn: g,modifierFnLock: h,modifierHyper: i,modifierNumLock: j,modifierScrollLock: k,modifierSuper: l,modifierSymbol: m,modifierSymbolLock: n})"
   prim__new :
@@ -288,121 +288,121 @@ namespace EventModifierInit
     -> UndefOr Boolean
     -> PrimIO EventModifierInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.altKey"
   prim__altKey : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.altKey = v}"
   prim__setAltKey : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ctrlKey"
   prim__ctrlKey : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ctrlKey = v}"
   prim__setCtrlKey : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.metaKey"
   prim__metaKey : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.metaKey = v}"
   prim__setMetaKey : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierAltGraph"
   prim__modifierAltGraph : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierAltGraph = v}"
   prim__setModifierAltGraph : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierCapsLock"
   prim__modifierCapsLock : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierCapsLock = v}"
   prim__setModifierCapsLock : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierFn"
   prim__modifierFn : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierFn = v}"
   prim__setModifierFn : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierFnLock"
   prim__modifierFnLock : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierFnLock = v}"
   prim__setModifierFnLock : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierHyper"
   prim__modifierHyper : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierHyper = v}"
   prim__setModifierHyper : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierNumLock"
   prim__modifierNumLock : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierNumLock = v}"
   prim__setModifierNumLock : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierScrollLock"
   prim__modifierScrollLock : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierScrollLock = v}"
   prim__setModifierScrollLock :
@@ -411,37 +411,37 @@ namespace EventModifierInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierSuper"
   prim__modifierSuper : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierSuper = v}"
   prim__setModifierSuper : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierSymbol"
   prim__modifierSymbol : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierSymbol = v}"
   prim__setModifierSymbol : EventModifierInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.modifierSymbolLock"
   prim__modifierSymbolLock : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.modifierSymbolLock = v}"
   prim__setModifierSymbolLock :
@@ -450,13 +450,13 @@ namespace EventModifierInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.shiftKey"
   prim__shiftKey : EventModifierInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.shiftKey = v}"
   prim__setShiftKey : EventModifierInit -> UndefOr Boolean -> PrimIO ()
@@ -465,12 +465,12 @@ namespace EventModifierInit
 
 
 namespace FocusEventInit
-
+  
   export
   %foreign "browser:lambda:(a)=> ({relatedTarget: a})"
   prim__new : UndefOr (Nullable EventTarget) -> PrimIO FocusEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relatedTarget"
   prim__relatedTarget :
@@ -478,7 +478,7 @@ namespace FocusEventInit
     -> PrimIO (UndefOr (Nullable EventTarget))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.relatedTarget = v}"
   prim__setRelatedTarget :
@@ -490,7 +490,7 @@ namespace FocusEventInit
 
 
 namespace InputEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({data: a,isComposing: b,inputType: c})"
   prim__new :
@@ -499,37 +499,37 @@ namespace InputEventInit
     -> UndefOr String
     -> PrimIO InputEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.data"
   prim__data : InputEventInit -> PrimIO (UndefOr (Nullable String))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.data = v}"
   prim__setData : InputEventInit -> UndefOr (Nullable String) -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.inputType"
   prim__inputType : InputEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.inputType = v}"
   prim__setInputType : InputEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isComposing"
   prim__isComposing : InputEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.isComposing = v}"
   prim__setIsComposing : InputEventInit -> UndefOr Boolean -> PrimIO ()
@@ -538,7 +538,7 @@ namespace InputEventInit
 
 
 namespace KeyboardEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e)=> ({key: a,code: b,location: c,repeat: d,isComposing: e})"
   prim__new :
@@ -549,61 +549,61 @@ namespace KeyboardEventInit
     -> UndefOr Boolean
     -> PrimIO KeyboardEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : KeyboardEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.code = v}"
   prim__setCode : KeyboardEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isComposing"
   prim__isComposing : KeyboardEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.isComposing = v}"
   prim__setIsComposing : KeyboardEventInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.key"
   prim__key : KeyboardEventInit -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.key = v}"
   prim__setKey : KeyboardEventInit -> UndefOr String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.location"
   prim__location : KeyboardEventInit -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.location = v}"
   prim__setLocation : KeyboardEventInit -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.repeat"
   prim__repeat : KeyboardEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.repeat = v}"
   prim__setRepeat : KeyboardEventInit -> UndefOr Boolean -> PrimIO ()
@@ -612,7 +612,7 @@ namespace KeyboardEventInit
 
 
 namespace MouseEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g)=> ({button: a,buttons: b,relatedTarget: c,screenX: d,screenY: e,clientX: f,clientY: g})"
   prim__new :
@@ -625,55 +625,55 @@ namespace MouseEventInit
     -> UndefOr Double
     -> PrimIO MouseEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.button"
   prim__button : MouseEventInit -> PrimIO (UndefOr Int16)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.button = v}"
   prim__setButton : MouseEventInit -> UndefOr Int16 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.buttons"
   prim__buttons : MouseEventInit -> PrimIO (UndefOr Bits16)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.buttons = v}"
   prim__setButtons : MouseEventInit -> UndefOr Bits16 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientX"
   prim__clientX : MouseEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clientX = v}"
   prim__setClientX : MouseEventInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.clientY"
   prim__clientY : MouseEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.clientY = v}"
   prim__setClientY : MouseEventInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.relatedTarget"
   prim__relatedTarget :
@@ -681,7 +681,7 @@ namespace MouseEventInit
     -> PrimIO (UndefOr (Nullable EventTarget))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.relatedTarget = v}"
   prim__setRelatedTarget :
@@ -690,25 +690,25 @@ namespace MouseEventInit
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenX"
   prim__screenX : MouseEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.screenX = v}"
   prim__setScreenX : MouseEventInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.screenY"
   prim__screenY : MouseEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.screenY = v}"
   prim__setScreenY : MouseEventInit -> UndefOr Double -> PrimIO ()
@@ -717,30 +717,30 @@ namespace MouseEventInit
 
 
 namespace UIEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b)=> ({view: a,detail: b})"
   prim__new : UndefOr (Nullable Window) -> UndefOr Int32 -> PrimIO UIEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.detail"
   prim__detail : UIEventInit -> PrimIO (UndefOr Int32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.detail = v}"
   prim__setDetail : UIEventInit -> UndefOr Int32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.view"
   prim__view : UIEventInit -> PrimIO (UndefOr (Nullable Window))
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.view = v}"
   prim__setView : UIEventInit -> UndefOr (Nullable Window) -> PrimIO ()
@@ -749,7 +749,7 @@ namespace UIEventInit
 
 
 namespace WheelEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d)=> ({deltaX: a,deltaY: b,deltaZ: c,deltaMode: d})"
   prim__new :
@@ -759,49 +759,53 @@ namespace WheelEventInit
     -> UndefOr Bits32
     -> PrimIO WheelEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaMode"
   prim__deltaMode : WheelEventInit -> PrimIO (UndefOr Bits32)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deltaMode = v}"
   prim__setDeltaMode : WheelEventInit -> UndefOr Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaX"
   prim__deltaX : WheelEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deltaX = v}"
   prim__setDeltaX : WheelEventInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaY"
   prim__deltaY : WheelEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deltaY = v}"
   prim__setDeltaY : WheelEventInit -> UndefOr Double -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.deltaZ"
   prim__deltaZ : WheelEventInit -> PrimIO (UndefOr Double)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.deltaZ = v}"
   prim__setDeltaZ : WheelEventInit -> UndefOr Double -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/UIEventsTypes.idr
+++ b/src/Web/Internal/UIEventsTypes.idr
@@ -162,3 +162,6 @@ ToFFI WheelEventInit WheelEventInit where toFFI = id
 
 export
 FromFFI WheelEventInit WheelEventInit where fromFFI = Just
+
+
+

--- a/src/Web/Internal/UrlPrim.idr
+++ b/src/Web/Internal/UrlPrim.idr
@@ -11,157 +11,157 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace URL
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new URL(a,b)"
   prim__new : String -> UndefOr String -> PrimIO URL
 
-
+  
   export
   %foreign "browser:lambda:(a)=>URL.createObjectURL(a)"
   prim__createObjectURL : Union2 Blob MediaSource -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(a)=>URL.createObjectURL(a)"
   prim__createObjectURL1 : MediaSource -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:(a)=>URL.revokeObjectURL(a)"
   prim__revokeObjectURL : String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hash"
   prim__hash : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hash = v}"
   prim__setHash : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.host"
   prim__host : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.host = v}"
   prim__setHost : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.hostname"
   prim__hostname : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.hostname = v}"
   prim__setHostname : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.href"
   prim__href : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.href = v}"
   prim__setHref : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.origin"
   prim__origin : URL -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.password"
   prim__password : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.password = v}"
   prim__setPassword : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pathname"
   prim__pathname : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.pathname = v}"
   prim__setPathname : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.port"
   prim__port : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.port = v}"
   prim__setPort : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.protocol"
   prim__protocol : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.protocol = v}"
   prim__setProtocol : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.search"
   prim__search : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.search = v}"
   prim__setSearch : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.searchParams"
   prim__searchParams : URL -> PrimIO URLSearchParams
 
-
+  
   export
   %foreign "browser:lambda:x=>x.username"
   prim__username : URL -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.username = v}"
   prim__setUsername : URL -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toJSON()"
   prim__toJSON : URL -> PrimIO String
@@ -169,49 +169,54 @@ namespace URL
 
 
 namespace URLSearchParams
-
+  
   export
   %foreign "browser:lambda:(a)=> new URLSearchParams(a)"
   prim__new :
        UndefOr (Union3 (Array (Array String)) (Record String String) String)
     -> PrimIO URLSearchParams
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.append(a,b)"
   prim__append : URLSearchParams -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.delete(a)"
   prim__delete : URLSearchParams -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAll(a)"
   prim__getAll : URLSearchParams -> String -> PrimIO (Array String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : URLSearchParams -> String -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.has(a)"
   prim__has : URLSearchParams -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.set(a,b)"
   prim__set : URLSearchParams -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.sort()"
   prim__sort : URLSearchParams -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.toString()"
   prim__toString : URLSearchParams -> PrimIO String
+
+
+
+
+

--- a/src/Web/Internal/UrlTypes.idr
+++ b/src/Web/Internal/UrlTypes.idr
@@ -33,3 +33,7 @@ FromFFI URLSearchParams URLSearchParams where fromFFI = Just
 export
 SafeCast URLSearchParams where
   safeCast = unsafeCastOnPrototypeName "URLSearchParams"
+
+
+
+

--- a/src/Web/Internal/VisibilityPrim.idr
+++ b/src/Web/Internal/VisibilityPrim.idr
@@ -4,3 +4,7 @@ import JS
 import Web.Internal.Types
 
 %default total
+
+
+
+

--- a/src/Web/Internal/VisibilityTypes.idr
+++ b/src/Web/Internal/VisibilityTypes.idr
@@ -10,33 +10,39 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace VisibilityState
-
+  
   public export
   data VisibilityState = Hidden | Visible
-
-  public export
+  
+  export
   Show VisibilityState where
     show Hidden = "hidden"
     show Visible = "visible"
-
-  public export
+  
+  export
   Eq VisibilityState where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord VisibilityState where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe VisibilityState
   read "hidden" = Just Hidden
   read "visible" = Just Visible
   read _ = Nothing
-
+  
   export
   ToFFI VisibilityState String where
     toFFI = show
-
+  
   export
   FromFFI VisibilityState String where
     fromFFI = read
+
+
+
+
+
+

--- a/src/Web/Internal/WebglPrim.idr
+++ b/src/Web/Internal/WebglPrim.idr
@@ -12,17 +12,17 @@ import Web.Internal.Types
 
 
 namespace WebGLActiveInfo
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : WebGLActiveInfo -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.size"
   prim__size : WebGLActiveInfo -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.type"
   prim__type : WebGLActiveInfo -> PrimIO Bits32
@@ -39,17 +39,17 @@ namespace WebGLActiveInfo
 
 
 namespace WebGLShaderPrecisionFormat
-
+  
   export
   %foreign "browser:lambda:x=>x.precision"
   prim__precision : WebGLShaderPrecisionFormat -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeMax"
   prim__rangeMax : WebGLShaderPrecisionFormat -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.rangeMin"
   prim__rangeMin : WebGLShaderPrecisionFormat -> PrimIO Int32
@@ -67,7 +67,7 @@ namespace WebGLShaderPrecisionFormat
 --------------------------------------------------------------------------------
 
 namespace WebGL2RenderingContextBase
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.beginQuery(a,b)"
   prim__beginQuery :
@@ -76,7 +76,7 @@ namespace WebGL2RenderingContextBase
     -> WebGLQuery
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.beginTransformFeedback(a)"
   prim__beginTransformFeedback :
@@ -84,7 +84,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bindBufferBase(a,b,c)"
   prim__bindBufferBase :
@@ -94,7 +94,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.bindBufferRange(a,b,c,d,e)"
   prim__bindBufferRange :
@@ -106,7 +106,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindSampler(a,b)"
   prim__bindSampler :
@@ -115,7 +115,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLSampler
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindTransformFeedback(a,b)"
   prim__bindTransformFeedback :
@@ -124,7 +124,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLTransformFeedback
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.bindVertexArray(a)"
   prim__bindVertexArray :
@@ -132,7 +132,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLVertexArrayObject
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.blitFramebuffer(a,b,c,d,e,f,g,h,i,j)"
   prim__blitFramebuffer :
@@ -149,7 +149,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearBufferfi(a,b,c,d)"
   prim__clearBufferfi :
@@ -160,7 +160,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearBufferfv(a,b,c,d)"
   prim__clearBufferfv :
@@ -171,7 +171,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearBufferiv(a,b,c,d)"
   prim__clearBufferiv :
@@ -182,7 +182,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearBufferuiv(a,b,c,d)"
   prim__clearBufferuiv :
@@ -193,7 +193,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.clientWaitSync(a,b,c)"
   prim__clientWaitSync :
@@ -203,7 +203,7 @@ namespace WebGL2RenderingContextBase
     -> JSBits64
     -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.compressedTexImage3D(a,b,c,d,e,f,g,h,i)"
   prim__compressedTexImage3D :
@@ -219,7 +219,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.compressedTexImage3D(a,b,c,d,e,f,g,h,i,j)"
   prim__compressedTexImage3D1 :
@@ -246,7 +246,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k)=>x.compressedTexSubImage3D(a,b,c,d,e,f,g,h,i,j,k)"
   prim__compressedTexSubImage3D :
@@ -264,7 +264,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k,l)=>x.compressedTexSubImage3D(a,b,c,d,e,f,g,h,i,j,k,l)"
   prim__compressedTexSubImage3D1 :
@@ -293,7 +293,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.copyBufferSubData(a,b,c,d,e)"
   prim__copyBufferSubData :
@@ -305,7 +305,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.copyTexSubImage3D(a,b,c,d,e,f,g,h,i)"
   prim__copyTexSubImage3D :
@@ -321,33 +321,33 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createQuery()"
   prim__createQuery : WebGL2RenderingContextBase -> PrimIO (Nullable WebGLQuery)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createSampler()"
   prim__createSampler :
        WebGL2RenderingContextBase
     -> PrimIO (Nullable WebGLSampler)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createTransformFeedback()"
   prim__createTransformFeedback :
        WebGL2RenderingContextBase
     -> PrimIO (Nullable WebGLTransformFeedback)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createVertexArray()"
   prim__createVertexArray :
        WebGL2RenderingContextBase
     -> PrimIO (Nullable WebGLVertexArrayObject)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteQuery(a)"
   prim__deleteQuery :
@@ -355,7 +355,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLQuery
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteSampler(a)"
   prim__deleteSampler :
@@ -363,7 +363,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLSampler
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteSync(a)"
   prim__deleteSync :
@@ -371,7 +371,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLSync
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteTransformFeedback(a)"
   prim__deleteTransformFeedback :
@@ -379,7 +379,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLTransformFeedback
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteVertexArray(a)"
   prim__deleteVertexArray :
@@ -387,7 +387,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLVertexArrayObject
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.drawArraysInstanced(a,b,c,d)"
   prim__drawArraysInstanced :
@@ -398,12 +398,12 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.drawBuffers(a)"
   prim__drawBuffers : WebGL2RenderingContextBase -> Array Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.drawElementsInstanced(a,b,c,d,e)"
   prim__drawElementsInstanced :
@@ -415,7 +415,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.drawRangeElements(a,b,c,d,e,f)"
   prim__drawRangeElements :
@@ -428,17 +428,17 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.endQuery(a)"
   prim__endQuery : WebGL2RenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.endTransformFeedback()"
   prim__endTransformFeedback : WebGL2RenderingContextBase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.fenceSync(a,b)"
   prim__fenceSync :
@@ -447,7 +447,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLSync)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.framebufferTextureLayer(a,b,c,d,e)"
   prim__framebufferTextureLayer :
@@ -459,7 +459,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getActiveUniformBlockName(a,b)"
   prim__getActiveUniformBlockName :
@@ -468,7 +468,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.getActiveUniformBlockParameter(a,b,c)"
   prim__getActiveUniformBlockParameter :
@@ -478,7 +478,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.getActiveUniforms(a,b,c)"
   prim__getActiveUniforms :
@@ -488,7 +488,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.getBufferSubData(a,b,c,d,e)"
   prim__getBufferSubData :
@@ -510,7 +510,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getFragDataLocation(a,b)"
   prim__getFragDataLocation :
@@ -519,7 +519,7 @@ namespace WebGL2RenderingContextBase
     -> String
     -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getIndexedParameter(a,b)"
   prim__getIndexedParameter :
@@ -528,7 +528,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.getInternalformatParameter(a,b,c)"
   prim__getInternalformatParameter :
@@ -538,7 +538,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getQueryParameter(a,b)"
   prim__getQueryParameter :
@@ -547,7 +547,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getQuery(a,b)"
   prim__getQuery :
@@ -556,7 +556,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLQuery)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getSamplerParameter(a,b)"
   prim__getSamplerParameter :
@@ -565,7 +565,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getSyncParameter(a,b)"
   prim__getSyncParameter :
@@ -574,7 +574,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getTransformFeedbackVarying(a,b)"
   prim__getTransformFeedbackVarying :
@@ -583,7 +583,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLActiveInfo)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getUniformBlockIndex(a,b)"
   prim__getUniformBlockIndex :
@@ -592,7 +592,7 @@ namespace WebGL2RenderingContextBase
     -> String
     -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getUniformIndices(a,b)"
   prim__getUniformIndices :
@@ -601,7 +601,7 @@ namespace WebGL2RenderingContextBase
     -> Array String
     -> PrimIO (Nullable (Array Bits32))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.invalidateFramebuffer(a,b)"
   prim__invalidateFramebuffer :
@@ -610,7 +610,7 @@ namespace WebGL2RenderingContextBase
     -> Array Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.invalidateSubFramebuffer(a,b,c,d,e,f)"
   prim__invalidateSubFramebuffer :
@@ -623,7 +623,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isQuery(a)"
   prim__isQuery :
@@ -631,7 +631,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLQuery
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isSampler(a)"
   prim__isSampler :
@@ -639,7 +639,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLSampler
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isSync(a)"
   prim__isSync :
@@ -647,7 +647,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLSync
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isTransformFeedback(a)"
   prim__isTransformFeedback :
@@ -655,7 +655,7 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLTransformFeedback
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isVertexArray(a)"
   prim__isVertexArray :
@@ -663,17 +663,17 @@ namespace WebGL2RenderingContextBase
     -> Nullable WebGLVertexArrayObject
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.pauseTransformFeedback()"
   prim__pauseTransformFeedback : WebGL2RenderingContextBase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.readBuffer(a)"
   prim__readBuffer : WebGL2RenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.renderbufferStorageMultisample(a,b,c,d,e)"
   prim__renderbufferStorageMultisample :
@@ -685,12 +685,12 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.resumeTransformFeedback()"
   prim__resumeTransformFeedback : WebGL2RenderingContextBase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.samplerParameterf(a,b,c)"
   prim__samplerParameterf :
@@ -700,7 +700,7 @@ namespace WebGL2RenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.samplerParameteri(a,b,c)"
   prim__samplerParameteri :
@@ -710,7 +710,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.texImage3D(a,b,c,d,e,f,g,h,i,j)"
   prim__texImage3D :
@@ -727,7 +727,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.texImage3D(a,b,c,d,e,f,g,h,i,j)"
   prim__texImage3D1 :
@@ -750,7 +750,7 @@ namespace WebGL2RenderingContextBase
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.texImage3D(a,b,c,d,e,f,g,h,i,j)"
   prim__texImage3D2 :
@@ -778,7 +778,7 @@ namespace WebGL2RenderingContextBase
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k)=>x.texImage3D(a,b,c,d,e,f,g,h,i,j,k)"
   prim__texImage3D3 :
@@ -806,7 +806,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.texStorage2D(a,b,c,d,e)"
   prim__texStorage2D :
@@ -818,7 +818,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.texStorage3D(a,b,c,d,e,f)"
   prim__texStorage3D :
@@ -831,7 +831,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k)=>x.texSubImage3D(a,b,c,d,e,f,g,h,i,j,k)"
   prim__texSubImage3D :
@@ -849,7 +849,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k)=>x.texSubImage3D(a,b,c,d,e,f,g,h,i,j,k)"
   prim__texSubImage3D1 :
@@ -873,7 +873,7 @@ namespace WebGL2RenderingContextBase
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j,k,l)=>x.texSubImage3D(a,b,c,d,e,f,g,h,i,j,k,l)"
   prim__texSubImage3D2 :
@@ -903,7 +903,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.transformFeedbackVaryings(a,b,c)"
   prim__transformFeedbackVaryings :
@@ -913,7 +913,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform1ui(a,b)"
   prim__uniform1ui :
@@ -922,7 +922,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform1uiv(a,b,c,d)"
   prim__uniform1uiv :
@@ -933,7 +933,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniform2ui(a,b,c)"
   prim__uniform2ui :
@@ -943,7 +943,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform2uiv(a,b,c,d)"
   prim__uniform2uiv :
@@ -954,7 +954,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3ui(a,b,c,d)"
   prim__uniform3ui :
@@ -965,7 +965,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3uiv(a,b,c,d)"
   prim__uniform3uiv :
@@ -976,7 +976,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniform4ui(a,b,c,d,e)"
   prim__uniform4ui :
@@ -988,7 +988,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform4uiv(a,b,c,d)"
   prim__uniform4uiv :
@@ -999,7 +999,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniformBlockBinding(a,b,c)"
   prim__uniformBlockBinding :
@@ -1009,7 +1009,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix2x3fv(a,b,c,d,e)"
   prim__uniformMatrix2x3fv :
@@ -1021,7 +1021,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix2x4fv(a,b,c,d,e)"
   prim__uniformMatrix2x4fv :
@@ -1033,7 +1033,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix3x2fv(a,b,c,d,e)"
   prim__uniformMatrix3x2fv :
@@ -1045,7 +1045,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix3x4fv(a,b,c,d,e)"
   prim__uniformMatrix3x4fv :
@@ -1057,7 +1057,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix4x2fv(a,b,c,d,e)"
   prim__uniformMatrix4x2fv :
@@ -1069,7 +1069,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix4x3fv(a,b,c,d,e)"
   prim__uniformMatrix4x3fv :
@@ -1081,7 +1081,7 @@ namespace WebGL2RenderingContextBase
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttribDivisor(a,b)"
   prim__vertexAttribDivisor :
@@ -1090,7 +1090,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.vertexAttribI4i(a,b,c,d,e)"
   prim__vertexAttribI4i :
@@ -1102,7 +1102,7 @@ namespace WebGL2RenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttribI4iv(a,b)"
   prim__vertexAttribI4iv :
@@ -1111,7 +1111,7 @@ namespace WebGL2RenderingContextBase
     -> Union2 Int32Array (Array Int32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.vertexAttribI4ui(a,b,c,d,e)"
   prim__vertexAttribI4ui :
@@ -1123,7 +1123,7 @@ namespace WebGL2RenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttribI4uiv(a,b)"
   prim__vertexAttribI4uiv :
@@ -1132,7 +1132,7 @@ namespace WebGL2RenderingContextBase
     -> Union2 UInt8Array (Array Bits32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.vertexAttribIPointer(a,b,c,d,e)"
   prim__vertexAttribIPointer :
@@ -1144,7 +1144,7 @@ namespace WebGL2RenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.waitSync(a,b,c)"
   prim__waitSync :
@@ -1157,7 +1157,7 @@ namespace WebGL2RenderingContextBase
 
 
 namespace WebGL2RenderingContextOverloads
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferData(a,b,c)"
   prim__bufferData :
@@ -1167,7 +1167,7 @@ namespace WebGL2RenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferData(a,b,c)"
   prim__bufferData1 :
@@ -1189,7 +1189,7 @@ namespace WebGL2RenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.bufferData(a,b,c,d,e)"
   prim__bufferData2 :
@@ -1211,7 +1211,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferSubData(a,b,c)"
   prim__bufferSubData :
@@ -1232,7 +1232,7 @@ namespace WebGL2RenderingContextOverloads
          ArrayBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.bufferSubData(a,b,c,d,e)"
   prim__bufferSubData1 :
@@ -1254,7 +1254,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.compressedTexImage2D(a,b,c,d,e,f,g,h)"
   prim__compressedTexImage2D :
@@ -1269,7 +1269,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.compressedTexImage2D(a,b,c,d,e,f,g,h,i)"
   prim__compressedTexImage2D1 :
@@ -1295,7 +1295,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.compressedTexSubImage2D(a,b,c,d,e,f,g,h,i)"
   prim__compressedTexSubImage2D :
@@ -1311,7 +1311,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.compressedTexSubImage2D(a,b,c,d,e,f,g,h,i,j)"
   prim__compressedTexSubImage2D1 :
@@ -1338,7 +1338,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.readPixels(a,b,c,d,e,f,g)"
   prim__readPixels :
@@ -1363,7 +1363,7 @@ namespace WebGL2RenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.readPixels(a,b,c,d,e,f,g)"
   prim__readPixels1 :
@@ -1377,7 +1377,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.readPixels(a,b,c,d,e,f,g,h)"
   prim__readPixels2 :
@@ -1402,7 +1402,7 @@ namespace WebGL2RenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texImage2D :
@@ -1429,7 +1429,7 @@ namespace WebGL2RenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.texImage2D(a,b,c,d,e,f)"
   prim__texImage2D1 :
@@ -1448,7 +1448,7 @@ namespace WebGL2RenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texImage2D2 :
@@ -1464,7 +1464,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texImage2D3 :
@@ -1486,7 +1486,7 @@ namespace WebGL2RenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.texImage2D(a,b,c,d,e,f,g,h,i,j)"
   prim__texImage2D4 :
@@ -1513,7 +1513,7 @@ namespace WebGL2RenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texSubImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texSubImage2D :
@@ -1540,7 +1540,7 @@ namespace WebGL2RenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.texSubImage2D(a,b,c,d,e,f,g)"
   prim__texSubImage2D1 :
@@ -1560,7 +1560,7 @@ namespace WebGL2RenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texSubImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texSubImage2D2 :
@@ -1576,7 +1576,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texSubImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texSubImage2D3 :
@@ -1598,7 +1598,7 @@ namespace WebGL2RenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i,j)=>x.texSubImage2D(a,b,c,d,e,f,g,h,i,j)"
   prim__texSubImage2D4 :
@@ -1625,7 +1625,7 @@ namespace WebGL2RenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform1fv(a,b,c,d)"
   prim__uniform1fv :
@@ -1636,7 +1636,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform1iv(a,b,c,d)"
   prim__uniform1iv :
@@ -1647,7 +1647,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform2fv(a,b,c,d)"
   prim__uniform2fv :
@@ -1658,7 +1658,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform2iv(a,b,c,d)"
   prim__uniform2iv :
@@ -1669,7 +1669,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3fv(a,b,c,d)"
   prim__uniform3fv :
@@ -1680,7 +1680,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3iv(a,b,c,d)"
   prim__uniform3iv :
@@ -1691,7 +1691,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform4fv(a,b,c,d)"
   prim__uniform4fv :
@@ -1702,7 +1702,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform4iv(a,b,c,d)"
   prim__uniform4iv :
@@ -1713,7 +1713,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix2fv(a,b,c,d,e)"
   prim__uniformMatrix2fv :
@@ -1725,7 +1725,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix3fv(a,b,c,d,e)"
   prim__uniformMatrix3fv :
@@ -1737,7 +1737,7 @@ namespace WebGL2RenderingContextOverloads
     -> UndefOr Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniformMatrix4fv(a,b,c,d,e)"
   prim__uniformMatrix4fv :
@@ -1752,29 +1752,29 @@ namespace WebGL2RenderingContextOverloads
 
 
 namespace WebGLRenderingContextBase
-
+  
   export
   %foreign "browser:lambda:x=>x.canvas"
   prim__canvas :
        WebGLRenderingContextBase
     -> PrimIO (Union2 HTMLCanvasElement OffscreenCanvas)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.drawingBufferHeight"
   prim__drawingBufferHeight : WebGLRenderingContextBase -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:x=>x.drawingBufferWidth"
   prim__drawingBufferWidth : WebGLRenderingContextBase -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.activeTexture(a)"
   prim__activeTexture : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.attachShader(a,b)"
   prim__attachShader :
@@ -1783,7 +1783,7 @@ namespace WebGLRenderingContextBase
     -> WebGLShader
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bindAttribLocation(a,b,c)"
   prim__bindAttribLocation :
@@ -1793,7 +1793,7 @@ namespace WebGLRenderingContextBase
     -> String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindBuffer(a,b)"
   prim__bindBuffer :
@@ -1802,7 +1802,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindFramebuffer(a,b)"
   prim__bindFramebuffer :
@@ -1811,7 +1811,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLFramebuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindRenderbuffer(a,b)"
   prim__bindRenderbuffer :
@@ -1820,7 +1820,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLRenderbuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.bindTexture(a,b)"
   prim__bindTexture :
@@ -1829,7 +1829,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLTexture
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.blendColor(a,b,c,d)"
   prim__blendColor :
@@ -1840,7 +1840,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.blendEquationSeparate(a,b)"
   prim__blendEquationSeparate :
@@ -1849,12 +1849,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.blendEquation(a)"
   prim__blendEquation : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.blendFuncSeparate(a,b,c,d)"
   prim__blendFuncSeparate :
@@ -1865,12 +1865,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.blendFunc(a,b)"
   prim__blendFunc : WebGLRenderingContextBase -> Bits32 -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.checkFramebufferStatus(a)"
   prim__checkFramebufferStatus :
@@ -1878,7 +1878,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.clearColor(a,b,c,d)"
   prim__clearColor :
@@ -1889,22 +1889,22 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clearDepth(a)"
   prim__clearDepth : WebGLRenderingContextBase -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clearStencil(a)"
   prim__clearStencil : WebGLRenderingContextBase -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.clear(a)"
   prim__clear : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.colorMask(a,b,c,d)"
   prim__colorMask :
@@ -1915,12 +1915,12 @@ namespace WebGLRenderingContextBase
     -> Boolean
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.compileShader(a)"
   prim__compileShader : WebGLRenderingContextBase -> WebGLShader -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.copyTexImage2D(a,b,c,d,e,f,g,h)"
   prim__copyTexImage2D :
@@ -1935,7 +1935,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.copyTexSubImage2D(a,b,c,d,e,f,g,h)"
   prim__copyTexSubImage2D :
@@ -1950,35 +1950,35 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createBuffer()"
   prim__createBuffer :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLBuffer)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createFramebuffer()"
   prim__createFramebuffer :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLFramebuffer)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createProgram()"
   prim__createProgram :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLProgram)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createRenderbuffer()"
   prim__createRenderbuffer :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLRenderbuffer)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.createShader(a)"
   prim__createShader :
@@ -1986,19 +1986,19 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLShader)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.createTexture()"
   prim__createTexture :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLTexture)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.cullFace(a)"
   prim__cullFace : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteBuffer(a)"
   prim__deleteBuffer :
@@ -2006,7 +2006,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteFramebuffer(a)"
   prim__deleteFramebuffer :
@@ -2014,7 +2014,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLFramebuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteProgram(a)"
   prim__deleteProgram :
@@ -2022,7 +2022,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLProgram
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteRenderbuffer(a)"
   prim__deleteRenderbuffer :
@@ -2030,7 +2030,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLRenderbuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteShader(a)"
   prim__deleteShader :
@@ -2038,7 +2038,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLShader
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.deleteTexture(a)"
   prim__deleteTexture :
@@ -2046,22 +2046,22 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLTexture
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.depthFunc(a)"
   prim__depthFunc : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.depthMask(a)"
   prim__depthMask : WebGLRenderingContextBase -> Boolean -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.depthRange(a,b)"
   prim__depthRange : WebGLRenderingContextBase -> Double -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.detachShader(a,b)"
   prim__detachShader :
@@ -2070,7 +2070,7 @@ namespace WebGLRenderingContextBase
     -> WebGLShader
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.disableVertexAttribArray(a)"
   prim__disableVertexAttribArray :
@@ -2078,12 +2078,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.disable(a)"
   prim__disable : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.drawArrays(a,b,c)"
   prim__drawArrays :
@@ -2093,7 +2093,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.drawElements(a,b,c,d)"
   prim__drawElements :
@@ -2104,7 +2104,7 @@ namespace WebGLRenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.enableVertexAttribArray(a)"
   prim__enableVertexAttribArray :
@@ -2112,22 +2112,22 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.enable(a)"
   prim__enable : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.finish()"
   prim__finish : WebGLRenderingContextBase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.flush()"
   prim__flush : WebGLRenderingContextBase -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.framebufferRenderbuffer(a,b,c,d)"
   prim__framebufferRenderbuffer :
@@ -2138,7 +2138,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLRenderbuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.framebufferTexture2D(a,b,c,d,e)"
   prim__framebufferTexture2D :
@@ -2150,17 +2150,17 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.frontFace(a)"
   prim__frontFace : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.generateMipmap(a)"
   prim__generateMipmap : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getActiveAttrib(a,b)"
   prim__getActiveAttrib :
@@ -2169,7 +2169,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLActiveInfo)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getActiveUniform(a,b)"
   prim__getActiveUniform :
@@ -2178,7 +2178,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLActiveInfo)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAttachedShaders(a)"
   prim__getAttachedShaders :
@@ -2186,7 +2186,7 @@ namespace WebGLRenderingContextBase
     -> WebGLProgram
     -> PrimIO (Nullable (Array WebGLShader))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getAttribLocation(a,b)"
   prim__getAttribLocation :
@@ -2195,7 +2195,7 @@ namespace WebGLRenderingContextBase
     -> String
     -> PrimIO Int32
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getBufferParameter(a,b)"
   prim__getBufferParameter :
@@ -2204,19 +2204,19 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getContextAttributes()"
   prim__getContextAttributes :
        WebGLRenderingContextBase
     -> PrimIO (Nullable WebGLContextAttributes)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getError()"
   prim__getError : WebGLRenderingContextBase -> PrimIO Bits32
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getExtension(a)"
   prim__getExtension :
@@ -2224,7 +2224,7 @@ namespace WebGLRenderingContextBase
     -> String
     -> PrimIO (Nullable Object)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.getFramebufferAttachmentParameter(a,b,c)"
   prim__getFramebufferAttachmentParameter :
@@ -2234,12 +2234,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getParameter(a)"
   prim__getParameter : WebGLRenderingContextBase -> Bits32 -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getProgramInfoLog(a)"
   prim__getProgramInfoLog :
@@ -2247,7 +2247,7 @@ namespace WebGLRenderingContextBase
     -> WebGLProgram
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getProgramParameter(a,b)"
   prim__getProgramParameter :
@@ -2256,7 +2256,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getRenderbufferParameter(a,b)"
   prim__getRenderbufferParameter :
@@ -2265,7 +2265,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getShaderInfoLog(a)"
   prim__getShaderInfoLog :
@@ -2273,7 +2273,7 @@ namespace WebGLRenderingContextBase
     -> WebGLShader
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getShaderParameter(a,b)"
   prim__getShaderParameter :
@@ -2282,7 +2282,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getShaderPrecisionFormat(a,b)"
   prim__getShaderPrecisionFormat :
@@ -2291,7 +2291,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO (Nullable WebGLShaderPrecisionFormat)
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getShaderSource(a)"
   prim__getShaderSource :
@@ -2299,14 +2299,14 @@ namespace WebGLRenderingContextBase
     -> WebGLShader
     -> PrimIO (Nullable String)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getSupportedExtensions()"
   prim__getSupportedExtensions :
        WebGLRenderingContextBase
     -> PrimIO (Nullable (Array String))
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getTexParameter(a,b)"
   prim__getTexParameter :
@@ -2315,7 +2315,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getUniformLocation(a,b)"
   prim__getUniformLocation :
@@ -2324,7 +2324,7 @@ namespace WebGLRenderingContextBase
     -> String
     -> PrimIO (Nullable WebGLUniformLocation)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getUniform(a,b)"
   prim__getUniform :
@@ -2333,7 +2333,7 @@ namespace WebGLRenderingContextBase
     -> WebGLUniformLocation
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getVertexAttribOffset(a,b)"
   prim__getVertexAttribOffset :
@@ -2342,7 +2342,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO JSInt64
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.getVertexAttrib(a,b)"
   prim__getVertexAttrib :
@@ -2351,12 +2351,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.hint(a,b)"
   prim__hint : WebGLRenderingContextBase -> Bits32 -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isBuffer(a)"
   prim__isBuffer :
@@ -2364,17 +2364,17 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLBuffer
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.isContextLost()"
   prim__isContextLost : WebGLRenderingContextBase -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isEnabled(a)"
   prim__isEnabled : WebGLRenderingContextBase -> Bits32 -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isFramebuffer(a)"
   prim__isFramebuffer :
@@ -2382,7 +2382,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLFramebuffer
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isProgram(a)"
   prim__isProgram :
@@ -2390,7 +2390,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLProgram
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isRenderbuffer(a)"
   prim__isRenderbuffer :
@@ -2398,7 +2398,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLRenderbuffer
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isShader(a)"
   prim__isShader :
@@ -2406,7 +2406,7 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLShader
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.isTexture(a)"
   prim__isTexture :
@@ -2414,22 +2414,22 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLTexture
     -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.lineWidth(a)"
   prim__lineWidth : WebGLRenderingContextBase -> Double -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.linkProgram(a)"
   prim__linkProgram : WebGLRenderingContextBase -> WebGLProgram -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.pixelStorei(a,b)"
   prim__pixelStorei : WebGLRenderingContextBase -> Bits32 -> Int32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.polygonOffset(a,b)"
   prim__polygonOffset :
@@ -2438,7 +2438,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.renderbufferStorage(a,b,c,d)"
   prim__renderbufferStorage :
@@ -2449,7 +2449,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.sampleCoverage(a,b)"
   prim__sampleCoverage :
@@ -2458,7 +2458,7 @@ namespace WebGLRenderingContextBase
     -> Boolean
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.scissor(a,b,c,d)"
   prim__scissor :
@@ -2469,7 +2469,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.shaderSource(a,b)"
   prim__shaderSource :
@@ -2478,7 +2478,7 @@ namespace WebGLRenderingContextBase
     -> String
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.stencilFuncSeparate(a,b,c,d)"
   prim__stencilFuncSeparate :
@@ -2489,7 +2489,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.stencilFunc(a,b,c)"
   prim__stencilFunc :
@@ -2499,7 +2499,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.stencilMaskSeparate(a,b)"
   prim__stencilMaskSeparate :
@@ -2508,12 +2508,12 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.stencilMask(a)"
   prim__stencilMask : WebGLRenderingContextBase -> Bits32 -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.stencilOpSeparate(a,b,c,d)"
   prim__stencilOpSeparate :
@@ -2524,7 +2524,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.stencilOp(a,b,c)"
   prim__stencilOp :
@@ -2534,7 +2534,7 @@ namespace WebGLRenderingContextBase
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.texParameterf(a,b,c)"
   prim__texParameterf :
@@ -2544,7 +2544,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.texParameteri(a,b,c)"
   prim__texParameteri :
@@ -2554,7 +2554,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform1f(a,b)"
   prim__uniform1f :
@@ -2563,7 +2563,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform1i(a,b)"
   prim__uniform1i :
@@ -2572,7 +2572,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniform2f(a,b,c)"
   prim__uniform2f :
@@ -2582,7 +2582,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniform2i(a,b,c)"
   prim__uniform2i :
@@ -2592,7 +2592,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3f(a,b,c,d)"
   prim__uniform3f :
@@ -2603,7 +2603,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.uniform3i(a,b,c,d)"
   prim__uniform3i :
@@ -2614,7 +2614,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniform4f(a,b,c,d,e)"
   prim__uniform4f :
@@ -2626,7 +2626,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.uniform4i(a,b,c,d,e)"
   prim__uniform4i :
@@ -2638,7 +2638,7 @@ namespace WebGLRenderingContextBase
     -> Int32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.useProgram(a)"
   prim__useProgram :
@@ -2646,12 +2646,12 @@ namespace WebGLRenderingContextBase
     -> Nullable WebGLProgram
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.validateProgram(a)"
   prim__validateProgram : WebGLRenderingContextBase -> WebGLProgram -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttrib1f(a,b)"
   prim__vertexAttrib1f :
@@ -2660,7 +2660,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttrib1fv(a,b)"
   prim__vertexAttrib1fv :
@@ -2669,7 +2669,7 @@ namespace WebGLRenderingContextBase
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.vertexAttrib2f(a,b,c)"
   prim__vertexAttrib2f :
@@ -2679,7 +2679,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttrib2fv(a,b)"
   prim__vertexAttrib2fv :
@@ -2688,7 +2688,7 @@ namespace WebGLRenderingContextBase
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.vertexAttrib3f(a,b,c,d)"
   prim__vertexAttrib3f :
@@ -2699,7 +2699,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttrib3fv(a,b)"
   prim__vertexAttrib3fv :
@@ -2708,7 +2708,7 @@ namespace WebGLRenderingContextBase
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.vertexAttrib4f(a,b,c,d,e)"
   prim__vertexAttrib4f :
@@ -2720,7 +2720,7 @@ namespace WebGLRenderingContextBase
     -> Double
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.vertexAttrib4fv(a,b)"
   prim__vertexAttrib4fv :
@@ -2729,7 +2729,7 @@ namespace WebGLRenderingContextBase
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.vertexAttribPointer(a,b,c,d,e,f)"
   prim__vertexAttribPointer :
@@ -2742,7 +2742,7 @@ namespace WebGLRenderingContextBase
     -> JSInt64
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d)=>x.viewport(a,b,c,d)"
   prim__viewport :
@@ -2756,7 +2756,7 @@ namespace WebGLRenderingContextBase
 
 
 namespace WebGLRenderingContextOverloads
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferData(a,b,c)"
   prim__bufferData :
@@ -2766,7 +2766,7 @@ namespace WebGLRenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferData(a,b,c)"
   prim__bufferData1 :
@@ -2788,7 +2788,7 @@ namespace WebGLRenderingContextOverloads
     -> Bits32
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.bufferSubData(a,b,c)"
   prim__bufferSubData :
@@ -2809,7 +2809,7 @@ namespace WebGLRenderingContextOverloads
          ArrayBuffer
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.compressedTexImage2D(a,b,c,d,e,f,g)"
   prim__compressedTexImage2D :
@@ -2833,7 +2833,7 @@ namespace WebGLRenderingContextOverloads
          DataView
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h)=>x.compressedTexSubImage2D(a,b,c,d,e,f,g,h)"
   prim__compressedTexSubImage2D :
@@ -2858,7 +2858,7 @@ namespace WebGLRenderingContextOverloads
          DataView
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.readPixels(a,b,c,d,e,f,g)"
   prim__readPixels :
@@ -2883,7 +2883,7 @@ namespace WebGLRenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texImage2D :
@@ -2910,7 +2910,7 @@ namespace WebGLRenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f)=>x.texImage2D(a,b,c,d,e,f)"
   prim__texImage2D1 :
@@ -2929,7 +2929,7 @@ namespace WebGLRenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g,h,i)=>x.texSubImage2D(a,b,c,d,e,f,g,h,i)"
   prim__texSubImage2D :
@@ -2956,7 +2956,7 @@ namespace WebGLRenderingContextOverloads
             DataView)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e,f,g)=>x.texSubImage2D(a,b,c,d,e,f,g)"
   prim__texSubImage2D1 :
@@ -2976,7 +2976,7 @@ namespace WebGLRenderingContextOverloads
          OffscreenCanvas
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform1fv(a,b)"
   prim__uniform1fv :
@@ -2985,7 +2985,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform1iv(a,b)"
   prim__uniform1iv :
@@ -2994,7 +2994,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Int32Array (Array Int32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform2fv(a,b)"
   prim__uniform2fv :
@@ -3003,7 +3003,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform2iv(a,b)"
   prim__uniform2iv :
@@ -3012,7 +3012,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Int32Array (Array Int32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform3fv(a,b)"
   prim__uniform3fv :
@@ -3021,7 +3021,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform3iv(a,b)"
   prim__uniform3iv :
@@ -3030,7 +3030,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Int32Array (Array Int32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform4fv(a,b)"
   prim__uniform4fv :
@@ -3039,7 +3039,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.uniform4iv(a,b)"
   prim__uniform4iv :
@@ -3048,7 +3048,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Int32Array (Array Int32)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniformMatrix2fv(a,b,c)"
   prim__uniformMatrix2fv :
@@ -3058,7 +3058,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniformMatrix3fv(a,b,c)"
   prim__uniformMatrix3fv :
@@ -3068,7 +3068,7 @@ namespace WebGLRenderingContextOverloads
     -> Union2 Float32Array (Array Double)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.uniformMatrix4fv(a,b,c)"
   prim__uniformMatrix4fv :
@@ -3086,7 +3086,7 @@ namespace WebGLRenderingContextOverloads
 --------------------------------------------------------------------------------
 
 namespace WebGLContextAttributes
-
+  
   export
   %foreign "browser:lambda:(a,b,c,d,e,f,g,h,i)=> ({alpha: a,depth: b,stencil: c,antialias: d,premultipliedAlpha: e,preserveDrawingBuffer: f,powerPreference: g,failIfMajorPerformanceCaveat: h,desynchronized: i})"
   prim__new :
@@ -3101,49 +3101,49 @@ namespace WebGLContextAttributes
     -> UndefOr Boolean
     -> PrimIO WebGLContextAttributes
 
-
+  
   export
   %foreign "browser:lambda:x=>x.alpha"
   prim__alpha : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.alpha = v}"
   prim__setAlpha : WebGLContextAttributes -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.antialias"
   prim__antialias : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.antialias = v}"
   prim__setAntialias : WebGLContextAttributes -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.depth"
   prim__depth : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.depth = v}"
   prim__setDepth : WebGLContextAttributes -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.desynchronized"
   prim__desynchronized : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.desynchronized = v}"
   prim__setDesynchronized :
@@ -3152,7 +3152,7 @@ namespace WebGLContextAttributes
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.failIfMajorPerformanceCaveat"
   prim__failIfMajorPerformanceCaveat :
@@ -3160,7 +3160,7 @@ namespace WebGLContextAttributes
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.failIfMajorPerformanceCaveat = v}"
   prim__setFailIfMajorPerformanceCaveat :
@@ -3169,13 +3169,13 @@ namespace WebGLContextAttributes
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.powerPreference"
   prim__powerPreference : WebGLContextAttributes -> PrimIO (UndefOr String)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.powerPreference = v}"
   prim__setPowerPreference :
@@ -3184,13 +3184,13 @@ namespace WebGLContextAttributes
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.premultipliedAlpha"
   prim__premultipliedAlpha : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.premultipliedAlpha = v}"
   prim__setPremultipliedAlpha :
@@ -3199,7 +3199,7 @@ namespace WebGLContextAttributes
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.preserveDrawingBuffer"
   prim__preserveDrawingBuffer :
@@ -3207,7 +3207,7 @@ namespace WebGLContextAttributes
     -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.preserveDrawingBuffer = v}"
   prim__setPreserveDrawingBuffer :
@@ -3216,13 +3216,17 @@ namespace WebGLContextAttributes
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.stencil"
   prim__stencil : WebGLContextAttributes -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.stencil = v}"
   prim__setStencil : WebGLContextAttributes -> UndefOr Boolean -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/WebglTypes.idr
+++ b/src/Web/Internal/WebglTypes.idr
@@ -10,35 +10,35 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace WebGLPowerPreference
-
+  
   public export
   data WebGLPowerPreference = Default | LowPower | HighPerformance
-
-  public export
+  
+  export
   Show WebGLPowerPreference where
     show Default = "default"
     show LowPower = "low-power"
     show HighPerformance = "high-performance"
-
-  public export
+  
+  export
   Eq WebGLPowerPreference where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord WebGLPowerPreference where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe WebGLPowerPreference
   read "default" = Just Default
   read "low-power" = Just LowPower
   read "high-performance" = Just HighPerformance
   read _ = Nothing
-
+  
   export
   ToFFI WebGLPowerPreference String where
     toFFI = show
-
+  
   export
   FromFFI WebGLPowerPreference String where
     fromFFI = read
@@ -302,3 +302,5 @@ ToFFI WebGLRenderingContextOverloads WebGLRenderingContextOverloads where toFFI 
 
 export
 FromFFI WebGLRenderingContextOverloads WebGLRenderingContextOverloads where fromFFI = Just
+
+

--- a/src/Web/Internal/WebidlPrim.idr
+++ b/src/Web/Internal/WebidlPrim.idr
@@ -11,22 +11,22 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace DOMException
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new DOMException(a,b)"
   prim__new : UndefOr String -> UndefOr String -> PrimIO DOMException
 
-
+  
   export
   %foreign "browser:lambda:x=>x.code"
   prim__code : DOMException -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.message"
   prim__message : DOMException -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.name"
   prim__name : DOMException -> PrimIO String
@@ -41,7 +41,7 @@ namespace DOMException
 --------------------------------------------------------------------------------
 
 namespace Function
-
+  
   export
   %foreign "browser:lambda:x=>(a)=>x(a)()"
   prim__toFunction : (IO (Array AnyPtr) -> IO AnyPtr) -> PrimIO Function
@@ -49,7 +49,9 @@ namespace Function
 
 
 namespace VoidFunction
-
+  
   export
   %foreign "browser:lambda:x=>()=>x()()"
   prim__toVoidFunction : (() -> IO ()) -> PrimIO VoidFunction
+
+

--- a/src/Web/Internal/WebidlTypes.idr
+++ b/src/Web/Internal/WebidlTypes.idr
@@ -44,3 +44,4 @@ ToFFI VoidFunction VoidFunction where toFFI = id
 
 export
 FromFFI VoidFunction VoidFunction where fromFFI = Just
+

--- a/src/Web/Internal/XhrPrim.idr
+++ b/src/Web/Internal/XhrPrim.idr
@@ -11,47 +11,47 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace FormData
-
+  
   export
   %foreign "browser:lambda:(a)=> new FormData(a)"
   prim__new : UndefOr HTMLFormElement -> PrimIO FormData
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.append(a,b)"
   prim__append : FormData -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.append(a,b,c)"
   prim__append1 : FormData -> String -> Blob -> UndefOr String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.delete(a)"
   prim__delete : FormData -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getAll(a)"
   prim__getAll : FormData -> String -> PrimIO (Array (Union2 File String))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.get(a)"
   prim__get : FormData -> String -> PrimIO (Nullable (Union2 File String))
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.has(a)"
   prim__has : FormData -> String -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.set(a,b)"
   prim__set : FormData -> String -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c)=>x.set(a,b,c)"
   prim__set1 : FormData -> String -> Blob -> UndefOr String -> PrimIO ()
@@ -59,22 +59,22 @@ namespace FormData
 
 
 namespace ProgressEvent
-
+  
   export
   %foreign "browser:lambda:(a,b)=> new ProgressEvent(a,b)"
   prim__new : String -> UndefOr ProgressEventInit -> PrimIO ProgressEvent
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lengthComputable"
   prim__lengthComputable : ProgressEvent -> PrimIO Boolean
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loaded"
   prim__loaded : ProgressEvent -> PrimIO JSBits64
 
-
+  
   export
   %foreign "browser:lambda:x=>x.total"
   prim__total : ProgressEvent -> PrimIO JSBits64
@@ -82,12 +82,12 @@ namespace ProgressEvent
 
 
 namespace XMLHttpRequest
-
+  
   export
   %foreign "browser:lambda:()=> new XMLHttpRequest()"
   prim__new : PrimIO XMLHttpRequest
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onreadystatechange"
   prim__onreadystatechange :
@@ -95,7 +95,7 @@ namespace XMLHttpRequest
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onreadystatechange = v}"
   prim__setOnreadystatechange :
@@ -104,93 +104,93 @@ namespace XMLHttpRequest
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.readyState"
   prim__readyState : XMLHttpRequest -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.response"
   prim__response : XMLHttpRequest -> PrimIO AnyPtr
 
-
+  
   export
   %foreign "browser:lambda:x=>x.responseText"
   prim__responseText : XMLHttpRequest -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.responseType"
   prim__responseType : XMLHttpRequest -> PrimIO String
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.responseType = v}"
   prim__setResponseType : XMLHttpRequest -> String -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.responseURL"
   prim__responseURL : XMLHttpRequest -> PrimIO String
 
-
+  
   export
   %foreign "browser:lambda:x=>x.responseXML"
   prim__responseXML : XMLHttpRequest -> PrimIO (Nullable Document)
 
-
+  
   export
   %foreign "browser:lambda:x=>x.status"
   prim__status : XMLHttpRequest -> PrimIO Bits16
 
-
+  
   export
   %foreign "browser:lambda:x=>x.statusText"
   prim__statusText : XMLHttpRequest -> PrimIO ByteString
 
-
+  
   export
   %foreign "browser:lambda:x=>x.timeout"
   prim__timeout : XMLHttpRequest -> PrimIO Bits32
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.timeout = v}"
   prim__setTimeout : XMLHttpRequest -> Bits32 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.upload"
   prim__upload : XMLHttpRequest -> PrimIO XMLHttpRequestUpload
 
-
+  
   export
   %foreign "browser:lambda:x=>x.withCredentials"
   prim__withCredentials : XMLHttpRequest -> PrimIO Boolean
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.withCredentials = v}"
   prim__setWithCredentials : XMLHttpRequest -> Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.abort()"
   prim__abort : XMLHttpRequest -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:x=>x.getAllResponseHeaders()"
   prim__getAllResponseHeaders : XMLHttpRequest -> PrimIO ByteString
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.getResponseHeader(a)"
   prim__getResponseHeader :
@@ -198,12 +198,12 @@ namespace XMLHttpRequest
     -> ByteString
     -> PrimIO (Nullable ByteString)
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.open(a,b)"
   prim__open : XMLHttpRequest -> ByteString -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b,c,d,e)=>x.open(a,b,c,d,e)"
   prim__open1 :
@@ -215,12 +215,12 @@ namespace XMLHttpRequest
     -> UndefOr (Nullable String)
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.overrideMimeType(a)"
   prim__overrideMimeType : XMLHttpRequest -> String -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a)=>x.send(a)"
   prim__send :
@@ -246,7 +246,7 @@ namespace XMLHttpRequest
                String))
     -> PrimIO ()
 
-
+  
   export
   %foreign "browser:lambda:(x,a,b)=>x.setRequestHeader(a,b)"
   prim__setRequestHeader :
@@ -258,7 +258,7 @@ namespace XMLHttpRequest
 
 
 namespace XMLHttpRequestEventTarget
-
+  
   export
   %foreign "browser:lambda:x=>x.onabort"
   prim__onabort :
@@ -266,7 +266,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onabort = v}"
   prim__setOnabort :
@@ -275,7 +275,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onerror"
   prim__onerror :
@@ -283,7 +283,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onerror = v}"
   prim__setOnerror :
@@ -292,7 +292,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onload"
   prim__onload :
@@ -300,7 +300,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onload = v}"
   prim__setOnload :
@@ -309,7 +309,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadend"
   prim__onloadend :
@@ -317,7 +317,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadend = v}"
   prim__setOnloadend :
@@ -326,7 +326,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onloadstart"
   prim__onloadstart :
@@ -334,7 +334,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onloadstart = v}"
   prim__setOnloadstart :
@@ -343,7 +343,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.onprogress"
   prim__onprogress :
@@ -351,7 +351,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.onprogress = v}"
   prim__setOnprogress :
@@ -360,7 +360,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.ontimeout"
   prim__ontimeout :
@@ -368,7 +368,7 @@ namespace XMLHttpRequestEventTarget
     -> PrimIO (Nullable EventHandlerNonNull)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.ontimeout = v}"
   prim__setOntimeout :
@@ -387,7 +387,7 @@ namespace XMLHttpRequestEventTarget
 --------------------------------------------------------------------------------
 
 namespace ProgressEventInit
-
+  
   export
   %foreign "browser:lambda:(a,b,c)=> ({lengthComputable: a,loaded: b,total: c})"
   prim__new :
@@ -396,37 +396,41 @@ namespace ProgressEventInit
     -> UndefOr JSBits64
     -> PrimIO ProgressEventInit
 
-
+  
   export
   %foreign "browser:lambda:x=>x.lengthComputable"
   prim__lengthComputable : ProgressEventInit -> PrimIO (UndefOr Boolean)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.lengthComputable = v}"
   prim__setLengthComputable : ProgressEventInit -> UndefOr Boolean -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.loaded"
   prim__loaded : ProgressEventInit -> PrimIO (UndefOr JSBits64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.loaded = v}"
   prim__setLoaded : ProgressEventInit -> UndefOr JSBits64 -> PrimIO ()
 
 
-
+  
   export
   %foreign "browser:lambda:x=>x.total"
   prim__total : ProgressEventInit -> PrimIO (UndefOr JSBits64)
 
 
-
+  
   export
   %foreign "browser:lambda:(x,v)=>{x.total = v}"
   prim__setTotal : ProgressEventInit -> UndefOr JSBits64 -> PrimIO ()
+
+
+
+

--- a/src/Web/Internal/XhrTypes.idr
+++ b/src/Web/Internal/XhrTypes.idr
@@ -10,7 +10,7 @@ import JS
 --------------------------------------------------------------------------------
 
 namespace XMLHttpRequestResponseType
-
+  
   public export
   data XMLHttpRequestResponseType =
       Empty
@@ -19,8 +19,8 @@ namespace XMLHttpRequestResponseType
     | Document
     | Json
     | Text
-
-  public export
+  
+  export
   Show XMLHttpRequestResponseType where
     show Empty = ""
     show Arraybuffer = "arraybuffer"
@@ -28,16 +28,16 @@ namespace XMLHttpRequestResponseType
     show Document = "document"
     show Json = "json"
     show Text = "text"
-
-  public export
+  
+  export
   Eq XMLHttpRequestResponseType where
     (==) = (==) `on` show
-
-  public export
+  
+  export
   Ord XMLHttpRequestResponseType where
     compare = compare `on` show
-
-  public export
+  
+  export
   read : String -> Maybe XMLHttpRequestResponseType
   read "" = Just Empty
   read "arraybuffer" = Just Arraybuffer
@@ -46,11 +46,11 @@ namespace XMLHttpRequestResponseType
   read "json" = Just Json
   read "text" = Just Text
   read _ = Nothing
-
+  
   export
   ToFFI XMLHttpRequestResponseType String where
     toFFI = show
-
+  
   export
   FromFFI XMLHttpRequestResponseType String where
     fromFFI = read
@@ -133,3 +133,6 @@ ToFFI ProgressEventInit ProgressEventInit where toFFI = id
 
 export
 FromFFI ProgressEventInit ProgressEventInit where fromFFI = Just
+
+
+

--- a/src/Web/Raw/Animation.idr
+++ b/src/Web/Raw/Animation.idr
@@ -12,249 +12,199 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Animation
-
+  
   export
-  currentTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
-    -> t
-    -> Attribute False Maybe Double
+  currentTime : {auto _ : Cast t Animation} -> t -> Attribute False Maybe Double
   currentTime v = fromNullablePrim
                     "Animation.getcurrentTime"
                     prim__currentTime
                     prim__setCurrentTime
-                    (v :> Animation)
+                    (cast {to = Animation} v)
 
-
+  
   export
   effect :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
+       {auto _ : Cast t Animation}
     -> t
     -> Attribute False Maybe AnimationEffect
   effect v = fromNullablePrim
                "Animation.geteffect"
                prim__effect
                prim__setEffect
-               (v :> Animation)
+               (cast {to = Animation} v)
 
-
+  
   export
   finished :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
+       {auto _ : Cast t1 Animation}
     -> (obj : t1)
     -> JSIO (Promise Animation)
-  finished a = primJS $ Animation.prim__finished (up a)
+  finished a = primJS $ Animation.prim__finished (cast a)
 
-
+  
   export
-  id :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
-  id v = fromPrim "Animation.getid" prim__id prim__setId (v :> Animation)
+  id : {auto _ : Cast t Animation} -> t -> Attribute True Prelude.id String
+  id v = fromPrim
+           "Animation.getid"
+           prim__id
+           prim__setId
+           (cast {to = Animation} v)
 
-
+  
   export
   oncancel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
+       {auto _ : Cast t Animation}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncancel v = fromNullablePrim
                  "Animation.getoncancel"
                  prim__oncancel
                  prim__setOncancel
-                 (v :> Animation)
+                 (cast {to = Animation} v)
 
-
+  
   export
   onfinish :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
+       {auto _ : Cast t Animation}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onfinish v = fromNullablePrim
                  "Animation.getonfinish"
                  prim__onfinish
                  prim__setOnfinish
-                 (v :> Animation)
+                 (cast {to = Animation} v)
 
-
+  
   export
-  pending :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  pending a = tryJS "Animation.pending" $ Animation.prim__pending (up a)
+  pending : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO Bool
+  pending a = tryJS "Animation.pending" $ Animation.prim__pending (cast a)
 
-
+  
   export
   playState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
+       {auto _ : Cast t1 Animation}
     -> (obj : t1)
     -> JSIO AnimationPlayState
-  playState a = tryJS "Animation.playState" $ Animation.prim__playState (up a)
+  playState a = tryJS "Animation.playState" $ Animation.prim__playState (cast a)
 
-
+  
   export
   playbackRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
+       {auto _ : Cast t Animation}
     -> t
     -> Attribute True Prelude.id Double
   playbackRate v = fromPrim
                      "Animation.getplaybackRate"
                      prim__playbackRate
                      prim__setPlaybackRate
-                     (v :> Animation)
+                     (cast {to = Animation} v)
 
-
+  
   export
-  ready :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise Animation)
-  ready a = primJS $ Animation.prim__ready (up a)
+  ready : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO (Promise Animation)
+  ready a = primJS $ Animation.prim__ready (cast a)
 
-
+  
   export
-  startTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
-    -> t
-    -> Attribute False Maybe Double
+  startTime : {auto _ : Cast t Animation} -> t -> Attribute False Maybe Double
   startTime v = fromNullablePrim
                   "Animation.getstartTime"
                   prim__startTime
                   prim__setStartTime
-                  (v :> Animation)
+                  (cast {to = Animation} v)
 
-
+  
   export
   timeline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Animation (Types t)}
+       {auto _ : Cast t Animation}
     -> t
     -> Attribute False Maybe AnimationTimeline
   timeline v = fromNullablePrim
                  "Animation.gettimeline"
                  prim__timeline
                  prim__setTimeline
-                 (v :> Animation)
+                 (cast {to = Animation} v)
 
-
+  
   export
-  cancel :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  cancel a = primJS $ Animation.prim__cancel (up a)
+  cancel : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO ()
+  cancel a = primJS $ Animation.prim__cancel (cast a)
 
-
+  
   export
-  finish :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  finish a = primJS $ Animation.prim__finish (up a)
+  finish : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO ()
+  finish a = primJS $ Animation.prim__finish (cast a)
 
-
+  
   export
-  pause :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  pause a = primJS $ Animation.prim__pause (up a)
+  pause : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO ()
+  pause a = primJS $ Animation.prim__pause (cast a)
 
-
+  
   export
-  play :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  play a = primJS $ Animation.prim__play (up a)
+  play : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO ()
+  play a = primJS $ Animation.prim__play (cast a)
 
-
+  
   export
-  reverse :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  reverse a = primJS $ Animation.prim__reverse (up a)
+  reverse : {auto _ : Cast t1 Animation} -> (obj : t1) -> JSIO ()
+  reverse a = primJS $ Animation.prim__reverse (cast a)
 
-
+  
   export
   updatePlaybackRate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animation (Types t1)}
+       {auto _ : Cast t1 Animation}
     -> (obj : t1)
     -> (playbackRate : Double)
     -> JSIO ()
-  updatePlaybackRate a b = primJS $ Animation.prim__updatePlaybackRate (up a) b
+  updatePlaybackRate a b = primJS $
+    Animation.prim__updatePlaybackRate (cast a) b
 
 
 
 namespace AnimationEffect
-
+  
   export
   getComputedTiming :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AnimationEffect (Types t1)}
+       {auto _ : Cast t1 AnimationEffect}
     -> (obj : t1)
     -> JSIO ComputedEffectTiming
-  getComputedTiming a = primJS $ AnimationEffect.prim__getComputedTiming (up a)
+  getComputedTiming a = primJS $
+    AnimationEffect.prim__getComputedTiming (cast a)
 
-
+  
   export
   getTiming :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AnimationEffect (Types t1)}
+       {auto _ : Cast t1 AnimationEffect}
     -> (obj : t1)
     -> JSIO EffectTiming
-  getTiming a = primJS $ AnimationEffect.prim__getTiming (up a)
+  getTiming a = primJS $ AnimationEffect.prim__getTiming (cast a)
 
-
+  
   export
   updateTiming' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem AnimationEffect (Types t1)}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t2)}
+       {auto _ : Cast t1 AnimationEffect}
+    -> {auto _ : Cast t2 OptionalEffectTiming}
     -> (obj : t1)
     -> (timing : Optional t2)
     -> JSIO ()
   updateTiming' a b = primJS $
-    AnimationEffect.prim__updateTiming (up a) (optUp b)
-
+    AnimationEffect.prim__updateTiming (cast a) (optUp b)
+  
   export
-  updateTiming :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AnimationEffect (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  updateTiming a = primJS $ AnimationEffect.prim__updateTiming (up a) undef
+  updateTiming : {auto _ : Cast t1 AnimationEffect} -> (obj : t1) -> JSIO ()
+  updateTiming a = primJS $ AnimationEffect.prim__updateTiming (cast a) undef
 
 
 
 namespace AnimationPlaybackEvent
-
+  
   export
   currentTime : (obj : AnimationPlaybackEvent) -> JSIO (Maybe Double)
   currentTime a = tryJS "AnimationPlaybackEvent.currentTime" $
     AnimationPlaybackEvent.prim__currentTime a
 
-
+  
   export
   timelineTime : (obj : AnimationPlaybackEvent) -> JSIO (Maybe Double)
   timelineTime a = tryJS "AnimationPlaybackEvent.timelineTime" $
@@ -263,21 +213,20 @@ namespace AnimationPlaybackEvent
 
 
 namespace AnimationTimeline
-
+  
   export
   currentTime :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AnimationTimeline (Types t1)}
+       {auto _ : Cast t1 AnimationTimeline}
     -> (obj : t1)
     -> JSIO (Maybe Double)
   currentTime a = tryJS "AnimationTimeline.currentTime" $
-    AnimationTimeline.prim__currentTime (up a)
+    AnimationTimeline.prim__currentTime (cast a)
 
 
 
 
 namespace KeyframeEffect
-
+  
   export
   composite : KeyframeEffect -> Attribute True Prelude.id CompositeOperation
   composite v = fromPrim
@@ -286,7 +235,7 @@ namespace KeyframeEffect
                   prim__setComposite
                   v
 
-
+  
   export
   iterationComposite :
        KeyframeEffect
@@ -297,7 +246,7 @@ namespace KeyframeEffect
                            prim__setIterationComposite
                            v
 
-
+  
   export
   target :
        KeyframeEffect
@@ -308,16 +257,15 @@ namespace KeyframeEffect
                prim__setTarget
                v
 
-
+  
   export
   getKeyframes : (obj : KeyframeEffect) -> JSIO (Array Object)
   getKeyframes a = primJS $ KeyframeEffect.prim__getKeyframes a
 
-
+  
   export
   setKeyframes :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Object (Types t2)}
+       {auto _ : Cast t2 Object}
     -> (obj : KeyframeEffect)
     -> (keyframes : Maybe t2)
     -> JSIO ()
@@ -331,38 +279,34 @@ namespace KeyframeEffect
 --------------------------------------------------------------------------------
 
 namespace Animatable
-
+  
   export
   animate' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Animatable (Types t1)}
-    -> {auto 0 _ : Elem Object (Types t2)}
+       {auto _ : Cast t1 Animatable}
+    -> {auto _ : Cast t2 Object}
     -> (obj : t1)
     -> (keyframes : Maybe t2)
     -> (options : Optional (HSum [Double, KeyframeAnimationOptions]))
     -> JSIO Animation
-  animate' a b c = primJS $ Animatable.prim__animate (up a) (mayUp b) (toFFI c)
-
+  animate' a b c = primJS $
+    Animatable.prim__animate (cast a) (mayUp b) (toFFI c)
+  
   export
   animate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Animatable (Types t1)}
-    -> {auto 0 _ : Elem Object (Types t2)}
+       {auto _ : Cast t1 Animatable}
+    -> {auto _ : Cast t2 Object}
     -> (obj : t1)
     -> (keyframes : Maybe t2)
     -> JSIO Animation
-  animate a b = primJS $ Animatable.prim__animate (up a) (mayUp b) undef
+  animate a b = primJS $ Animatable.prim__animate (cast a) (mayUp b) undef
 
-
+  
   export
   getAnimations :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Animatable (Types t1)}
+       {auto _ : Cast t1 Animatable}
     -> (obj : t1)
     -> JSIO (Array Animation)
-  getAnimations a = primJS $ Animatable.prim__getAnimations (up a)
+  getAnimations a = primJS $ Animatable.prim__getAnimations (cast a)
 
 
 
@@ -372,23 +316,22 @@ namespace Animatable
 --------------------------------------------------------------------------------
 
 namespace AnimationPlaybackEventInit
-
+  
   export
   new' :
        (currentTime : Optional (Maybe Double))
     -> (timelineTime : Optional (Maybe Double))
     -> JSIO AnimationPlaybackEventInit
   new' a b = primJS $ AnimationPlaybackEventInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO AnimationPlaybackEventInit
   new = primJS $ AnimationPlaybackEventInit.prim__new undef undef
 
-
+  
   export
   currentTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AnimationPlaybackEventInit (Types t)}
+       {auto _ : Cast t AnimationPlaybackEventInit}
     -> t
     -> Attribute True Optional (Maybe Double)
   currentTime v = fromUndefOrPrim
@@ -396,13 +339,12 @@ namespace AnimationPlaybackEventInit
                     prim__currentTime
                     prim__setCurrentTime
                     Nothing
-                    (v :> AnimationPlaybackEventInit)
+                    (cast {to = AnimationPlaybackEventInit} v)
 
-
+  
   export
   timelineTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AnimationPlaybackEventInit (Types t)}
+       {auto _ : Cast t AnimationPlaybackEventInit}
     -> t
     -> Attribute True Optional (Maybe Double)
   timelineTime v = fromUndefOrPrim
@@ -410,12 +352,12 @@ namespace AnimationPlaybackEventInit
                      prim__timelineTime
                      prim__setTimelineTime
                      Nothing
-                     (v :> AnimationPlaybackEventInit)
+                     (cast {to = AnimationPlaybackEventInit} v)
 
 
 
 namespace BaseComputedKeyframe
-
+  
   export
   new' :
        (offset : Optional (Maybe Double))
@@ -425,42 +367,39 @@ namespace BaseComputedKeyframe
     -> JSIO BaseComputedKeyframe
   new' a b c d = primJS $
     BaseComputedKeyframe.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO BaseComputedKeyframe
   new = primJS $ BaseComputedKeyframe.prim__new undef undef undef undef
 
-
+  
   export
   composite :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseComputedKeyframe (Types t)}
+       {auto _ : Cast t BaseComputedKeyframe}
     -> t
     -> Attribute False Optional CompositeOperationOrAuto
   composite v = fromUndefOrPrimNoDefault
                   "BaseComputedKeyframe.getcomposite"
                   prim__composite
                   prim__setComposite
-                  (v :> BaseComputedKeyframe)
+                  (cast {to = BaseComputedKeyframe} v)
 
-
+  
   export
   computedOffset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseComputedKeyframe (Types t)}
+       {auto _ : Cast t BaseComputedKeyframe}
     -> t
     -> Attribute False Optional Double
   computedOffset v = fromUndefOrPrimNoDefault
                        "BaseComputedKeyframe.getcomputedOffset"
                        prim__computedOffset
                        prim__setComputedOffset
-                       (v :> BaseComputedKeyframe)
+                       (cast {to = BaseComputedKeyframe} v)
 
-
+  
   export
   easing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseComputedKeyframe (Types t)}
+       {auto _ : Cast t BaseComputedKeyframe}
     -> t
     -> Attribute True Optional String
   easing v = fromUndefOrPrim
@@ -468,13 +407,12 @@ namespace BaseComputedKeyframe
                prim__easing
                prim__setEasing
                "linear"
-               (v :> BaseComputedKeyframe)
+               (cast {to = BaseComputedKeyframe} v)
 
-
+  
   export
   offset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseComputedKeyframe (Types t)}
+       {auto _ : Cast t BaseComputedKeyframe}
     -> t
     -> Attribute True Optional (Maybe Double)
   offset v = fromUndefOrPrim
@@ -482,12 +420,12 @@ namespace BaseComputedKeyframe
                prim__offset
                prim__setOffset
                Nothing
-               (v :> BaseComputedKeyframe)
+               (cast {to = BaseComputedKeyframe} v)
 
 
 
 namespace BaseKeyframe
-
+  
   export
   new' :
        (offset : Optional (Maybe Double))
@@ -495,43 +433,37 @@ namespace BaseKeyframe
     -> (composite : Optional CompositeOperationOrAuto)
     -> JSIO BaseKeyframe
   new' a b c = primJS $ BaseKeyframe.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO BaseKeyframe
   new = primJS $ BaseKeyframe.prim__new undef undef undef
 
-
+  
   export
   composite :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseKeyframe (Types t)}
+       {auto _ : Cast t BaseKeyframe}
     -> t
     -> Attribute False Optional CompositeOperationOrAuto
   composite v = fromUndefOrPrimNoDefault
                   "BaseKeyframe.getcomposite"
                   prim__composite
                   prim__setComposite
-                  (v :> BaseKeyframe)
+                  (cast {to = BaseKeyframe} v)
 
-
+  
   export
-  easing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseKeyframe (Types t)}
-    -> t
-    -> Attribute True Optional String
+  easing : {auto _ : Cast t BaseKeyframe} -> t -> Attribute True Optional String
   easing v = fromUndefOrPrim
                "BaseKeyframe.geteasing"
                prim__easing
                prim__setEasing
                "linear"
-               (v :> BaseKeyframe)
+               (cast {to = BaseKeyframe} v)
 
-
+  
   export
   offset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BaseKeyframe (Types t)}
+       {auto _ : Cast t BaseKeyframe}
     -> t
     -> Attribute True Optional (Maybe Double)
   offset v = fromUndefOrPrim
@@ -539,12 +471,12 @@ namespace BaseKeyframe
                prim__offset
                prim__setOffset
                Nothing
-               (v :> BaseKeyframe)
+               (cast {to = BaseKeyframe} v)
 
 
 
 namespace BasePropertyIndexedKeyframe
-
+  
   export
   new' :
        (offset : Optional (Maybe (HSum [Double, Array (Nullable Double)])))
@@ -553,42 +485,39 @@ namespace BasePropertyIndexedKeyframe
     -> JSIO BasePropertyIndexedKeyframe
   new' a b c = primJS $
     BasePropertyIndexedKeyframe.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO BasePropertyIndexedKeyframe
   new = primJS $ BasePropertyIndexedKeyframe.prim__new undef undef undef
 
-
+  
   export
   composite :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BasePropertyIndexedKeyframe (Types t)}
+       {auto _ : Cast t BasePropertyIndexedKeyframe}
     -> t
     -> Attribute False Optional (Union2 String (Array String))
   composite v = fromUndefOrPrimNoDefault
                   "BasePropertyIndexedKeyframe.getcomposite"
                   prim__composite
                   prim__setComposite
-                  (v :> BasePropertyIndexedKeyframe)
+                  (cast {to = BasePropertyIndexedKeyframe} v)
 
-
+  
   export
   easing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BasePropertyIndexedKeyframe (Types t)}
+       {auto _ : Cast t BasePropertyIndexedKeyframe}
     -> t
     -> Attribute False Optional (Union2 String (Array String))
   easing v = fromUndefOrPrimNoDefault
                "BasePropertyIndexedKeyframe.geteasing"
                prim__easing
                prim__setEasing
-               (v :> BasePropertyIndexedKeyframe)
+               (cast {to = BasePropertyIndexedKeyframe} v)
 
-
+  
   export
   offset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BasePropertyIndexedKeyframe (Types t)}
+       {auto _ : Cast t BasePropertyIndexedKeyframe}
     -> t
     -> Attribute False Optional (Maybe
                                    (Union2 Double (Array (Nullable Double))))
@@ -596,12 +525,12 @@ namespace BasePropertyIndexedKeyframe
                "BasePropertyIndexedKeyframe.getoffset"
                prim__offset
                prim__setOffset
-               (v :> BasePropertyIndexedKeyframe)
+               (cast {to = BasePropertyIndexedKeyframe} v)
 
 
 
 namespace ComputedEffectTiming
-
+  
   export
   new' :
        (endTime : Optional Double)
@@ -617,93 +546,87 @@ namespace ComputedEffectTiming
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   new : JSIO ComputedEffectTiming
   new = primJS $ ComputedEffectTiming.prim__new undef undef undef undef undef
 
-
+  
   export
   activeDuration :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ComputedEffectTiming (Types t)}
+       {auto _ : Cast t ComputedEffectTiming}
     -> t
     -> Attribute False Optional Double
   activeDuration v = fromUndefOrPrimNoDefault
                        "ComputedEffectTiming.getactiveDuration"
                        prim__activeDuration
                        prim__setActiveDuration
-                       (v :> ComputedEffectTiming)
+                       (cast {to = ComputedEffectTiming} v)
 
-
+  
   export
   currentIteration :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ComputedEffectTiming (Types t)}
+       {auto _ : Cast t ComputedEffectTiming}
     -> t
     -> Attribute False Optional (Maybe Double)
   currentIteration v = fromUndefOrPrimNoDefault
                          "ComputedEffectTiming.getcurrentIteration"
                          prim__currentIteration
                          prim__setCurrentIteration
-                         (v :> ComputedEffectTiming)
+                         (cast {to = ComputedEffectTiming} v)
 
-
+  
   export
   endTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ComputedEffectTiming (Types t)}
+       {auto _ : Cast t ComputedEffectTiming}
     -> t
     -> Attribute False Optional Double
   endTime v = fromUndefOrPrimNoDefault
                 "ComputedEffectTiming.getendTime"
                 prim__endTime
                 prim__setEndTime
-                (v :> ComputedEffectTiming)
+                (cast {to = ComputedEffectTiming} v)
 
-
+  
   export
   localTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ComputedEffectTiming (Types t)}
+       {auto _ : Cast t ComputedEffectTiming}
     -> t
     -> Attribute False Optional (Maybe Double)
   localTime v = fromUndefOrPrimNoDefault
                   "ComputedEffectTiming.getlocalTime"
                   prim__localTime
                   prim__setLocalTime
-                  (v :> ComputedEffectTiming)
+                  (cast {to = ComputedEffectTiming} v)
 
-
+  
   export
   progress :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ComputedEffectTiming (Types t)}
+       {auto _ : Cast t ComputedEffectTiming}
     -> t
     -> Attribute False Optional (Maybe Double)
   progress v = fromUndefOrPrimNoDefault
                  "ComputedEffectTiming.getprogress"
                  prim__progress
                  prim__setProgress
-                 (v :> ComputedEffectTiming)
+                 (cast {to = ComputedEffectTiming} v)
 
 
 
 namespace DocumentTimelineOptions
-
+  
   export
   new' : (originTime : Optional Double) -> JSIO DocumentTimelineOptions
   new' a = primJS $ DocumentTimelineOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO DocumentTimelineOptions
   new = primJS $ DocumentTimelineOptions.prim__new undef
 
-
+  
   export
   originTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DocumentTimelineOptions (Types t)}
+       {auto _ : Cast t DocumentTimelineOptions}
     -> t
     -> Attribute True Optional Double
   originTime v = fromUndefOrPrim
@@ -711,12 +634,12 @@ namespace DocumentTimelineOptions
                    prim__originTime
                    prim__setOriginTime
                    0
-                   (v :> DocumentTimelineOptions)
+                   (cast {to = DocumentTimelineOptions} v)
 
 
 
 namespace EffectTiming
-
+  
   export
   new' :
        (delay : Optional Double)
@@ -738,71 +661,60 @@ namespace EffectTiming
       (toFFI f)
       (toFFI g)
       (toFFI h)
-
+  
   export
   new : JSIO EffectTiming
   new = primJS $
     EffectTiming.prim__new undef undef undef undef undef undef undef undef
 
-
+  
   export
-  delay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  delay : {auto _ : Cast t EffectTiming} -> t -> Attribute True Optional Double
   delay v = fromUndefOrPrim
               "EffectTiming.getdelay"
               prim__delay
               prim__setDelay
               0
-              (v :> EffectTiming)
+              (cast {to = EffectTiming} v)
 
-
+  
   export
   direction :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute False Optional PlaybackDirection
   direction v = fromUndefOrPrimNoDefault
                   "EffectTiming.getdirection"
                   prim__direction
                   prim__setDirection
-                  (v :> EffectTiming)
+                  (cast {to = EffectTiming} v)
 
-
+  
   export
   duration :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute False Optional (HSum [Double, String])
   duration v = fromUndefOrPrimNoDefault
                  "EffectTiming.getduration"
                  prim__duration
                  prim__setDuration
-                 (v :> EffectTiming)
+                 (cast {to = EffectTiming} v)
 
-
+  
   export
-  easing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
-    -> t
-    -> Attribute True Optional String
+  easing : {auto _ : Cast t EffectTiming} -> t -> Attribute True Optional String
   easing v = fromUndefOrPrim
                "EffectTiming.geteasing"
                prim__easing
                prim__setEasing
                "linear"
-               (v :> EffectTiming)
+               (cast {to = EffectTiming} v)
 
-
+  
   export
   endDelay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute True Optional Double
   endDelay v = fromUndefOrPrim
@@ -810,26 +722,24 @@ namespace EffectTiming
                  prim__endDelay
                  prim__setEndDelay
                  0
-                 (v :> EffectTiming)
+                 (cast {to = EffectTiming} v)
 
-
+  
   export
   fill :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute False Optional FillMode
   fill v = fromUndefOrPrimNoDefault
              "EffectTiming.getfill"
              prim__fill
              prim__setFill
-             (v :> EffectTiming)
+             (cast {to = EffectTiming} v)
 
-
+  
   export
   iterationStart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute True Optional Double
   iterationStart v = fromUndefOrPrim
@@ -837,13 +747,12 @@ namespace EffectTiming
                        prim__iterationStart
                        prim__setIterationStart
                        0.0
-                       (v :> EffectTiming)
+                       (cast {to = EffectTiming} v)
 
-
+  
   export
   iterations :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EffectTiming (Types t)}
+       {auto _ : Cast t EffectTiming}
     -> t
     -> Attribute True Optional Double
   iterations v = fromUndefOrPrim
@@ -851,25 +760,24 @@ namespace EffectTiming
                    prim__iterations
                    prim__setIterations
                    1.0
-                   (v :> EffectTiming)
+                   (cast {to = EffectTiming} v)
 
 
 
 namespace KeyframeAnimationOptions
-
+  
   export
   new' : (id : Optional String) -> JSIO KeyframeAnimationOptions
   new' a = primJS $ KeyframeAnimationOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO KeyframeAnimationOptions
   new = primJS $ KeyframeAnimationOptions.prim__new undef
 
-
+  
   export
   id :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyframeAnimationOptions (Types t)}
+       {auto _ : Cast t KeyframeAnimationOptions}
     -> t
     -> Attribute True Optional String
   id v = fromUndefOrPrim
@@ -877,53 +785,51 @@ namespace KeyframeAnimationOptions
            prim__id
            prim__setId
            ""
-           (v :> KeyframeAnimationOptions)
+           (cast {to = KeyframeAnimationOptions} v)
 
 
 
 namespace KeyframeEffectOptions
-
+  
   export
   new' :
        (iterationComposite : Optional IterationCompositeOperation)
     -> (composite : Optional CompositeOperation)
     -> JSIO KeyframeEffectOptions
   new' a b = primJS $ KeyframeEffectOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO KeyframeEffectOptions
   new = primJS $ KeyframeEffectOptions.prim__new undef undef
 
-
+  
   export
   composite :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyframeEffectOptions (Types t)}
+       {auto _ : Cast t KeyframeEffectOptions}
     -> t
     -> Attribute False Optional CompositeOperation
   composite v = fromUndefOrPrimNoDefault
                   "KeyframeEffectOptions.getcomposite"
                   prim__composite
                   prim__setComposite
-                  (v :> KeyframeEffectOptions)
+                  (cast {to = KeyframeEffectOptions} v)
 
-
+  
   export
   iterationComposite :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyframeEffectOptions (Types t)}
+       {auto _ : Cast t KeyframeEffectOptions}
     -> t
     -> Attribute False Optional IterationCompositeOperation
   iterationComposite v = fromUndefOrPrimNoDefault
                            "KeyframeEffectOptions.getiterationComposite"
                            prim__iterationComposite
                            prim__setIterationComposite
-                           (v :> KeyframeEffectOptions)
+                           (cast {to = KeyframeEffectOptions} v)
 
 
 
 namespace OptionalEffectTiming
-
+  
   export
   new' :
        (delay : Optional Double)
@@ -945,7 +851,7 @@ namespace OptionalEffectTiming
       (toFFI f)
       (toFFI g)
       (toFFI h)
-
+  
   export
   new : JSIO OptionalEffectTiming
   new = primJS $
@@ -959,106 +865,101 @@ namespace OptionalEffectTiming
       undef
       undef
 
-
+  
   export
   delay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional Double
   delay v = fromUndefOrPrimNoDefault
               "OptionalEffectTiming.getdelay"
               prim__delay
               prim__setDelay
-              (v :> OptionalEffectTiming)
+              (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   direction :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional PlaybackDirection
   direction v = fromUndefOrPrimNoDefault
                   "OptionalEffectTiming.getdirection"
                   prim__direction
                   prim__setDirection
-                  (v :> OptionalEffectTiming)
+                  (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   duration :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional (HSum [Double, String])
   duration v = fromUndefOrPrimNoDefault
                  "OptionalEffectTiming.getduration"
                  prim__duration
                  prim__setDuration
-                 (v :> OptionalEffectTiming)
+                 (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   easing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional String
   easing v = fromUndefOrPrimNoDefault
                "OptionalEffectTiming.geteasing"
                prim__easing
                prim__setEasing
-               (v :> OptionalEffectTiming)
+               (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   endDelay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional Double
   endDelay v = fromUndefOrPrimNoDefault
                  "OptionalEffectTiming.getendDelay"
                  prim__endDelay
                  prim__setEndDelay
-                 (v :> OptionalEffectTiming)
+                 (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   fill :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional FillMode
   fill v = fromUndefOrPrimNoDefault
              "OptionalEffectTiming.getfill"
              prim__fill
              prim__setFill
-             (v :> OptionalEffectTiming)
+             (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   iterationStart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional Double
   iterationStart v = fromUndefOrPrimNoDefault
                        "OptionalEffectTiming.getiterationStart"
                        prim__iterationStart
                        prim__setIterationStart
-                       (v :> OptionalEffectTiming)
+                       (cast {to = OptionalEffectTiming} v)
 
-
+  
   export
   iterations :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem OptionalEffectTiming (Types t)}
+       {auto _ : Cast t OptionalEffectTiming}
     -> t
     -> Attribute False Optional Double
   iterations v = fromUndefOrPrimNoDefault
                    "OptionalEffectTiming.getiterations"
                    prim__iterations
                    prim__setIterations
-                   (v :> OptionalEffectTiming)
+                   (cast {to = OptionalEffectTiming} v)
+
+
+

--- a/src/Web/Raw/Clipboard.idr
+++ b/src/Web/Raw/Clipboard.idr
@@ -12,17 +12,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Clipboard
-
+  
   export
   read : (obj : Clipboard) -> JSIO (Promise (Array ClipboardItem))
   read a = primJS $ Clipboard.prim__read a
 
-
+  
   export
   readText : (obj : Clipboard) -> JSIO (Promise String)
   readText a = primJS $ Clipboard.prim__readText a
 
-
+  
   export
   write :
        (obj : Clipboard)
@@ -30,7 +30,7 @@ namespace Clipboard
     -> JSIO (Promise Undefined)
   write a b = primJS $ Clipboard.prim__write a b
 
-
+  
   export
   writeText : (obj : Clipboard) -> (data_ : String) -> JSIO (Promise Undefined)
   writeText a b = primJS $ Clipboard.prim__writeText a b
@@ -38,21 +38,20 @@ namespace Clipboard
 
 
 namespace ClipboardEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ClipboardEventInit (Types t2)}
+       {auto _ : Cast t2 ClipboardEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO ClipboardEvent
   new' a b = primJS $ ClipboardEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO ClipboardEvent
   new a = primJS $ ClipboardEvent.prim__new a undef
 
-
+  
   export
   clipboardData : (obj : ClipboardEvent) -> JSIO (Maybe DataTransfer)
   clipboardData a = tryJS "ClipboardEvent.clipboardData" $
@@ -61,60 +60,58 @@ namespace ClipboardEvent
 
 
 namespace ClipboardItem
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ClipboardItemOptions (Types t2)}
+       {auto _ : Cast t2 ClipboardItemOptions}
     -> (items : Record String (Promise (Union2 String Blob)))
     -> (options : Optional t2)
     -> JSIO ClipboardItem
   new' a b = primJS $ ClipboardItem.prim__new a (optUp b)
-
+  
   export
   new :
        (items : Record String (Promise (Union2 String Blob)))
     -> JSIO ClipboardItem
   new a = primJS $ ClipboardItem.prim__new a undef
 
-
+  
   export
   createDelayed' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ClipboardItemOptions (Types t2)}
+       {auto _ : Cast t2 ClipboardItemOptions}
     -> (items : Record String ClipboardItemDelayedCallback)
     -> (options : Optional t2)
     -> JSIO ClipboardItem
   createDelayed' a b = primJS $ ClipboardItem.prim__createDelayed a (optUp b)
-
+  
   export
   createDelayed :
        (items : Record String ClipboardItemDelayedCallback)
     -> JSIO ClipboardItem
   createDelayed a = primJS $ ClipboardItem.prim__createDelayed a undef
 
-
+  
   export
   delayed : (obj : ClipboardItem) -> JSIO Bool
   delayed a = tryJS "ClipboardItem.delayed" $ ClipboardItem.prim__delayed a
 
-
+  
   export
   lastModified : (obj : ClipboardItem) -> JSIO JSInt64
   lastModified a = primJS $ ClipboardItem.prim__lastModified a
 
-
+  
   export
   presentationStyle : (obj : ClipboardItem) -> JSIO PresentationStyle
   presentationStyle a = tryJS "ClipboardItem.presentationStyle" $
     ClipboardItem.prim__presentationStyle a
 
-
+  
   export
   types : (obj : ClipboardItem) -> JSIO (Array String)
   types a = primJS $ ClipboardItem.prim__types a
 
-
+  
   export
   getType : (obj : ClipboardItem) -> (type : String) -> JSIO (Promise Blob)
   getType a b = primJS $ ClipboardItem.prim__getType a b
@@ -128,22 +125,21 @@ namespace ClipboardItem
 --------------------------------------------------------------------------------
 
 namespace ClipboardEventInit
-
+  
   export
   new' :
        (clipboardData : Optional (Maybe DataTransfer))
     -> JSIO ClipboardEventInit
   new' a = primJS $ ClipboardEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO ClipboardEventInit
   new = primJS $ ClipboardEventInit.prim__new undef
 
-
+  
   export
   clipboardData :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ClipboardEventInit (Types t)}
+       {auto _ : Cast t ClipboardEventInit}
     -> t
     -> Attribute True Optional (Maybe DataTransfer)
   clipboardData v = fromUndefOrPrim
@@ -151,54 +147,52 @@ namespace ClipboardEventInit
                       prim__clipboardData
                       prim__setClipboardData
                       Nothing
-                      (v :> ClipboardEventInit)
+                      (cast {to = ClipboardEventInit} v)
 
 
 
 namespace ClipboardItemOptions
-
+  
   export
   new' :
        (presentationStyle : Optional PresentationStyle)
     -> JSIO ClipboardItemOptions
   new' a = primJS $ ClipboardItemOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ClipboardItemOptions
   new = primJS $ ClipboardItemOptions.prim__new undef
 
-
+  
   export
   presentationStyle :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ClipboardItemOptions (Types t)}
+       {auto _ : Cast t ClipboardItemOptions}
     -> t
     -> Attribute False Optional PresentationStyle
   presentationStyle v = fromUndefOrPrimNoDefault
                           "ClipboardItemOptions.getpresentationStyle"
                           prim__presentationStyle
                           prim__setPresentationStyle
-                          (v :> ClipboardItemOptions)
+                          (cast {to = ClipboardItemOptions} v)
 
 
 
 namespace ClipboardPermissionDescriptor
-
+  
   export
   new' :
        (allowWithoutGesture : Optional Bool)
     -> JSIO ClipboardPermissionDescriptor
   new' a = primJS $ ClipboardPermissionDescriptor.prim__new (toFFI a)
-
+  
   export
   new : JSIO ClipboardPermissionDescriptor
   new = primJS $ ClipboardPermissionDescriptor.prim__new undef
 
-
+  
   export
   allowWithoutGesture :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ClipboardPermissionDescriptor (Types t)}
+       {auto _ : Cast t ClipboardPermissionDescriptor}
     -> t
     -> Attribute True Optional Bool
   allowWithoutGesture v = fromUndefOrPrim
@@ -206,7 +200,7 @@ namespace ClipboardPermissionDescriptor
                             prim__allowWithoutGesture
                             prim__setAllowWithoutGesture
                             False
-                            (v :> ClipboardPermissionDescriptor)
+                            (cast {to = ClipboardPermissionDescriptor} v)
 
 
 
@@ -216,9 +210,11 @@ namespace ClipboardPermissionDescriptor
 --------------------------------------------------------------------------------
 
 namespace ClipboardItemDelayedCallback
-
+  
   export
   toClipboardItemDelayedCallback :
        (() -> IO (Promise (Union2 String Blob)))
     -> JSIO ClipboardItemDelayedCallback
   toClipboardItemDelayedCallback cb = primJS $ prim__toClipboardItemDelayedCallback cb
+
+

--- a/src/Web/Raw/Css.idr
+++ b/src/Web/Raw/Css.idr
@@ -12,60 +12,56 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CSSGroupingRule
-
+  
   export
   cssRules :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSGroupingRule (Types t1)}
+       {auto _ : Cast t1 CSSGroupingRule}
     -> (obj : t1)
     -> JSIO CSSRuleList
-  cssRules a = primJS $ CSSGroupingRule.prim__cssRules (up a)
+  cssRules a = primJS $ CSSGroupingRule.prim__cssRules (cast a)
 
-
+  
   export
   deleteRule :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSGroupingRule (Types t1)}
+       {auto _ : Cast t1 CSSGroupingRule}
     -> (obj : t1)
     -> (index : Bits32)
     -> JSIO ()
-  deleteRule a b = primJS $ CSSGroupingRule.prim__deleteRule (up a) b
+  deleteRule a b = primJS $ CSSGroupingRule.prim__deleteRule (cast a) b
 
-
+  
   export
   insertRule' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSGroupingRule (Types t1)}
+       {auto _ : Cast t1 CSSGroupingRule}
     -> (obj : t1)
     -> (rule : String)
     -> (index : Optional Bits32)
     -> JSIO Bits32
   insertRule' a b c = primJS $
-    CSSGroupingRule.prim__insertRule (up a) b (toFFI c)
-
+    CSSGroupingRule.prim__insertRule (cast a) b (toFFI c)
+  
   export
   insertRule :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSGroupingRule (Types t1)}
+       {auto _ : Cast t1 CSSGroupingRule}
     -> (obj : t1)
     -> (rule : String)
     -> JSIO Bits32
-  insertRule a b = primJS $ CSSGroupingRule.prim__insertRule (up a) b undef
+  insertRule a b = primJS $ CSSGroupingRule.prim__insertRule (cast a) b undef
 
 
 
 namespace CSSImportRule
-
+  
   export
   href : (obj : CSSImportRule) -> JSIO String
   href a = primJS $ CSSImportRule.prim__href a
 
-
+  
   export
   media : (obj : CSSImportRule) -> JSIO MediaList
   media a = primJS $ CSSImportRule.prim__media a
 
-
+  
   export
   styleSheet : (obj : CSSImportRule) -> JSIO CSSStyleSheet
   styleSheet a = primJS $ CSSImportRule.prim__styleSheet a
@@ -73,12 +69,12 @@ namespace CSSImportRule
 
 
 namespace CSSMarginRule
-
+  
   export
   name : (obj : CSSMarginRule) -> JSIO String
   name a = primJS $ CSSMarginRule.prim__name a
 
-
+  
   export
   style : (obj : CSSMarginRule) -> JSIO CSSStyleDeclaration
   style a = primJS $ CSSMarginRule.prim__style a
@@ -86,12 +82,12 @@ namespace CSSMarginRule
 
 
 namespace CSSNamespaceRule
-
+  
   export
   namespaceURI : (obj : CSSNamespaceRule) -> JSIO String
   namespaceURI a = primJS $ CSSNamespaceRule.prim__namespaceURI a
 
-
+  
   export
   prefix_ : (obj : CSSNamespaceRule) -> JSIO String
   prefix_ a = primJS $ CSSNamespaceRule.prim__prefix a
@@ -99,7 +95,7 @@ namespace CSSNamespaceRule
 
 
 namespace CSSPageRule
-
+  
   export
   selectorText : CSSPageRule -> Attribute True Prelude.id String
   selectorText v = fromPrim
@@ -108,7 +104,7 @@ namespace CSSPageRule
                      prim__setSelectorText
                      v
 
-
+  
   export
   style : (obj : CSSPageRule) -> JSIO CSSStyleDeclaration
   style a = primJS $ CSSPageRule.prim__style a
@@ -116,12 +112,12 @@ namespace CSSPageRule
 
 
 namespace CSSPseudoElement
-
+  
   export
   element : (obj : CSSPseudoElement) -> JSIO Element
   element a = primJS $ CSSPseudoElement.prim__element a
 
-
+  
   export
   type : (obj : CSSPseudoElement) -> JSIO String
   type a = primJS $ CSSPseudoElement.prim__type a
@@ -129,96 +125,83 @@ namespace CSSPseudoElement
 
 
 namespace CSSRule
-
-  public export
+  
+  export
   CHARSET_RULE : Bits16
   CHARSET_RULE = 2
 
-
-  public export
+  
+  export
   FONT_FACE_RULE : Bits16
   FONT_FACE_RULE = 5
 
-
-  public export
+  
+  export
   IMPORT_RULE : Bits16
   IMPORT_RULE = 3
 
-
-  public export
+  
+  export
   MARGIN_RULE : Bits16
   MARGIN_RULE = 9
 
-
-  public export
+  
+  export
   MEDIA_RULE : Bits16
   MEDIA_RULE = 4
 
-
-  public export
+  
+  export
   NAMESPACE_RULE : Bits16
   NAMESPACE_RULE = 10
 
-
-  public export
+  
+  export
   PAGE_RULE : Bits16
   PAGE_RULE = 6
 
-
-  public export
+  
+  export
   STYLE_RULE : Bits16
   STYLE_RULE = 1
 
-
+  
   export
-  cssText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CSSRule (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  cssText : {auto _ : Cast t CSSRule} -> t -> Attribute True Prelude.id String
   cssText v = fromPrim
                 "CSSRule.getcssText"
                 prim__cssText
                 prim__setCssText
-                (v :> CSSRule)
+                (cast {to = CSSRule} v)
 
-
+  
   export
-  parentRule :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSRule (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe CSSRule)
-  parentRule a = tryJS "CSSRule.parentRule" $ CSSRule.prim__parentRule (up a)
+  parentRule : {auto _ : Cast t1 CSSRule} -> (obj : t1) -> JSIO (Maybe CSSRule)
+  parentRule a = tryJS "CSSRule.parentRule" $ CSSRule.prim__parentRule (cast a)
 
-
+  
   export
   parentStyleSheet :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSRule (Types t1)}
+       {auto _ : Cast t1 CSSRule}
     -> (obj : t1)
     -> JSIO (Maybe CSSStyleSheet)
   parentStyleSheet a = tryJS "CSSRule.parentStyleSheet" $
-    CSSRule.prim__parentStyleSheet (up a)
+    CSSRule.prim__parentStyleSheet (cast a)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CSSRule (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  type a = primJS $ CSSRule.prim__type (up a)
+  type : {auto _ : Cast t1 CSSRule} -> (obj : t1) -> JSIO Bits16
+  type a = primJS $ CSSRule.prim__type (cast a)
 
 
 
 namespace CSSRuleList
-
+  
   export
   length : (obj : CSSRuleList) -> JSIO Bits32
   length a = primJS $ CSSRuleList.prim__length a
 
-
+  
   export
   item : (obj : CSSRuleList) -> (index : Bits32) -> JSIO (Maybe CSSRule)
   item a b = tryJS "CSSRuleList.item" $ CSSRuleList.prim__item a b
@@ -226,7 +209,7 @@ namespace CSSRuleList
 
 
 namespace CSSStyleDeclaration
-
+  
   export
   cssFloat : CSSStyleDeclaration -> Attribute True Prelude.id String
   cssFloat v = fromPrim
@@ -235,7 +218,7 @@ namespace CSSStyleDeclaration
                  prim__setCssFloat
                  v
 
-
+  
   export
   cssText : CSSStyleDeclaration -> Attribute True Prelude.id String
   cssText v = fromPrim
@@ -244,18 +227,18 @@ namespace CSSStyleDeclaration
                 prim__setCssText
                 v
 
-
+  
   export
   length : (obj : CSSStyleDeclaration) -> JSIO Bits32
   length a = primJS $ CSSStyleDeclaration.prim__length a
 
-
+  
   export
   parentRule : (obj : CSSStyleDeclaration) -> JSIO (Maybe CSSRule)
   parentRule a = tryJS "CSSStyleDeclaration.parentRule" $
     CSSStyleDeclaration.prim__parentRule a
 
-
+  
   export
   getPropertyPriority :
        (obj : CSSStyleDeclaration)
@@ -264,7 +247,7 @@ namespace CSSStyleDeclaration
   getPropertyPriority a b = primJS $
     CSSStyleDeclaration.prim__getPropertyPriority a b
 
-
+  
   export
   getPropertyValue :
        (obj : CSSStyleDeclaration)
@@ -272,12 +255,12 @@ namespace CSSStyleDeclaration
     -> JSIO String
   getPropertyValue a b = primJS $ CSSStyleDeclaration.prim__getPropertyValue a b
 
-
+  
   export
   item : (obj : CSSStyleDeclaration) -> (index : Bits32) -> JSIO String
   item a b = primJS $ CSSStyleDeclaration.prim__item a b
 
-
+  
   export
   removeProperty :
        (obj : CSSStyleDeclaration)
@@ -285,7 +268,7 @@ namespace CSSStyleDeclaration
     -> JSIO String
   removeProperty a b = primJS $ CSSStyleDeclaration.prim__removeProperty a b
 
-
+  
   export
   setProperty' :
        (obj : CSSStyleDeclaration)
@@ -295,7 +278,7 @@ namespace CSSStyleDeclaration
     -> JSIO ()
   setProperty' a b c d = primJS $
     CSSStyleDeclaration.prim__setProperty a b c (toFFI d)
-
+  
   export
   setProperty :
        (obj : CSSStyleDeclaration)
@@ -307,7 +290,7 @@ namespace CSSStyleDeclaration
 
 
 namespace CSSStyleRule
-
+  
   export
   selectorText : CSSStyleRule -> Attribute True Prelude.id String
   selectorText v = fromPrim
@@ -316,7 +299,7 @@ namespace CSSStyleRule
                      prim__setSelectorText
                      v
 
-
+  
   export
   style : (obj : CSSStyleRule) -> JSIO CSSStyleDeclaration
   style a = primJS $ CSSStyleRule.prim__style a
@@ -324,23 +307,23 @@ namespace CSSStyleRule
 
 
 namespace CSSStyleSheet
-
+  
   export
   cssRules : (obj : CSSStyleSheet) -> JSIO CSSRuleList
   cssRules a = primJS $ CSSStyleSheet.prim__cssRules a
 
-
+  
   export
   ownerRule : (obj : CSSStyleSheet) -> JSIO (Maybe CSSRule)
   ownerRule a = tryJS "CSSStyleSheet.ownerRule" $
     CSSStyleSheet.prim__ownerRule a
 
-
+  
   export
   rules : (obj : CSSStyleSheet) -> JSIO CSSRuleList
   rules a = primJS $ CSSStyleSheet.prim__rules a
 
-
+  
   export
   addRule' :
        (obj : CSSStyleSheet)
@@ -350,17 +333,17 @@ namespace CSSStyleSheet
     -> JSIO Int32
   addRule' a b c d = primJS $
     CSSStyleSheet.prim__addRule a (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   addRule : (obj : CSSStyleSheet) -> JSIO Int32
   addRule a = primJS $ CSSStyleSheet.prim__addRule a undef undef undef
 
-
+  
   export
   deleteRule : (obj : CSSStyleSheet) -> (index : Bits32) -> JSIO ()
   deleteRule a b = primJS $ CSSStyleSheet.prim__deleteRule a b
 
-
+  
   export
   insertRule' :
        (obj : CSSStyleSheet)
@@ -368,16 +351,16 @@ namespace CSSStyleSheet
     -> (index : Optional Bits32)
     -> JSIO Bits32
   insertRule' a b c = primJS $ CSSStyleSheet.prim__insertRule a b (toFFI c)
-
+  
   export
   insertRule : (obj : CSSStyleSheet) -> (rule : String) -> JSIO Bits32
   insertRule a b = primJS $ CSSStyleSheet.prim__insertRule a b undef
 
-
+  
   export
   removeRule' : (obj : CSSStyleSheet) -> (index : Optional Bits32) -> JSIO ()
   removeRule' a b = primJS $ CSSStyleSheet.prim__removeRule a (toFFI b)
-
+  
   export
   removeRule : (obj : CSSStyleSheet) -> JSIO ()
   removeRule a = primJS $ CSSStyleSheet.prim__removeRule a undef
@@ -385,12 +368,12 @@ namespace CSSStyleSheet
 
 
 namespace MediaList
-
+  
   export
   length : (obj : MediaList) -> JSIO Bits32
   length a = primJS $ MediaList.prim__length a
 
-
+  
   export
   mediaText : MediaList -> Attribute True Prelude.id String
   mediaText v = fromPrim
@@ -399,17 +382,17 @@ namespace MediaList
                   prim__setMediaText
                   v
 
-
+  
   export
   appendMedium : (obj : MediaList) -> (medium : String) -> JSIO ()
   appendMedium a b = primJS $ MediaList.prim__appendMedium a b
 
-
+  
   export
   deleteMedium : (obj : MediaList) -> (medium : String) -> JSIO ()
   deleteMedium a b = primJS $ MediaList.prim__deleteMedium a b
 
-
+  
   export
   item : (obj : MediaList) -> (index : Bits32) -> JSIO (Maybe String)
   item a b = tryJS "MediaList.item" $ MediaList.prim__item a b
@@ -417,83 +400,62 @@ namespace MediaList
 
 
 namespace StyleSheet
-
+  
   export
-  disabled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StyleSheet (Types t)}
-    -> t
-    -> Attribute True Prelude.id Bool
+  disabled : {auto _ : Cast t StyleSheet} -> t -> Attribute True Prelude.id Bool
   disabled v = fromPrim
                  "StyleSheet.getdisabled"
                  prim__disabled
                  prim__setDisabled
-                 (v :> StyleSheet)
+                 (cast {to = StyleSheet} v)
 
-
+  
   export
-  href :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe String)
-  href a = tryJS "StyleSheet.href" $ StyleSheet.prim__href (up a)
+  href : {auto _ : Cast t1 StyleSheet} -> (obj : t1) -> JSIO (Maybe String)
+  href a = tryJS "StyleSheet.href" $ StyleSheet.prim__href (cast a)
 
-
+  
   export
-  media :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
-    -> (obj : t1)
-    -> JSIO MediaList
-  media a = primJS $ StyleSheet.prim__media (up a)
+  media : {auto _ : Cast t1 StyleSheet} -> (obj : t1) -> JSIO MediaList
+  media a = primJS $ StyleSheet.prim__media (cast a)
 
-
+  
   export
   ownerNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
+       {auto _ : Cast t1 StyleSheet}
     -> (obj : t1)
     -> JSIO (Maybe (HSum [Element, ProcessingInstruction]))
-  ownerNode a = tryJS "StyleSheet.ownerNode" $ StyleSheet.prim__ownerNode (up a)
+  ownerNode a = tryJS "StyleSheet.ownerNode" $
+    StyleSheet.prim__ownerNode (cast a)
 
-
+  
   export
   parentStyleSheet :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
+       {auto _ : Cast t1 StyleSheet}
     -> (obj : t1)
     -> JSIO (Maybe CSSStyleSheet)
   parentStyleSheet a = tryJS "StyleSheet.parentStyleSheet" $
-    StyleSheet.prim__parentStyleSheet (up a)
+    StyleSheet.prim__parentStyleSheet (cast a)
 
-
+  
   export
-  title :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe String)
-  title a = tryJS "StyleSheet.title" $ StyleSheet.prim__title (up a)
+  title : {auto _ : Cast t1 StyleSheet} -> (obj : t1) -> JSIO (Maybe String)
+  title a = tryJS "StyleSheet.title" $ StyleSheet.prim__title (cast a)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StyleSheet (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  type a = primJS $ StyleSheet.prim__type (up a)
+  type : {auto _ : Cast t1 StyleSheet} -> (obj : t1) -> JSIO String
+  type a = primJS $ StyleSheet.prim__type (cast a)
 
 
 
 namespace StyleSheetList
-
+  
   export
   length : (obj : StyleSheetList) -> JSIO Bits32
   length a = primJS $ StyleSheetList.prim__length a
 
-
+  
   export
   item :
        (obj : StyleSheetList)
@@ -509,23 +471,25 @@ namespace StyleSheetList
 --------------------------------------------------------------------------------
 
 namespace ElementCSSInlineStyle
-
+  
   export
   style :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ElementCSSInlineStyle (Types t1)}
+       {auto _ : Cast t1 ElementCSSInlineStyle}
     -> (obj : t1)
     -> JSIO CSSStyleDeclaration
-  style a = primJS $ ElementCSSInlineStyle.prim__style (up a)
+  style a = primJS $ ElementCSSInlineStyle.prim__style (cast a)
 
 
 
 namespace LinkStyle
-
+  
   export
   sheet :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem LinkStyle (Types t1)}
+       {auto _ : Cast t1 LinkStyle}
     -> (obj : t1)
     -> JSIO (Maybe CSSStyleSheet)
-  sheet a = tryJS "LinkStyle.sheet" $ LinkStyle.prim__sheet (up a)
+  sheet a = tryJS "LinkStyle.sheet" $ LinkStyle.prim__sheet (cast a)
+
+
+
+

--- a/src/Web/Raw/Cssomview.idr
+++ b/src/Web/Raw/Cssomview.idr
@@ -12,17 +12,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CaretPosition
-
+  
   export
   offset : (obj : CaretPosition) -> JSIO Bits32
   offset a = primJS $ CaretPosition.prim__offset a
 
-
+  
   export
   offsetNode : (obj : CaretPosition) -> JSIO Node
   offsetNode a = primJS $ CaretPosition.prim__offsetNode a
 
-
+  
   export
   getClientRect : (obj : CaretPosition) -> JSIO (Maybe DOMRect)
   getClientRect a = tryJS "CaretPosition.getClientRect" $
@@ -31,17 +31,17 @@ namespace CaretPosition
 
 
 namespace MediaQueryList
-
+  
   export
   matches : (obj : MediaQueryList) -> JSIO Bool
   matches a = tryJS "MediaQueryList.matches" $ MediaQueryList.prim__matches a
 
-
+  
   export
   media : (obj : MediaQueryList) -> JSIO String
   media a = primJS $ MediaQueryList.prim__media a
 
-
+  
   export
   onchange : MediaQueryList -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
@@ -50,7 +50,7 @@ namespace MediaQueryList
                  prim__setOnchange
                  v
 
-
+  
   export
   addListener :
        (obj : MediaQueryList)
@@ -58,7 +58,7 @@ namespace MediaQueryList
     -> JSIO ()
   addListener a b = primJS $ MediaQueryList.prim__addListener a (toFFI b)
 
-
+  
   export
   removeListener :
        (obj : MediaQueryList)
@@ -69,27 +69,26 @@ namespace MediaQueryList
 
 
 namespace MediaQueryListEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MediaQueryListEventInit (Types t2)}
+       {auto _ : Cast t2 MediaQueryListEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO MediaQueryListEvent
   new' a b = primJS $ MediaQueryListEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO MediaQueryListEvent
   new a = primJS $ MediaQueryListEvent.prim__new a undef
 
-
+  
   export
   matches : (obj : MediaQueryListEvent) -> JSIO Bool
   matches a = tryJS "MediaQueryListEvent.matches" $
     MediaQueryListEvent.prim__matches a
 
-
+  
   export
   media : (obj : MediaQueryListEvent) -> JSIO String
   media a = primJS $ MediaQueryListEvent.prim__media a
@@ -97,32 +96,32 @@ namespace MediaQueryListEvent
 
 
 namespace Screen
-
+  
   export
   availHeight : (obj : Screen) -> JSIO Int32
   availHeight a = primJS $ Screen.prim__availHeight a
 
-
+  
   export
   availWidth : (obj : Screen) -> JSIO Int32
   availWidth a = primJS $ Screen.prim__availWidth a
 
-
+  
   export
   colorDepth : (obj : Screen) -> JSIO Bits32
   colorDepth a = primJS $ Screen.prim__colorDepth a
 
-
+  
   export
   height : (obj : Screen) -> JSIO Int32
   height a = primJS $ Screen.prim__height a
 
-
+  
   export
   pixelDepth : (obj : Screen) -> JSIO Bits32
   pixelDepth a = primJS $ Screen.prim__pixelDepth a
 
-
+  
   export
   width : (obj : Screen) -> JSIO Int32
   width a = primJS $ Screen.prim__width a
@@ -130,22 +129,22 @@ namespace Screen
 
 
 namespace VisualViewport
-
+  
   export
   height : (obj : VisualViewport) -> JSIO Double
   height a = primJS $ VisualViewport.prim__height a
 
-
+  
   export
   offsetLeft : (obj : VisualViewport) -> JSIO Double
   offsetLeft a = primJS $ VisualViewport.prim__offsetLeft a
 
-
+  
   export
   offsetTop : (obj : VisualViewport) -> JSIO Double
   offsetTop a = primJS $ VisualViewport.prim__offsetTop a
 
-
+  
   export
   onresize : VisualViewport -> Attribute False Maybe EventHandlerNonNull
   onresize v = fromNullablePrim
@@ -154,7 +153,7 @@ namespace VisualViewport
                  prim__setOnresize
                  v
 
-
+  
   export
   onscroll : VisualViewport -> Attribute False Maybe EventHandlerNonNull
   onscroll v = fromNullablePrim
@@ -163,7 +162,7 @@ namespace VisualViewport
                  prim__setOnscroll
                  v
 
-
+  
   export
   onscrollend : VisualViewport -> Attribute False Maybe EventHandlerNonNull
   onscrollend v = fromNullablePrim
@@ -172,22 +171,22 @@ namespace VisualViewport
                     prim__setOnscrollend
                     v
 
-
+  
   export
   pageLeft : (obj : VisualViewport) -> JSIO Double
   pageLeft a = primJS $ VisualViewport.prim__pageLeft a
 
-
+  
   export
   pageTop : (obj : VisualViewport) -> JSIO Double
   pageTop a = primJS $ VisualViewport.prim__pageTop a
 
-
+  
   export
   scale : (obj : VisualViewport) -> JSIO Double
   scale a = primJS $ VisualViewport.prim__scale a
 
-
+  
   export
   width : (obj : VisualViewport) -> JSIO Double
   width a = primJS $ VisualViewport.prim__width a
@@ -200,115 +199,109 @@ namespace VisualViewport
 --------------------------------------------------------------------------------
 
 namespace GeometryUtils
-
+  
   export
   convertPointFromNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
-    -> {auto 0 _ : Elem ConvertCoordinateOptions (Types t4)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMPointInit}
+    -> {auto _ : Cast t4 ConvertCoordinateOptions}
     -> (obj : t1)
     -> (point : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> (options : Optional t4)
     -> JSIO DOMPoint
   convertPointFromNode' a b c d = primJS $
-    GeometryUtils.prim__convertPointFromNode (up a) (up b) (toFFI c) (optUp d)
-
+    GeometryUtils.prim__convertPointFromNode
+      (cast a)
+      (cast b)
+      (toFFI c)
+      (optUp d)
+  
   export
   convertPointFromNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMPointInit}
     -> (obj : t1)
     -> (point : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> JSIO DOMPoint
   convertPointFromNode a b c = primJS $
-    GeometryUtils.prim__convertPointFromNode (up a) (up b) (toFFI c) undef
+    GeometryUtils.prim__convertPointFromNode (cast a) (cast b) (toFFI c) undef
 
-
+  
   export
   convertQuadFromNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t2)}
-    -> {auto 0 _ : Elem ConvertCoordinateOptions (Types t4)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMQuadInit}
+    -> {auto _ : Cast t4 ConvertCoordinateOptions}
     -> (obj : t1)
     -> (quad : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> (options : Optional t4)
     -> JSIO DOMQuad
   convertQuadFromNode' a b c d = primJS $
-    GeometryUtils.prim__convertQuadFromNode (up a) (up b) (toFFI c) (optUp d)
-
+    GeometryUtils.prim__convertQuadFromNode
+      (cast a)
+      (cast b)
+      (toFFI c)
+      (optUp d)
+  
   export
   convertQuadFromNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t2)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMQuadInit}
     -> (obj : t1)
     -> (quad : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> JSIO DOMQuad
   convertQuadFromNode a b c = primJS $
-    GeometryUtils.prim__convertQuadFromNode (up a) (up b) (toFFI c) undef
+    GeometryUtils.prim__convertQuadFromNode (cast a) (cast b) (toFFI c) undef
 
-
+  
   export
   convertRectFromNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t2)}
-    -> {auto 0 _ : Elem ConvertCoordinateOptions (Types t4)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMRectReadOnly}
+    -> {auto _ : Cast t4 ConvertCoordinateOptions}
     -> (obj : t1)
     -> (rect : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> (options : Optional t4)
     -> JSIO DOMQuad
   convertRectFromNode' a b c d = primJS $
-    GeometryUtils.prim__convertRectFromNode (up a) (up b) (toFFI c) (optUp d)
-
+    GeometryUtils.prim__convertRectFromNode
+      (cast a)
+      (cast b)
+      (toFFI c)
+      (optUp d)
+  
   export
   convertRectFromNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t2)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 DOMRectReadOnly}
     -> (obj : t1)
     -> (rect : t2)
     -> (from : HSum [Text, Element, CSSPseudoElement, Document])
     -> JSIO DOMQuad
   convertRectFromNode a b c = primJS $
-    GeometryUtils.prim__convertRectFromNode (up a) (up b) (toFFI c) undef
+    GeometryUtils.prim__convertRectFromNode (cast a) (cast b) (toFFI c) undef
 
-
+  
   export
   getBoxQuads' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
-    -> {auto 0 _ : Elem BoxQuadOptions (Types t2)}
+       {auto _ : Cast t1 GeometryUtils}
+    -> {auto _ : Cast t2 BoxQuadOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO (Array DOMQuad)
-  getBoxQuads' a b = primJS $ GeometryUtils.prim__getBoxQuads (up a) (optUp b)
-
+  getBoxQuads' a b = primJS $ GeometryUtils.prim__getBoxQuads (cast a) (optUp b)
+  
   export
   getBoxQuads :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem GeometryUtils (Types t1)}
+       {auto _ : Cast t1 GeometryUtils}
     -> (obj : t1)
     -> JSIO (Array DOMQuad)
-  getBoxQuads a = primJS $ GeometryUtils.prim__getBoxQuads (up a) undef
+  getBoxQuads a = primJS $ GeometryUtils.prim__getBoxQuads (cast a) undef
 
 
 
@@ -318,7 +311,7 @@ namespace GeometryUtils
 --------------------------------------------------------------------------------
 
 namespace BoxQuadOptions
-
+  
   export
   new' :
        (box : Optional CSSBoxType)
@@ -326,29 +319,27 @@ namespace BoxQuadOptions
                        (HSum [Text, Element, CSSPseudoElement, Document]))
     -> JSIO BoxQuadOptions
   new' a b = primJS $ BoxQuadOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO BoxQuadOptions
   new = primJS $ BoxQuadOptions.prim__new undef undef
 
-
+  
   export
   box :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BoxQuadOptions (Types t)}
+       {auto _ : Cast t BoxQuadOptions}
     -> t
     -> Attribute False Optional CSSBoxType
   box v = fromUndefOrPrimNoDefault
             "BoxQuadOptions.getbox"
             prim__box
             prim__setBox
-            (v :> BoxQuadOptions)
+            (cast {to = BoxQuadOptions} v)
 
-
+  
   export
   relativeTo :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BoxQuadOptions (Types t)}
+       {auto _ : Cast t BoxQuadOptions}
     -> t
     -> Attribute False Optional (HSum
                                    [Text, Element, CSSPseudoElement, Document])
@@ -356,28 +347,27 @@ namespace BoxQuadOptions
                    "BoxQuadOptions.getrelativeTo"
                    prim__relativeTo
                    prim__setRelativeTo
-                   (v :> BoxQuadOptions)
+                   (cast {to = BoxQuadOptions} v)
 
 
 
 namespace CheckVisibilityOptions
-
+  
   export
   new' :
        (checkOpacity : Optional Bool)
     -> (checkVisibilityCSS : Optional Bool)
     -> JSIO CheckVisibilityOptions
   new' a b = primJS $ CheckVisibilityOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO CheckVisibilityOptions
   new = primJS $ CheckVisibilityOptions.prim__new undef undef
 
-
+  
   export
   checkOpacity :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CheckVisibilityOptions (Types t)}
+       {auto _ : Cast t CheckVisibilityOptions}
     -> t
     -> Attribute True Optional Bool
   checkOpacity v = fromUndefOrPrim
@@ -385,13 +375,12 @@ namespace CheckVisibilityOptions
                      prim__checkOpacity
                      prim__setCheckOpacity
                      False
-                     (v :> CheckVisibilityOptions)
+                     (cast {to = CheckVisibilityOptions} v)
 
-
+  
   export
   checkVisibilityCSS :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CheckVisibilityOptions (Types t)}
+       {auto _ : Cast t CheckVisibilityOptions}
     -> t
     -> Attribute True Optional Bool
   checkVisibilityCSS v = fromUndefOrPrim
@@ -399,69 +388,66 @@ namespace CheckVisibilityOptions
                            prim__checkVisibilityCSS
                            prim__setCheckVisibilityCSS
                            False
-                           (v :> CheckVisibilityOptions)
+                           (cast {to = CheckVisibilityOptions} v)
 
 
 
 namespace ConvertCoordinateOptions
-
+  
   export
   new' :
        (fromBox : Optional CSSBoxType)
     -> (toBox : Optional CSSBoxType)
     -> JSIO ConvertCoordinateOptions
   new' a b = primJS $ ConvertCoordinateOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ConvertCoordinateOptions
   new = primJS $ ConvertCoordinateOptions.prim__new undef undef
 
-
+  
   export
   fromBox :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConvertCoordinateOptions (Types t)}
+       {auto _ : Cast t ConvertCoordinateOptions}
     -> t
     -> Attribute False Optional CSSBoxType
   fromBox v = fromUndefOrPrimNoDefault
                 "ConvertCoordinateOptions.getfromBox"
                 prim__fromBox
                 prim__setFromBox
-                (v :> ConvertCoordinateOptions)
+                (cast {to = ConvertCoordinateOptions} v)
 
-
+  
   export
   toBox :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConvertCoordinateOptions (Types t)}
+       {auto _ : Cast t ConvertCoordinateOptions}
     -> t
     -> Attribute False Optional CSSBoxType
   toBox v = fromUndefOrPrimNoDefault
               "ConvertCoordinateOptions.gettoBox"
               prim__toBox
               prim__setToBox
-              (v :> ConvertCoordinateOptions)
+              (cast {to = ConvertCoordinateOptions} v)
 
 
 
 namespace MediaQueryListEventInit
-
+  
   export
   new' :
        (media : Optional String)
     -> (matches : Optional Bool)
     -> JSIO MediaQueryListEventInit
   new' a b = primJS $ MediaQueryListEventInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO MediaQueryListEventInit
   new = primJS $ MediaQueryListEventInit.prim__new undef undef
 
-
+  
   export
   matches :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaQueryListEventInit (Types t)}
+       {auto _ : Cast t MediaQueryListEventInit}
     -> t
     -> Attribute True Optional Bool
   matches v = fromUndefOrPrim
@@ -469,13 +455,12 @@ namespace MediaQueryListEventInit
                 prim__matches
                 prim__setMatches
                 False
-                (v :> MediaQueryListEventInit)
+                (cast {to = MediaQueryListEventInit} v)
 
-
+  
   export
   media :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaQueryListEventInit (Types t)}
+       {auto _ : Cast t MediaQueryListEventInit}
     -> t
     -> Attribute True Optional String
   media v = fromUndefOrPrim
@@ -483,111 +468,109 @@ namespace MediaQueryListEventInit
               prim__media
               prim__setMedia
               ""
-              (v :> MediaQueryListEventInit)
+              (cast {to = MediaQueryListEventInit} v)
 
 
 
 namespace ScrollIntoViewOptions
-
+  
   export
   new' :
        (block : Optional ScrollLogicalPosition)
     -> (inline : Optional ScrollLogicalPosition)
     -> JSIO ScrollIntoViewOptions
   new' a b = primJS $ ScrollIntoViewOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ScrollIntoViewOptions
   new = primJS $ ScrollIntoViewOptions.prim__new undef undef
 
-
+  
   export
   block :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ScrollIntoViewOptions (Types t)}
+       {auto _ : Cast t ScrollIntoViewOptions}
     -> t
     -> Attribute False Optional ScrollLogicalPosition
   block v = fromUndefOrPrimNoDefault
               "ScrollIntoViewOptions.getblock"
               prim__block
               prim__setBlock
-              (v :> ScrollIntoViewOptions)
+              (cast {to = ScrollIntoViewOptions} v)
 
-
+  
   export
   inline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ScrollIntoViewOptions (Types t)}
+       {auto _ : Cast t ScrollIntoViewOptions}
     -> t
     -> Attribute False Optional ScrollLogicalPosition
   inline v = fromUndefOrPrimNoDefault
                "ScrollIntoViewOptions.getinline"
                prim__inline
                prim__setInline
-               (v :> ScrollIntoViewOptions)
+               (cast {to = ScrollIntoViewOptions} v)
 
 
 
 namespace ScrollOptions
-
+  
   export
   new' : (behavior : Optional ScrollBehavior) -> JSIO ScrollOptions
   new' a = primJS $ ScrollOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ScrollOptions
   new = primJS $ ScrollOptions.prim__new undef
 
-
+  
   export
   behavior :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ScrollOptions (Types t)}
+       {auto _ : Cast t ScrollOptions}
     -> t
     -> Attribute False Optional ScrollBehavior
   behavior v = fromUndefOrPrimNoDefault
                  "ScrollOptions.getbehavior"
                  prim__behavior
                  prim__setBehavior
-                 (v :> ScrollOptions)
+                 (cast {to = ScrollOptions} v)
 
 
 
 namespace ScrollToOptions
-
+  
   export
   new' :
        (left : Optional Double)
     -> (top : Optional Double)
     -> JSIO ScrollToOptions
   new' a b = primJS $ ScrollToOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ScrollToOptions
   new = primJS $ ScrollToOptions.prim__new undef undef
 
-
+  
   export
   left :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t)}
+       {auto _ : Cast t ScrollToOptions}
     -> t
     -> Attribute False Optional Double
   left v = fromUndefOrPrimNoDefault
              "ScrollToOptions.getleft"
              prim__left
              prim__setLeft
-             (v :> ScrollToOptions)
+             (cast {to = ScrollToOptions} v)
 
-
+  
   export
   top :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t)}
+       {auto _ : Cast t ScrollToOptions}
     -> t
     -> Attribute False Optional Double
   top v = fromUndefOrPrimNoDefault
             "ScrollToOptions.gettop"
             prim__top
             prim__setTop
-            (v :> ScrollToOptions)
+            (cast {to = ScrollToOptions} v)
+
+
+

--- a/src/Web/Raw/Dom.idr
+++ b/src/Web/Raw/Dom.idr
@@ -12,17 +12,17 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace AbortController
-
+  
   export
   new : JSIO AbortController
   new = primJS $ AbortController.prim__new
 
-
+  
   export
   signal : (obj : AbortController) -> JSIO AbortSignal
   signal a = primJS $ AbortController.prim__signal a
 
-
+  
   export
   abort : (obj : AbortController) -> JSIO ()
   abort a = primJS $ AbortController.prim__abort a
@@ -30,17 +30,17 @@ namespace AbortController
 
 
 namespace AbortSignal
-
+  
   export
   abort : JSIO AbortSignal
   abort = primJS $ AbortSignal.prim__abort
 
-
+  
   export
   aborted : (obj : AbortSignal) -> JSIO Bool
   aborted a = tryJS "AbortSignal.aborted" $ AbortSignal.prim__aborted a
 
-
+  
   export
   onabort : AbortSignal -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
@@ -52,86 +52,66 @@ namespace AbortSignal
 
 
 namespace AbstractRange
-
+  
   export
-  collapsed :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AbstractRange (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  collapsed : {auto _ : Cast t1 AbstractRange} -> (obj : t1) -> JSIO Bool
   collapsed a = tryJS "AbstractRange.collapsed" $
-    AbstractRange.prim__collapsed (up a)
+    AbstractRange.prim__collapsed (cast a)
 
-
+  
   export
-  endContainer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AbstractRange (Types t1)}
-    -> (obj : t1)
-    -> JSIO Node
-  endContainer a = primJS $ AbstractRange.prim__endContainer (up a)
+  endContainer : {auto _ : Cast t1 AbstractRange} -> (obj : t1) -> JSIO Node
+  endContainer a = primJS $ AbstractRange.prim__endContainer (cast a)
 
-
+  
   export
-  endOffset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AbstractRange (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  endOffset a = primJS $ AbstractRange.prim__endOffset (up a)
+  endOffset : {auto _ : Cast t1 AbstractRange} -> (obj : t1) -> JSIO Bits32
+  endOffset a = primJS $ AbstractRange.prim__endOffset (cast a)
 
-
+  
   export
-  startContainer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AbstractRange (Types t1)}
-    -> (obj : t1)
-    -> JSIO Node
-  startContainer a = primJS $ AbstractRange.prim__startContainer (up a)
+  startContainer : {auto _ : Cast t1 AbstractRange} -> (obj : t1) -> JSIO Node
+  startContainer a = primJS $ AbstractRange.prim__startContainer (cast a)
 
-
+  
   export
-  startOffset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem AbstractRange (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  startOffset a = primJS $ AbstractRange.prim__startOffset (up a)
+  startOffset : {auto _ : Cast t1 AbstractRange} -> (obj : t1) -> JSIO Bits32
+  startOffset a = primJS $ AbstractRange.prim__startOffset (cast a)
 
 
 
 namespace Attr
-
+  
   export
   localName : (obj : Attr) -> JSIO String
   localName a = primJS $ Attr.prim__localName a
 
-
+  
   export
   name : (obj : Attr) -> JSIO String
   name a = primJS $ Attr.prim__name a
 
-
+  
   export
   namespaceURI : (obj : Attr) -> JSIO (Maybe String)
   namespaceURI a = tryJS "Attr.namespaceURI" $ Attr.prim__namespaceURI a
 
-
+  
   export
   ownerElement : (obj : Attr) -> JSIO (Maybe Element)
   ownerElement a = tryJS "Attr.ownerElement" $ Attr.prim__ownerElement a
 
-
+  
   export
   prefix_ : (obj : Attr) -> JSIO (Maybe String)
   prefix_ a = tryJS "Attr.prefix_" $ Attr.prim__prefix a
 
-
+  
   export
   specified : (obj : Attr) -> JSIO Bool
   specified a = tryJS "Attr.specified" $ Attr.prim__specified a
 
-
+  
   export
   value : Attr -> Attribute True Prelude.id String
   value v = fromPrim "Attr.getvalue" prim__value prim__setValue v
@@ -140,91 +120,81 @@ namespace Attr
 
 
 namespace CharacterData
-
+  
   export
   data_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CharacterData (Types t)}
+       {auto _ : Cast t CharacterData}
     -> t
     -> Attribute True Prelude.id String
   data_ v = fromPrim
               "CharacterData.getdata"
               prim__data
               prim__setData
-              (v :> CharacterData)
+              (cast {to = CharacterData} v)
 
-
+  
   export
-  length :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  length a = primJS $ CharacterData.prim__length (up a)
+  length : {auto _ : Cast t1 CharacterData} -> (obj : t1) -> JSIO Bits32
+  length a = primJS $ CharacterData.prim__length (cast a)
 
-
+  
   export
   appendData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
+       {auto _ : Cast t1 CharacterData}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO ()
-  appendData a b = primJS $ CharacterData.prim__appendData (up a) b
+  appendData a b = primJS $ CharacterData.prim__appendData (cast a) b
 
-
+  
   export
   deleteData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
+       {auto _ : Cast t1 CharacterData}
     -> (obj : t1)
     -> (offset : Bits32)
     -> (count : Bits32)
     -> JSIO ()
-  deleteData a b c = primJS $ CharacterData.prim__deleteData (up a) b c
+  deleteData a b c = primJS $ CharacterData.prim__deleteData (cast a) b c
 
-
+  
   export
   insertData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
+       {auto _ : Cast t1 CharacterData}
     -> (obj : t1)
     -> (offset : Bits32)
     -> (data_ : String)
     -> JSIO ()
-  insertData a b c = primJS $ CharacterData.prim__insertData (up a) b c
+  insertData a b c = primJS $ CharacterData.prim__insertData (cast a) b c
 
-
+  
   export
   replaceData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
+       {auto _ : Cast t1 CharacterData}
     -> (obj : t1)
     -> (offset : Bits32)
     -> (count : Bits32)
     -> (data_ : String)
     -> JSIO ()
-  replaceData a b c d = primJS $ CharacterData.prim__replaceData (up a) b c d
+  replaceData a b c d = primJS $ CharacterData.prim__replaceData (cast a) b c d
 
-
+  
   export
   substringData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CharacterData (Types t1)}
+       {auto _ : Cast t1 CharacterData}
     -> (obj : t1)
     -> (offset : Bits32)
     -> (count : Bits32)
     -> JSIO String
-  substringData a b c = primJS $ CharacterData.prim__substringData (up a) b c
+  substringData a b c = primJS $ CharacterData.prim__substringData (cast a) b c
 
 
 
 namespace Comment
-
+  
   export
   new' : (data_ : Optional String) -> JSIO Comment
   new' a = primJS $ Comment.prim__new (toFFI a)
-
+  
   export
   new : JSIO Comment
   new = primJS $ Comment.prim__new undef
@@ -232,26 +202,25 @@ namespace Comment
 
 
 namespace CustomEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem CustomEventInit (Types t2)}
+       {auto _ : Cast t2 CustomEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO CustomEvent
   new' a b = primJS $ CustomEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO CustomEvent
   new a = primJS $ CustomEvent.prim__new a undef
 
-
+  
   export
   detail : (obj : CustomEvent) -> JSIO Any
   detail a = tryJS "CustomEvent.detail" $ CustomEvent.prim__detail a
 
-
+  
   export
   initCustomEvent' :
        (obj : CustomEvent)
@@ -262,7 +231,7 @@ namespace CustomEvent
     -> JSIO ()
   initCustomEvent' a b c d e = primJS $
     CustomEvent.prim__initCustomEvent a b (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   initCustomEvent : (obj : CustomEvent) -> (type : String) -> JSIO ()
   initCustomEvent a b = primJS $
@@ -271,7 +240,7 @@ namespace CustomEvent
 
 
 namespace DOMImplementation
-
+  
   export
   createDocument' :
        (obj : DOMImplementation)
@@ -281,7 +250,7 @@ namespace DOMImplementation
     -> JSIO XMLDocument
   createDocument' a b c d = primJS $
     DOMImplementation.prim__createDocument a (toFFI b) c (toFFI d)
-
+  
   export
   createDocument :
        (obj : DOMImplementation)
@@ -291,7 +260,7 @@ namespace DOMImplementation
   createDocument a b c = primJS $
     DOMImplementation.prim__createDocument a (toFFI b) c undef
 
-
+  
   export
   createDocumentType :
        (obj : DOMImplementation)
@@ -302,7 +271,7 @@ namespace DOMImplementation
   createDocumentType a b c d = primJS $
     DOMImplementation.prim__createDocumentType a b c d
 
-
+  
   export
   createHTMLDocument' :
        (obj : DOMImplementation)
@@ -310,13 +279,13 @@ namespace DOMImplementation
     -> JSIO Document
   createHTMLDocument' a b = primJS $
     DOMImplementation.prim__createHTMLDocument a (toFFI b)
-
+  
   export
   createHTMLDocument : (obj : DOMImplementation) -> JSIO Document
   createHTMLDocument a = primJS $
     DOMImplementation.prim__createHTMLDocument a undef
 
-
+  
   export
   hasFeature : (obj : DOMImplementation) -> JSIO Bool
   hasFeature a = tryJS "DOMImplementation.hasFeature" $
@@ -325,37 +294,37 @@ namespace DOMImplementation
 
 
 namespace DOMTokenList
-
+  
   export
   length : (obj : DOMTokenList) -> JSIO Bits32
   length a = primJS $ DOMTokenList.prim__length a
 
-
+  
   export
   value : DOMTokenList -> Attribute True Prelude.id String
   value v = fromPrim "DOMTokenList.getvalue" prim__value prim__setValue v
 
-
+  
   export
   add : (obj : DOMTokenList) -> (tokens : List String) -> JSIO ()
   add a b = primJS $ DOMTokenList.prim__add a (toFFI b)
 
-
+  
   export
   contains : (obj : DOMTokenList) -> (token : String) -> JSIO Bool
   contains a b = tryJS "DOMTokenList.contains" $ DOMTokenList.prim__contains a b
 
-
+  
   export
   item : (obj : DOMTokenList) -> (index : Bits32) -> JSIO (Maybe String)
   item a b = tryJS "DOMTokenList.item" $ DOMTokenList.prim__item a b
 
-
+  
   export
   remove : (obj : DOMTokenList) -> (tokens : List String) -> JSIO ()
   remove a b = primJS $ DOMTokenList.prim__remove a (toFFI b)
 
-
+  
   export
   replace :
        (obj : DOMTokenList)
@@ -365,12 +334,12 @@ namespace DOMTokenList
   replace a b c = tryJS "DOMTokenList.replace" $
     DOMTokenList.prim__replace a b c
 
-
+  
   export
   supports : (obj : DOMTokenList) -> (token : String) -> JSIO Bool
   supports a b = tryJS "DOMTokenList.supports" $ DOMTokenList.prim__supports a b
 
-
+  
   export
   toggle' :
        (obj : DOMTokenList)
@@ -379,7 +348,7 @@ namespace DOMTokenList
     -> JSIO Bool
   toggle' a b c = tryJS "DOMTokenList.toggle'" $
     DOMTokenList.prim__toggle a b (toFFI c)
-
+  
   export
   toggle : (obj : DOMTokenList) -> (token : String) -> JSIO Bool
   toggle a b = tryJS "DOMTokenList.toggle" $ DOMTokenList.prim__toggle a b undef
@@ -387,964 +356,769 @@ namespace DOMTokenList
 
 
 namespace Document
-
+  
   export
   new : JSIO Document
   new = primJS $ Document.prim__new
 
-
+  
   export
   get :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (name : String)
     -> JSIO Object
-  get a b = primJS $ Document.prim__get (up a) b
+  get a b = primJS $ Document.prim__get (cast a) b
 
-
+  
   export
-  URL :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  URL a = primJS $ Document.prim__URL (up a)
+  URL : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  URL a = primJS $ Document.prim__URL (cast a)
 
-
+  
   export
   alinkColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute True Prelude.id String
   alinkColor v = fromPrim
                    "Document.getalinkColor"
                    prim__alinkColor
                    prim__setAlinkColor
-                   (v :> Document)
+                   (cast {to = Document} v)
 
-
+  
   export
-  all :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLAllCollection
-  all a = primJS $ Document.prim__all (up a)
+  all : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLAllCollection
+  all a = primJS $ Document.prim__all (cast a)
 
-
+  
   export
-  anchors :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  anchors a = primJS $ Document.prim__anchors (up a)
+  anchors : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  anchors a = primJS $ Document.prim__anchors (cast a)
 
-
+  
   export
-  applets :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  applets a = primJS $ Document.prim__applets (up a)
+  applets : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  applets a = primJS $ Document.prim__applets (cast a)
 
-
+  
   export
-  bgColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  bgColor : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
   bgColor v = fromPrim
                 "Document.getbgColor"
                 prim__bgColor
                 prim__setBgColor
-                (v :> Document)
+                (cast {to = Document} v)
 
-
+  
   export
-  body :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute False Maybe HTMLElement
+  body : {auto _ : Cast t Document} -> t -> Attribute False Maybe HTMLElement
   body v = fromNullablePrim
              "Document.getbody"
              prim__body
              prim__setBody
-             (v :> Document)
+             (cast {to = Document} v)
 
-
+  
   export
-  characterSet :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  characterSet a = primJS $ Document.prim__characterSet (up a)
+  characterSet : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  characterSet a = primJS $ Document.prim__characterSet (cast a)
 
-
+  
   export
-  charset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  charset a = primJS $ Document.prim__charset (up a)
+  charset : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  charset a = primJS $ Document.prim__charset (cast a)
 
-
+  
   export
-  compatMode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  compatMode a = primJS $ Document.prim__compatMode (up a)
+  compatMode : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  compatMode a = primJS $ Document.prim__compatMode (cast a)
 
-
+  
   export
-  contentType :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  contentType a = primJS $ Document.prim__contentType (up a)
+  contentType : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  contentType a = primJS $ Document.prim__contentType (cast a)
 
-
+  
   export
-  cookie :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  cookie : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
   cookie v = fromPrim
                "Document.getcookie"
                prim__cookie
                prim__setCookie
-               (v :> Document)
+               (cast {to = Document} v)
 
-
+  
   export
   currentScript :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe (HSum [HTMLScriptElement, SVGScriptElement]))
   currentScript a = tryJS "Document.currentScript" $
-    Document.prim__currentScript (up a)
+    Document.prim__currentScript (cast a)
 
-
+  
   export
   defaultView :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe WindowProxy)
   defaultView a = tryJS "Document.defaultView" $
-    Document.prim__defaultView (up a)
+    Document.prim__defaultView (cast a)
 
-
+  
   export
   designMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute True Prelude.id String
   designMode v = fromPrim
                    "Document.getdesignMode"
                    prim__designMode
                    prim__setDesignMode
-                   (v :> Document)
+                   (cast {to = Document} v)
 
-
+  
   export
-  dir :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
-  dir v = fromPrim "Document.getdir" prim__dir prim__setDir (v :> Document)
+  dir : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
+  dir v = fromPrim
+            "Document.getdir"
+            prim__dir
+            prim__setDir
+            (cast {to = Document} v)
 
-
+  
   export
   doctype :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe DocumentType)
-  doctype a = tryJS "Document.doctype" $ Document.prim__doctype (up a)
+  doctype a = tryJS "Document.doctype" $ Document.prim__doctype (cast a)
 
-
+  
   export
   documentElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   documentElement a = tryJS "Document.documentElement" $
-    Document.prim__documentElement (up a)
+    Document.prim__documentElement (cast a)
 
-
+  
   export
-  documentURI :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  documentURI a = primJS $ Document.prim__documentURI (up a)
+  documentURI : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  documentURI a = primJS $ Document.prim__documentURI (cast a)
 
-
+  
   export
-  domain :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  domain : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
   domain v = fromPrim
                "Document.getdomain"
                prim__domain
                prim__setDomain
-               (v :> Document)
+               (cast {to = Document} v)
 
-
+  
   export
-  embeds :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  embeds a = primJS $ Document.prim__embeds (up a)
+  embeds : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  embeds a = primJS $ Document.prim__embeds (cast a)
 
-
+  
   export
-  fgColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  fgColor : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
   fgColor v = fromPrim
                 "Document.getfgColor"
                 prim__fgColor
                 prim__setFgColor
-                (v :> Document)
+                (cast {to = Document} v)
 
-
+  
   export
-  forms :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  forms a = primJS $ Document.prim__forms (up a)
+  forms : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  forms a = primJS $ Document.prim__forms (cast a)
 
-
+  
   export
   head :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe HTMLHeadElement)
-  head a = tryJS "Document.head" $ Document.prim__head (up a)
+  head a = tryJS "Document.head" $ Document.prim__head (cast a)
 
-
+  
   export
-  hidden :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  hidden a = tryJS "Document.hidden" $ Document.prim__hidden (up a)
+  hidden : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO Bool
+  hidden a = tryJS "Document.hidden" $ Document.prim__hidden (cast a)
 
-
+  
   export
-  images :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  images a = primJS $ Document.prim__images (up a)
+  images : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  images a = primJS $ Document.prim__images (cast a)
 
-
+  
   export
   implementation_ :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO DOMImplementation
-  implementation_ a = primJS $ Document.prim__implementation (up a)
+  implementation_ a = primJS $ Document.prim__implementation (cast a)
 
-
+  
   export
-  inputEncoding :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  inputEncoding a = primJS $ Document.prim__inputEncoding (up a)
+  inputEncoding : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  inputEncoding a = primJS $ Document.prim__inputEncoding (cast a)
 
-
+  
   export
-  lastModified :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  lastModified a = primJS $ Document.prim__lastModified (up a)
+  lastModified : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  lastModified a = primJS $ Document.prim__lastModified (cast a)
 
-
+  
   export
   linkColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute True Prelude.id String
   linkColor v = fromPrim
                   "Document.getlinkColor"
                   prim__linkColor
                   prim__setLinkColor
-                  (v :> Document)
+                  (cast {to = Document} v)
 
-
+  
   export
-  links :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  links a = primJS $ Document.prim__links (up a)
+  links : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  links a = primJS $ Document.prim__links (cast a)
 
-
+  
   export
-  location :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Location)
-  location a = tryJS "Document.location" $ Document.prim__location (up a)
+  location : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO (Maybe Location)
+  location a = tryJS "Document.location" $ Document.prim__location (cast a)
 
-
+  
   export
   onreadystatechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onreadystatechange v = fromNullablePrim
                            "Document.getonreadystatechange"
                            prim__onreadystatechange
                            prim__setOnreadystatechange
-                           (v :> Document)
+                           (cast {to = Document} v)
 
-
+  
   export
   onvisibilitychange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onvisibilitychange v = fromNullablePrim
                            "Document.getonvisibilitychange"
                            prim__onvisibilitychange
                            prim__setOnvisibilitychange
-                           (v :> Document)
+                           (cast {to = Document} v)
 
-
+  
   export
-  plugins :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  plugins a = primJS $ Document.prim__plugins (up a)
+  plugins : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  plugins a = primJS $ Document.prim__plugins (cast a)
 
-
+  
   export
   readyState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO DocumentReadyState
-  readyState a = tryJS "Document.readyState" $ Document.prim__readyState (up a)
+  readyState a = tryJS "Document.readyState" $
+    Document.prim__readyState (cast a)
 
-
+  
   export
-  referrer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  referrer a = primJS $ Document.prim__referrer (up a)
+  referrer : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO String
+  referrer a = primJS $ Document.prim__referrer (cast a)
 
-
+  
   export
   rootElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe SVGSVGElement)
   rootElement a = tryJS "Document.rootElement" $
-    Document.prim__rootElement (up a)
+    Document.prim__rootElement (cast a)
 
-
+  
   export
-  scripts :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  scripts a = primJS $ Document.prim__scripts (up a)
+  scripts : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO HTMLCollection
+  scripts a = primJS $ Document.prim__scripts (cast a)
 
-
+  
   export
   scrollingElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   scrollingElement a = tryJS "Document.scrollingElement" $
-    Document.prim__scrollingElement (up a)
+    Document.prim__scrollingElement (cast a)
 
-
+  
   export
-  timeline :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO DocumentTimeline
-  timeline a = primJS $ Document.prim__timeline (up a)
+  timeline : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO DocumentTimeline
+  timeline a = primJS $ Document.prim__timeline (cast a)
 
-
+  
   export
-  title :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  title : {auto _ : Cast t Document} -> t -> Attribute True Prelude.id String
   title v = fromPrim
               "Document.gettitle"
               prim__title
               prim__setTitle
-              (v :> Document)
+              (cast {to = Document} v)
 
-
+  
   export
   visibilityState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO VisibilityState
   visibilityState a = tryJS "Document.visibilityState" $
-    Document.prim__visibilityState (up a)
+    Document.prim__visibilityState (cast a)
 
-
+  
   export
   vlinkColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Document (Types t)}
+       {auto _ : Cast t Document}
     -> t
     -> Attribute True Prelude.id String
   vlinkColor v = fromPrim
                    "Document.getvlinkColor"
                    prim__vlinkColor
                    prim__setVlinkColor
-                   (v :> Document)
+                   (cast {to = Document} v)
 
-
+  
   export
   adoptNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (node : t2)
     -> JSIO Node
-  adoptNode a b = primJS $ Document.prim__adoptNode (up a) (up b)
+  adoptNode a b = primJS $ Document.prim__adoptNode (cast a) (cast b)
 
-
+  
   export
-  captureEvents :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  captureEvents a = primJS $ Document.prim__captureEvents (up a)
+  captureEvents : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO ()
+  captureEvents a = primJS $ Document.prim__captureEvents (cast a)
 
-
+  
   export
   caretPositionFromPoint :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO (Maybe CaretPosition)
   caretPositionFromPoint a b c = tryJS "Document.caretPositionFromPoint" $
-    Document.prim__caretPositionFromPoint (up a) b c
+    Document.prim__caretPositionFromPoint (cast a) b c
 
-
+  
   export
-  clear :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  clear a = primJS $ Document.prim__clear (up a)
+  clear : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO ()
+  clear a = primJS $ Document.prim__clear (cast a)
 
-
+  
   export
-  close :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  close a = primJS $ Document.prim__close (up a)
+  close : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO ()
+  close a = primJS $ Document.prim__close (cast a)
 
-
+  
   export
   createAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (localName : String)
     -> JSIO Attr
-  createAttribute a b = primJS $ Document.prim__createAttribute (up a) b
+  createAttribute a b = primJS $ Document.prim__createAttribute (cast a) b
 
-
+  
   export
   createAttributeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (qualifiedName : String)
     -> JSIO Attr
   createAttributeNS a b c = primJS $
-    Document.prim__createAttributeNS (up a) (toFFI b) c
+    Document.prim__createAttributeNS (cast a) (toFFI b) c
 
-
+  
   export
   createCDATASection :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO CDATASection
-  createCDATASection a b = primJS $ Document.prim__createCDATASection (up a) b
+  createCDATASection a b = primJS $ Document.prim__createCDATASection (cast a) b
 
-
+  
   export
   createComment :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO Comment
-  createComment a b = primJS $ Document.prim__createComment (up a) b
+  createComment a b = primJS $ Document.prim__createComment (cast a) b
 
-
+  
   export
   createDocumentFragment :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO DocumentFragment
   createDocumentFragment a = primJS $
-    Document.prim__createDocumentFragment (up a)
+    Document.prim__createDocumentFragment (cast a)
 
-
+  
   export
   createElement' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (localName : String)
     -> (options : Optional (HSum [String, ElementCreationOptions]))
     -> JSIO Element
   createElement' a b c = primJS $
-    Document.prim__createElement (up a) b (toFFI c)
-
+    Document.prim__createElement (cast a) b (toFFI c)
+  
   export
   createElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (localName : String)
     -> JSIO Element
-  createElement a b = primJS $ Document.prim__createElement (up a) b undef
+  createElement a b = primJS $ Document.prim__createElement (cast a) b undef
 
-
+  
   export
   createElementNS' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (qualifiedName : String)
     -> (options : Optional (HSum [String, ElementCreationOptions]))
     -> JSIO Element
   createElementNS' a b c d = primJS $
-    Document.prim__createElementNS (up a) (toFFI b) c (toFFI d)
-
+    Document.prim__createElementNS (cast a) (toFFI b) c (toFFI d)
+  
   export
   createElementNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (qualifiedName : String)
     -> JSIO Element
   createElementNS a b c = primJS $
-    Document.prim__createElementNS (up a) (toFFI b) c undef
+    Document.prim__createElementNS (cast a) (toFFI b) c undef
 
-
+  
   export
   createEvent :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (interface_ : String)
     -> JSIO Event
-  createEvent a b = primJS $ Document.prim__createEvent (up a) b
+  createEvent a b = primJS $ Document.prim__createEvent (cast a) b
 
-
+  
   export
   createNodeIterator' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (root : t2)
     -> (whatToShow : Optional Bits32)
     -> (filter : Optional (Maybe NodeFilter))
     -> JSIO NodeIterator
   createNodeIterator' a b c d = primJS $
-    Document.prim__createNodeIterator (up a) (up b) (toFFI c) (toFFI d)
-
+    Document.prim__createNodeIterator (cast a) (cast b) (toFFI c) (toFFI d)
+  
   export
   createNodeIterator :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (root : t2)
     -> JSIO NodeIterator
   createNodeIterator a b = primJS $
-    Document.prim__createNodeIterator (up a) (up b) undef undef
+    Document.prim__createNodeIterator (cast a) (cast b) undef undef
 
-
+  
   export
   createProcessingInstruction :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (target : String)
     -> (data_ : String)
     -> JSIO ProcessingInstruction
   createProcessingInstruction a b c = primJS $
-    Document.prim__createProcessingInstruction (up a) b c
+    Document.prim__createProcessingInstruction (cast a) b c
 
-
+  
   export
-  createRange :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO Range
-  createRange a = primJS $ Document.prim__createRange (up a)
+  createRange : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO Range
+  createRange a = primJS $ Document.prim__createRange (cast a)
 
-
+  
   export
   createTextNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO Text
-  createTextNode a b = primJS $ Document.prim__createTextNode (up a) b
+  createTextNode a b = primJS $ Document.prim__createTextNode (cast a) b
 
-
+  
   export
   createTreeWalker' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (root : t2)
     -> (whatToShow : Optional Bits32)
     -> (filter : Optional (Maybe NodeFilter))
     -> JSIO TreeWalker
   createTreeWalker' a b c d = primJS $
-    Document.prim__createTreeWalker (up a) (up b) (toFFI c) (toFFI d)
-
+    Document.prim__createTreeWalker (cast a) (cast b) (toFFI c) (toFFI d)
+  
   export
   createTreeWalker :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (root : t2)
     -> JSIO TreeWalker
   createTreeWalker a b = primJS $
-    Document.prim__createTreeWalker (up a) (up b) undef undef
+    Document.prim__createTreeWalker (cast a) (cast b) undef undef
 
-
+  
   export
   elementFromPoint :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO (Maybe Element)
   elementFromPoint a b c = tryJS "Document.elementFromPoint" $
-    Document.prim__elementFromPoint (up a) b c
+    Document.prim__elementFromPoint (cast a) b c
 
-
+  
   export
   elementsFromPoint :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO (Array Element)
-  elementsFromPoint a b c = primJS $ Document.prim__elementsFromPoint (up a) b c
+  elementsFromPoint a b c = primJS $
+    Document.prim__elementsFromPoint (cast a) b c
 
-
+  
   export
   execCommand' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> (showUI : Optional Bool)
     -> (value : Optional String)
     -> JSIO Bool
   execCommand' a b c d = tryJS "Document.execCommand'" $
-    Document.prim__execCommand (up a) b (toFFI c) (toFFI d)
-
+    Document.prim__execCommand (cast a) b (toFFI c) (toFFI d)
+  
   export
   execCommand :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO Bool
   execCommand a b = tryJS "Document.execCommand" $
-    Document.prim__execCommand (up a) b undef undef
+    Document.prim__execCommand (cast a) b undef undef
 
-
+  
   export
   getAnimations :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> JSIO (Array Animation)
-  getAnimations a = primJS $ Document.prim__getAnimations (up a)
+  getAnimations a = primJS $ Document.prim__getAnimations (cast a)
 
-
+  
   export
   getElementsByClassName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (classNames : String)
     -> JSIO HTMLCollection
   getElementsByClassName a b = primJS $
-    Document.prim__getElementsByClassName (up a) b
+    Document.prim__getElementsByClassName (cast a) b
 
-
+  
   export
   getElementsByName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (elementName : String)
     -> JSIO NodeList
-  getElementsByName a b = primJS $ Document.prim__getElementsByName (up a) b
+  getElementsByName a b = primJS $ Document.prim__getElementsByName (cast a) b
 
-
+  
   export
   getElementsByTagName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO HTMLCollection
   getElementsByTagName a b = primJS $
-    Document.prim__getElementsByTagName (up a) b
+    Document.prim__getElementsByTagName (cast a) b
 
-
+  
   export
   getElementsByTagNameNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO HTMLCollection
   getElementsByTagNameNS a b c = primJS $
-    Document.prim__getElementsByTagNameNS (up a) (toFFI b) c
+    Document.prim__getElementsByTagNameNS (cast a) (toFFI b) c
 
-
+  
   export
-  hasFocus :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  hasFocus a = tryJS "Document.hasFocus" $ Document.prim__hasFocus (up a)
+  hasFocus : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO Bool
+  hasFocus a = tryJS "Document.hasFocus" $ Document.prim__hasFocus (cast a)
 
-
+  
   export
   importNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (node : t2)
     -> (deep : Optional Bool)
     -> JSIO Node
-  importNode' a b c = primJS $ Document.prim__importNode (up a) (up b) (toFFI c)
-
+  importNode' a b c = primJS $
+    Document.prim__importNode (cast a) (cast b) (toFFI c)
+  
   export
   importNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Document}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (node : t2)
     -> JSIO Node
-  importNode a b = primJS $ Document.prim__importNode (up a) (up b) undef
+  importNode a b = primJS $ Document.prim__importNode (cast a) (cast b) undef
 
-
+  
   export
   open' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (unused1 : Optional String)
     -> (unused2 : Optional String)
     -> JSIO Document
-  open' a b c = primJS $ Document.prim__open (up a) (toFFI b) (toFFI c)
-
+  open' a b c = primJS $ Document.prim__open (cast a) (toFFI b) (toFFI c)
+  
   export
-  open_ :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO Document
-  open_ a = primJS $ Document.prim__open (up a) undef undef
+  open_ : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO Document
+  open_ a = primJS $ Document.prim__open (cast a) undef undef
 
-
+  
   export
   open1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (url : String)
     -> (name : String)
     -> (features : String)
     -> JSIO (Maybe WindowProxy)
-  open1 a b c d = tryJS "Document.open1" $ Document.prim__open1 (up a) b c d
+  open1 a b c d = tryJS "Document.open1" $ Document.prim__open1 (cast a) b c d
 
-
+  
   export
   queryCommandEnabled :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO Bool
   queryCommandEnabled a b = tryJS "Document.queryCommandEnabled" $
-    Document.prim__queryCommandEnabled (up a) b
+    Document.prim__queryCommandEnabled (cast a) b
 
-
+  
   export
   queryCommandIndeterm :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO Bool
   queryCommandIndeterm a b = tryJS "Document.queryCommandIndeterm" $
-    Document.prim__queryCommandIndeterm (up a) b
+    Document.prim__queryCommandIndeterm (cast a) b
 
-
+  
   export
   queryCommandState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO Bool
   queryCommandState a b = tryJS "Document.queryCommandState" $
-    Document.prim__queryCommandState (up a) b
+    Document.prim__queryCommandState (cast a) b
 
-
+  
   export
   queryCommandSupported :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO Bool
   queryCommandSupported a b = tryJS "Document.queryCommandSupported" $
-    Document.prim__queryCommandSupported (up a) b
+    Document.prim__queryCommandSupported (cast a) b
 
-
+  
   export
   queryCommandValue :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (commandId : String)
     -> JSIO String
-  queryCommandValue a b = primJS $ Document.prim__queryCommandValue (up a) b
+  queryCommandValue a b = primJS $ Document.prim__queryCommandValue (cast a) b
 
-
+  
   export
-  releaseEvents :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  releaseEvents a = primJS $ Document.prim__releaseEvents (up a)
+  releaseEvents : {auto _ : Cast t1 Document} -> (obj : t1) -> JSIO ()
+  releaseEvents a = primJS $ Document.prim__releaseEvents (cast a)
 
-
+  
   export
   write :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (text : List String)
     -> JSIO ()
-  write a b = primJS $ Document.prim__write (up a) (toFFI b)
+  write a b = primJS $ Document.prim__write (cast a) (toFFI b)
 
-
+  
   export
   writeln :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Document (Types t1)}
+       {auto _ : Cast t1 Document}
     -> (obj : t1)
     -> (text : List String)
     -> JSIO ()
-  writeln a b = primJS $ Document.prim__writeln (up a) (toFFI b)
+  writeln a b = primJS $ Document.prim__writeln (cast a) (toFFI b)
 
 
 
 namespace DocumentFragment
-
+  
   export
   new : JSIO DocumentFragment
   new = primJS $ DocumentFragment.prim__new
@@ -1352,17 +1126,17 @@ namespace DocumentFragment
 
 
 namespace DocumentType
-
+  
   export
   name : (obj : DocumentType) -> JSIO String
   name a = primJS $ DocumentType.prim__name a
 
-
+  
   export
   publicId : (obj : DocumentType) -> JSIO String
   publicId a = primJS $ DocumentType.prim__publicId a
 
-
+  
   export
   systemId : (obj : DocumentType) -> JSIO String
   systemId a = primJS $ DocumentType.prim__systemId a
@@ -1370,1019 +1144,808 @@ namespace DocumentType
 
 
 namespace Element
-
+  
   export
-  attributes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO NamedNodeMap
-  attributes a = primJS $ Element.prim__attributes (up a)
+  attributes : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO NamedNodeMap
+  attributes a = primJS $ Element.prim__attributes (cast a)
 
-
+  
   export
-  classList :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMTokenList
-  classList a = primJS $ Element.prim__classList (up a)
+  classList : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO DOMTokenList
+  classList a = primJS $ Element.prim__classList (cast a)
 
-
+  
   export
-  className :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  className : {auto _ : Cast t Element} -> t -> Attribute True Prelude.id String
   className v = fromPrim
                   "Element.getclassName"
                   prim__className
                   prim__setClassName
-                  (v :> Element)
+                  (cast {to = Element} v)
 
-
+  
   export
-  clientHeight :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  clientHeight a = primJS $ Element.prim__clientHeight (up a)
+  clientHeight : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  clientHeight a = primJS $ Element.prim__clientHeight (cast a)
 
-
+  
   export
-  clientLeft :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  clientLeft a = primJS $ Element.prim__clientLeft (up a)
+  clientLeft : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  clientLeft a = primJS $ Element.prim__clientLeft (cast a)
 
-
+  
   export
-  clientTop :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  clientTop a = primJS $ Element.prim__clientTop (up a)
+  clientTop : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  clientTop a = primJS $ Element.prim__clientTop (cast a)
 
-
+  
   export
-  clientWidth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  clientWidth a = primJS $ Element.prim__clientWidth (up a)
+  clientWidth : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  clientWidth a = primJS $ Element.prim__clientWidth (cast a)
 
-
+  
   export
-  id :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
-  id v = fromPrim "Element.getid" prim__id prim__setId (v :> Element)
+  id : {auto _ : Cast t Element} -> t -> Attribute True Prelude.id String
+  id v = fromPrim "Element.getid" prim__id prim__setId (cast {to = Element} v)
 
-
+  
   export
-  localName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  localName a = primJS $ Element.prim__localName (up a)
+  localName : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO String
+  localName a = primJS $ Element.prim__localName (cast a)
 
-
+  
   export
-  namespaceURI :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe String)
+  namespaceURI : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO (Maybe String)
   namespaceURI a = tryJS "Element.namespaceURI" $
-    Element.prim__namespaceURI (up a)
+    Element.prim__namespaceURI (cast a)
 
-
+  
   export
-  outerHTML :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  outerHTML : {auto _ : Cast t Element} -> t -> Attribute True Prelude.id String
   outerHTML v = fromPrim
                   "Element.getouterHTML"
                   prim__outerHTML
                   prim__setOuterHTML
-                  (v :> Element)
+                  (cast {to = Element} v)
 
-
+  
   export
-  prefix_ :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe String)
-  prefix_ a = tryJS "Element.prefix_" $ Element.prim__prefix (up a)
+  prefix_ : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO (Maybe String)
+  prefix_ a = tryJS "Element.prefix_" $ Element.prim__prefix (cast a)
 
-
+  
   export
-  scrollHeight :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  scrollHeight a = primJS $ Element.prim__scrollHeight (up a)
+  scrollHeight : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  scrollHeight a = primJS $ Element.prim__scrollHeight (cast a)
 
-
+  
   export
   scrollLeft :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
+       {auto _ : Cast t Element}
     -> t
     -> Attribute True Prelude.id Double
   scrollLeft v = fromPrim
                    "Element.getscrollLeft"
                    prim__scrollLeft
                    prim__setScrollLeft
-                   (v :> Element)
+                   (cast {to = Element} v)
 
-
+  
   export
-  scrollTop :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
-    -> t
-    -> Attribute True Prelude.id Double
+  scrollTop : {auto _ : Cast t Element} -> t -> Attribute True Prelude.id Double
   scrollTop v = fromPrim
                   "Element.getscrollTop"
                   prim__scrollTop
                   prim__setScrollTop
-                  (v :> Element)
+                  (cast {to = Element} v)
 
-
+  
   export
-  scrollWidth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  scrollWidth a = primJS $ Element.prim__scrollWidth (up a)
+  scrollWidth : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Int32
+  scrollWidth a = primJS $ Element.prim__scrollWidth (cast a)
 
-
+  
   export
   shadowRoot :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> JSIO (Maybe ShadowRoot)
-  shadowRoot a = tryJS "Element.shadowRoot" $ Element.prim__shadowRoot (up a)
+  shadowRoot a = tryJS "Element.shadowRoot" $ Element.prim__shadowRoot (cast a)
 
-
+  
   export
-  slot :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Element (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
-  slot v = fromPrim "Element.getslot" prim__slot prim__setSlot (v :> Element)
+  slot : {auto _ : Cast t Element} -> t -> Attribute True Prelude.id String
+  slot v = fromPrim
+             "Element.getslot"
+             prim__slot
+             prim__setSlot
+             (cast {to = Element} v)
 
-
+  
   export
-  tagName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  tagName a = primJS $ Element.prim__tagName (up a)
+  tagName : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO String
+  tagName a = primJS $ Element.prim__tagName (cast a)
 
-
+  
   export
   attachShadow :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem ShadowRootInit (Types t2)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t2 ShadowRootInit}
     -> (obj : t1)
     -> (init : t2)
     -> JSIO ShadowRoot
-  attachShadow a b = primJS $ Element.prim__attachShadow (up a) (up b)
+  attachShadow a b = primJS $ Element.prim__attachShadow (cast a) (cast b)
 
-
+  
   export
   checkVisibility' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem CheckVisibilityOptions (Types t2)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t2 CheckVisibilityOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO Bool
   checkVisibility' a b = tryJS "Element.checkVisibility'" $
-    Element.prim__checkVisibility (up a) (optUp b)
-
+    Element.prim__checkVisibility (cast a) (optUp b)
+  
   export
-  checkVisibility :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  checkVisibility : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Bool
   checkVisibility a = tryJS "Element.checkVisibility" $
-    Element.prim__checkVisibility (up a) undef
+    Element.prim__checkVisibility (cast a) undef
 
-
+  
   export
   closest :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (selectors : String)
     -> JSIO (Maybe Element)
-  closest a b = tryJS "Element.closest" $ Element.prim__closest (up a) b
+  closest a b = tryJS "Element.closest" $ Element.prim__closest (cast a) b
 
-
+  
   export
   getAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO (Maybe String)
   getAttribute a b = tryJS "Element.getAttribute" $
-    Element.prim__getAttribute (up a) b
+    Element.prim__getAttribute (cast a) b
 
-
+  
   export
   getAttributeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO (Maybe String)
   getAttributeNS a b c = tryJS "Element.getAttributeNS" $
-    Element.prim__getAttributeNS (up a) (toFFI b) c
+    Element.prim__getAttributeNS (cast a) (toFFI b) c
 
-
+  
   export
   getAttributeNames :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> JSIO (Array String)
-  getAttributeNames a = primJS $ Element.prim__getAttributeNames (up a)
+  getAttributeNames a = primJS $ Element.prim__getAttributeNames (cast a)
 
-
+  
   export
   getAttributeNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO (Maybe Attr)
   getAttributeNode a b = tryJS "Element.getAttributeNode" $
-    Element.prim__getAttributeNode (up a) b
+    Element.prim__getAttributeNode (cast a) b
 
-
+  
   export
   getAttributeNodeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO (Maybe Attr)
   getAttributeNodeNS a b c = tryJS "Element.getAttributeNodeNS" $
-    Element.prim__getAttributeNodeNS (up a) (toFFI b) c
+    Element.prim__getAttributeNodeNS (cast a) (toFFI b) c
 
-
+  
   export
   getBoundingClientRect :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> JSIO DOMRect
-  getBoundingClientRect a = primJS $ Element.prim__getBoundingClientRect (up a)
+  getBoundingClientRect a = primJS $
+    Element.prim__getBoundingClientRect (cast a)
 
-
+  
   export
-  getClientRects :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMRectList
-  getClientRects a = primJS $ Element.prim__getClientRects (up a)
+  getClientRects : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO DOMRectList
+  getClientRects a = primJS $ Element.prim__getClientRects (cast a)
 
-
+  
   export
   getElementsByClassName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (classNames : String)
     -> JSIO HTMLCollection
   getElementsByClassName a b = primJS $
-    Element.prim__getElementsByClassName (up a) b
+    Element.prim__getElementsByClassName (cast a) b
 
-
+  
   export
   getElementsByTagName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO HTMLCollection
   getElementsByTagName a b = primJS $
-    Element.prim__getElementsByTagName (up a) b
+    Element.prim__getElementsByTagName (cast a) b
 
-
+  
   export
   getElementsByTagNameNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO HTMLCollection
   getElementsByTagNameNS a b c = primJS $
-    Element.prim__getElementsByTagNameNS (up a) (toFFI b) c
+    Element.prim__getElementsByTagNameNS (cast a) (toFFI b) c
 
-
+  
   export
   hasAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO Bool
   hasAttribute a b = tryJS "Element.hasAttribute" $
-    Element.prim__hasAttribute (up a) b
+    Element.prim__hasAttribute (cast a) b
 
-
+  
   export
   hasAttributeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO Bool
   hasAttributeNS a b c = tryJS "Element.hasAttributeNS" $
-    Element.prim__hasAttributeNS (up a) (toFFI b) c
+    Element.prim__hasAttributeNS (cast a) (toFFI b) c
 
-
+  
   export
-  hasAttributes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  hasAttributes : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO Bool
   hasAttributes a = tryJS "Element.hasAttributes" $
-    Element.prim__hasAttributes (up a)
+    Element.prim__hasAttributes (cast a)
 
-
+  
   export
   insertAdjacentElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem Element (Types t3)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t3 Element}
     -> (obj : t1)
     -> (where_ : String)
     -> (element : t3)
     -> JSIO (Maybe Element)
   insertAdjacentElement a b c = tryJS "Element.insertAdjacentElement" $
-    Element.prim__insertAdjacentElement (up a) b (up c)
+    Element.prim__insertAdjacentElement (cast a) b (cast c)
 
-
+  
   export
   insertAdjacentHTML :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (position : String)
     -> (text : String)
     -> JSIO ()
   insertAdjacentHTML a b c = primJS $
-    Element.prim__insertAdjacentHTML (up a) b c
+    Element.prim__insertAdjacentHTML (cast a) b c
 
-
+  
   export
   insertAdjacentText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (where_ : String)
     -> (data_ : String)
     -> JSIO ()
   insertAdjacentText a b c = primJS $
-    Element.prim__insertAdjacentText (up a) b c
+    Element.prim__insertAdjacentText (cast a) b c
 
-
+  
   export
   matches :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (selectors : String)
     -> JSIO Bool
-  matches a b = tryJS "Element.matches" $ Element.prim__matches (up a) b
+  matches a b = tryJS "Element.matches" $ Element.prim__matches (cast a) b
 
-
+  
   export
   pseudo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (type : String)
     -> JSIO (Maybe CSSPseudoElement)
-  pseudo a b = tryJS "Element.pseudo" $ Element.prim__pseudo (up a) b
+  pseudo a b = tryJS "Element.pseudo" $ Element.prim__pseudo (cast a) b
 
-
+  
   export
   removeAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO ()
-  removeAttribute a b = primJS $ Element.prim__removeAttribute (up a) b
+  removeAttribute a b = primJS $ Element.prim__removeAttribute (cast a) b
 
-
+  
   export
   removeAttributeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (localName : String)
     -> JSIO ()
   removeAttributeNS a b c = primJS $
-    Element.prim__removeAttributeNS (up a) (toFFI b) c
+    Element.prim__removeAttributeNS (cast a) (toFFI b) c
 
-
+  
   export
   removeAttributeNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (attr : Attr)
     -> JSIO Attr
-  removeAttributeNode a b = primJS $ Element.prim__removeAttributeNode (up a) b
+  removeAttributeNode a b = primJS $
+    Element.prim__removeAttributeNode (cast a) b
 
-
+  
   export
   scrollBy' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t2 ScrollToOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO ()
-  scrollBy' a b = primJS $ Element.prim__scrollBy (up a) (optUp b)
-
+  scrollBy' a b = primJS $ Element.prim__scrollBy (cast a) (optUp b)
+  
   export
-  scrollBy :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  scrollBy a = primJS $ Element.prim__scrollBy (up a) undef
+  scrollBy : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO ()
+  scrollBy a = primJS $ Element.prim__scrollBy (cast a) undef
 
-
+  
   export
   scrollBy1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  scrollBy1 a b c = primJS $ Element.prim__scrollBy1 (up a) b c
+  scrollBy1 a b c = primJS $ Element.prim__scrollBy1 (cast a) b c
 
-
+  
   export
   scroll' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t2 ScrollToOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO ()
-  scroll' a b = primJS $ Element.prim__scroll (up a) (optUp b)
-
+  scroll' a b = primJS $ Element.prim__scroll (cast a) (optUp b)
+  
   export
-  scroll :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  scroll a = primJS $ Element.prim__scroll (up a) undef
+  scroll : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO ()
+  scroll a = primJS $ Element.prim__scroll (cast a) undef
 
-
+  
   export
   scroll1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  scroll1 a b c = primJS $ Element.prim__scroll1 (up a) b c
+  scroll1 a b c = primJS $ Element.prim__scroll1 (cast a) b c
 
-
+  
   export
   scrollIntoView' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (arg : Optional (HSum [Bool, ScrollIntoViewOptions]))
     -> JSIO ()
-  scrollIntoView' a b = primJS $ Element.prim__scrollIntoView (up a) (toFFI b)
-
+  scrollIntoView' a b = primJS $ Element.prim__scrollIntoView (cast a) (toFFI b)
+  
   export
-  scrollIntoView :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  scrollIntoView a = primJS $ Element.prim__scrollIntoView (up a) undef
+  scrollIntoView : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO ()
+  scrollIntoView a = primJS $ Element.prim__scrollIntoView (cast a) undef
 
-
+  
   export
   scrollTo' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t1 Element}
+    -> {auto _ : Cast t2 ScrollToOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO ()
-  scrollTo' a b = primJS $ Element.prim__scrollTo (up a) (optUp b)
-
+  scrollTo' a b = primJS $ Element.prim__scrollTo (cast a) (optUp b)
+  
   export
-  scrollTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  scrollTo a = primJS $ Element.prim__scrollTo (up a) undef
+  scrollTo : {auto _ : Cast t1 Element} -> (obj : t1) -> JSIO ()
+  scrollTo a = primJS $ Element.prim__scrollTo (cast a) undef
 
-
+  
   export
   scrollTo1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  scrollTo1 a b c = primJS $ Element.prim__scrollTo1 (up a) b c
+  scrollTo1 a b c = primJS $ Element.prim__scrollTo1 (cast a) b c
 
-
+  
   export
   setAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> (value : String)
     -> JSIO ()
-  setAttribute a b c = primJS $ Element.prim__setAttribute (up a) b c
+  setAttribute a b c = primJS $ Element.prim__setAttribute (cast a) b c
 
-
+  
   export
   setAttributeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> (qualifiedName : String)
     -> (value : String)
     -> JSIO ()
   setAttributeNS a b c d = primJS $
-    Element.prim__setAttributeNS (up a) (toFFI b) c d
+    Element.prim__setAttributeNS (cast a) (toFFI b) c d
 
-
+  
   export
   setAttributeNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (attr : Attr)
     -> JSIO (Maybe Attr)
   setAttributeNode a b = tryJS "Element.setAttributeNode" $
-    Element.prim__setAttributeNode (up a) b
+    Element.prim__setAttributeNode (cast a) b
 
-
+  
   export
   setAttributeNodeNS :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (attr : Attr)
     -> JSIO (Maybe Attr)
   setAttributeNodeNS a b = tryJS "Element.setAttributeNodeNS" $
-    Element.prim__setAttributeNodeNS (up a) b
+    Element.prim__setAttributeNodeNS (cast a) b
 
-
+  
   export
   toggleAttribute' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> (force : Optional Bool)
     -> JSIO Bool
   toggleAttribute' a b c = tryJS "Element.toggleAttribute'" $
-    Element.prim__toggleAttribute (up a) b (toFFI c)
-
+    Element.prim__toggleAttribute (cast a) b (toFFI c)
+  
   export
   toggleAttribute :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (qualifiedName : String)
     -> JSIO Bool
   toggleAttribute a b = tryJS "Element.toggleAttribute" $
-    Element.prim__toggleAttribute (up a) b undef
+    Element.prim__toggleAttribute (cast a) b undef
 
-
+  
   export
   webkitMatchesSelector :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Element (Types t1)}
+       {auto _ : Cast t1 Element}
     -> (obj : t1)
     -> (selectors : String)
     -> JSIO Bool
   webkitMatchesSelector a b = tryJS "Element.webkitMatchesSelector" $
-    Element.prim__webkitMatchesSelector (up a) b
+    Element.prim__webkitMatchesSelector (cast a) b
 
 
 
 namespace Event
-
-  public export
+  
+  export
   AT_TARGET : Bits16
   AT_TARGET = 2
 
-
-  public export
+  
+  export
   BUBBLING_PHASE : Bits16
   BUBBLING_PHASE = 3
 
-
-  public export
+  
+  export
   CAPTURING_PHASE : Bits16
   CAPTURING_PHASE = 1
 
-
-  public export
+  
+  export
   NONE : Bits16
   NONE = 0
 
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem EventInit (Types t2)}
+       {auto _ : Cast t2 EventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO Event
   new' a b = primJS $ Event.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO Event
   new a = primJS $ Event.prim__new a undef
 
-
+  
   export
-  bubbles :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  bubbles a = tryJS "Event.bubbles" $ Event.prim__bubbles (up a)
+  bubbles : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bool
+  bubbles a = tryJS "Event.bubbles" $ Event.prim__bubbles (cast a)
 
-
+  
   export
-  cancelBubble :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Event (Types t)}
-    -> t
-    -> Attribute True Prelude.id Bool
+  cancelBubble : {auto _ : Cast t Event} -> t -> Attribute True Prelude.id Bool
   cancelBubble v = fromPrim
                      "Event.getcancelBubble"
                      prim__cancelBubble
                      prim__setCancelBubble
-                     (v :> Event)
+                     (cast {to = Event} v)
 
-
+  
   export
-  cancelable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  cancelable a = tryJS "Event.cancelable" $ Event.prim__cancelable (up a)
+  cancelable : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bool
+  cancelable a = tryJS "Event.cancelable" $ Event.prim__cancelable (cast a)
 
-
+  
   export
-  composed :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  composed a = tryJS "Event.composed" $ Event.prim__composed (up a)
+  composed : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bool
+  composed a = tryJS "Event.composed" $ Event.prim__composed (cast a)
 
-
+  
   export
   currentTarget :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
+       {auto _ : Cast t1 Event}
     -> (obj : t1)
     -> JSIO (Maybe EventTarget)
   currentTarget a = tryJS "Event.currentTarget" $
-    Event.prim__currentTarget (up a)
+    Event.prim__currentTarget (cast a)
 
-
+  
   export
-  defaultPrevented :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  defaultPrevented : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bool
   defaultPrevented a = tryJS "Event.defaultPrevented" $
-    Event.prim__defaultPrevented (up a)
+    Event.prim__defaultPrevented (cast a)
 
-
+  
   export
-  eventPhase :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  eventPhase a = primJS $ Event.prim__eventPhase (up a)
+  eventPhase : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bits16
+  eventPhase a = primJS $ Event.prim__eventPhase (cast a)
 
-
+  
   export
-  isTrusted :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  isTrusted a = tryJS "Event.isTrusted" $ Event.prim__isTrusted (up a)
+  isTrusted : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Bool
+  isTrusted a = tryJS "Event.isTrusted" $ Event.prim__isTrusted (cast a)
 
-
+  
   export
-  returnValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Event (Types t)}
-    -> t
-    -> Attribute True Prelude.id Bool
+  returnValue : {auto _ : Cast t Event} -> t -> Attribute True Prelude.id Bool
   returnValue v = fromPrim
                     "Event.getreturnValue"
                     prim__returnValue
                     prim__setReturnValue
-                    (v :> Event)
+                    (cast {to = Event} v)
 
-
+  
   export
   srcElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
+       {auto _ : Cast t1 Event}
     -> (obj : t1)
     -> JSIO (Maybe EventTarget)
-  srcElement a = tryJS "Event.srcElement" $ Event.prim__srcElement (up a)
+  srcElement a = tryJS "Event.srcElement" $ Event.prim__srcElement (cast a)
 
-
+  
   export
-  target :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe EventTarget)
-  target a = tryJS "Event.target" $ Event.prim__target (up a)
+  target : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO (Maybe EventTarget)
+  target a = tryJS "Event.target" $ Event.prim__target (cast a)
 
-
+  
   export
-  timeStamp :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  timeStamp a = primJS $ Event.prim__timeStamp (up a)
+  timeStamp : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO Double
+  timeStamp a = primJS $ Event.prim__timeStamp (cast a)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  type a = primJS $ Event.prim__type (up a)
+  type : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO String
+  type a = primJS $ Event.prim__type (cast a)
 
-
+  
   export
   composedPath :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
+       {auto _ : Cast t1 Event}
     -> (obj : t1)
     -> JSIO (Array EventTarget)
-  composedPath a = primJS $ Event.prim__composedPath (up a)
+  composedPath a = primJS $ Event.prim__composedPath (cast a)
 
-
+  
   export
   initEvent' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
+       {auto _ : Cast t1 Event}
     -> (obj : t1)
     -> (type : String)
     -> (bubbles : Optional Bool)
     -> (cancelable : Optional Bool)
     -> JSIO ()
   initEvent' a b c d = primJS $
-    Event.prim__initEvent (up a) b (toFFI c) (toFFI d)
-
+    Event.prim__initEvent (cast a) b (toFFI c) (toFFI d)
+  
   export
   initEvent :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
+       {auto _ : Cast t1 Event}
     -> (obj : t1)
     -> (type : String)
     -> JSIO ()
-  initEvent a b = primJS $ Event.prim__initEvent (up a) b undef undef
+  initEvent a b = primJS $ Event.prim__initEvent (cast a) b undef undef
 
-
+  
   export
-  preventDefault :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  preventDefault a = primJS $ Event.prim__preventDefault (up a)
+  preventDefault : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO ()
+  preventDefault a = primJS $ Event.prim__preventDefault (cast a)
 
-
+  
   export
-  stopImmediatePropagation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
+  stopImmediatePropagation : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO ()
   stopImmediatePropagation a = primJS $
-    Event.prim__stopImmediatePropagation (up a)
+    Event.prim__stopImmediatePropagation (cast a)
 
-
+  
   export
-  stopPropagation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Event (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  stopPropagation a = primJS $ Event.prim__stopPropagation (up a)
+  stopPropagation : {auto _ : Cast t1 Event} -> (obj : t1) -> JSIO ()
+  stopPropagation a = primJS $ Event.prim__stopPropagation (cast a)
 
 
 
 namespace EventTarget
-
+  
   export
   new : JSIO EventTarget
   new = primJS $ EventTarget.prim__new
 
-
+  
   export
   addEventListener' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
+       {auto _ : Cast t1 EventTarget}
     -> (obj : t1)
     -> (type : String)
     -> (callback : Maybe EventListener)
     -> (options : Optional (HSum [AddEventListenerOptions, Bool]))
     -> JSIO ()
   addEventListener' a b c d = primJS $
-    EventTarget.prim__addEventListener (up a) b (toFFI c) (toFFI d)
-
+    EventTarget.prim__addEventListener (cast a) b (toFFI c) (toFFI d)
+  
   export
   addEventListener :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
+       {auto _ : Cast t1 EventTarget}
     -> (obj : t1)
     -> (type : String)
     -> (callback : Maybe EventListener)
     -> JSIO ()
   addEventListener a b c = primJS $
-    EventTarget.prim__addEventListener (up a) b (toFFI c) undef
+    EventTarget.prim__addEventListener (cast a) b (toFFI c) undef
 
-
+  
   export
   dispatchEvent :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
-    -> {auto 0 _ : Elem Event (Types t2)}
+       {auto _ : Cast t1 EventTarget}
+    -> {auto _ : Cast t2 Event}
     -> (obj : t1)
     -> (event : t2)
     -> JSIO Bool
   dispatchEvent a b = tryJS "EventTarget.dispatchEvent" $
-    EventTarget.prim__dispatchEvent (up a) (up b)
+    EventTarget.prim__dispatchEvent (cast a) (cast b)
 
-
+  
   export
   removeEventListener' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
+       {auto _ : Cast t1 EventTarget}
     -> (obj : t1)
     -> (type : String)
     -> (callback : Maybe EventListener)
     -> (options : Optional (HSum [EventListenerOptions, Bool]))
     -> JSIO ()
   removeEventListener' a b c d = primJS $
-    EventTarget.prim__removeEventListener (up a) b (toFFI c) (toFFI d)
-
+    EventTarget.prim__removeEventListener (cast a) b (toFFI c) (toFFI d)
+  
   export
   removeEventListener :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
+       {auto _ : Cast t1 EventTarget}
     -> (obj : t1)
     -> (type : String)
     -> (callback : Maybe EventListener)
     -> JSIO ()
   removeEventListener a b c = primJS $
-    EventTarget.prim__removeEventListener (up a) b (toFFI c) undef
+    EventTarget.prim__removeEventListener (cast a) b (toFFI c) undef
 
 
 
 namespace HTMLCollection
-
+  
   export
-  length :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLCollection (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  length a = primJS $ HTMLCollection.prim__length (up a)
+  length : {auto _ : Cast t1 HTMLCollection} -> (obj : t1) -> JSIO Bits32
+  length a = primJS $ HTMLCollection.prim__length (cast a)
 
-
+  
   export
   item :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLCollection (Types t1)}
+       {auto _ : Cast t1 HTMLCollection}
     -> (obj : t1)
     -> (index : Bits32)
     -> JSIO (Maybe Element)
-  item a b = tryJS "HTMLCollection.item" $ HTMLCollection.prim__item (up a) b
+  item a b = tryJS "HTMLCollection.item" $ HTMLCollection.prim__item (cast a) b
 
-
+  
   export
   namedItem :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLCollection (Types t1)}
+       {auto _ : Cast t1 HTMLCollection}
     -> (obj : t1)
     -> (name : String)
     -> JSIO (Maybe Element)
   namedItem a b = tryJS "HTMLCollection.namedItem" $
-    HTMLCollection.prim__namedItem (up a) b
+    HTMLCollection.prim__namedItem (cast a) b
 
 
 
 namespace MutationObserver
-
+  
   export
   new : (callback : MutationCallback) -> JSIO MutationObserver
   new a = primJS $ MutationObserver.prim__new a
 
-
+  
   export
   disconnect : (obj : MutationObserver) -> JSIO ()
   disconnect a = primJS $ MutationObserver.prim__disconnect a
 
-
+  
   export
   observe' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Node (Types t2)}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t3)}
+       {auto _ : Cast t2 Node}
+    -> {auto _ : Cast t3 MutationObserverInit}
     -> (obj : MutationObserver)
     -> (target : t2)
     -> (options : Optional t3)
     -> JSIO ()
-  observe' a b c = primJS $ MutationObserver.prim__observe a (up b) (optUp c)
-
+  observe' a b c = primJS $ MutationObserver.prim__observe a (cast b) (optUp c)
+  
   export
   observe :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : MutationObserver)
     -> (target : t2)
     -> JSIO ()
-  observe a b = primJS $ MutationObserver.prim__observe a (up b) undef
+  observe a b = primJS $ MutationObserver.prim__observe a (cast b) undef
 
-
+  
   export
   takeRecords : (obj : MutationObserver) -> JSIO (Array MutationRecord)
   takeRecords a = primJS $ MutationObserver.prim__takeRecords a
@@ -2390,51 +1953,51 @@ namespace MutationObserver
 
 
 namespace MutationRecord
-
+  
   export
   addedNodes : (obj : MutationRecord) -> JSIO NodeList
   addedNodes a = primJS $ MutationRecord.prim__addedNodes a
 
-
+  
   export
   attributeName : (obj : MutationRecord) -> JSIO (Maybe String)
   attributeName a = tryJS "MutationRecord.attributeName" $
     MutationRecord.prim__attributeName a
 
-
+  
   export
   attributeNamespace : (obj : MutationRecord) -> JSIO (Maybe String)
   attributeNamespace a = tryJS "MutationRecord.attributeNamespace" $
     MutationRecord.prim__attributeNamespace a
 
-
+  
   export
   nextSibling : (obj : MutationRecord) -> JSIO (Maybe Node)
   nextSibling a = tryJS "MutationRecord.nextSibling" $
     MutationRecord.prim__nextSibling a
 
-
+  
   export
   oldValue : (obj : MutationRecord) -> JSIO (Maybe String)
   oldValue a = tryJS "MutationRecord.oldValue" $ MutationRecord.prim__oldValue a
 
-
+  
   export
   previousSibling : (obj : MutationRecord) -> JSIO (Maybe Node)
   previousSibling a = tryJS "MutationRecord.previousSibling" $
     MutationRecord.prim__previousSibling a
 
-
+  
   export
   removedNodes : (obj : MutationRecord) -> JSIO NodeList
   removedNodes a = primJS $ MutationRecord.prim__removedNodes a
 
-
+  
   export
   target : (obj : MutationRecord) -> JSIO Node
   target a = primJS $ MutationRecord.prim__target a
 
-
+  
   export
   type : (obj : MutationRecord) -> JSIO String
   type a = primJS $ MutationRecord.prim__type a
@@ -2442,12 +2005,12 @@ namespace MutationRecord
 
 
 namespace NamedNodeMap
-
+  
   export
   length : (obj : NamedNodeMap) -> JSIO Bits32
   length a = primJS $ NamedNodeMap.prim__length a
 
-
+  
   export
   getNamedItemNS :
        (obj : NamedNodeMap)
@@ -2457,7 +2020,7 @@ namespace NamedNodeMap
   getNamedItemNS a b c = tryJS "NamedNodeMap.getNamedItemNS" $
     NamedNodeMap.prim__getNamedItemNS a (toFFI b) c
 
-
+  
   export
   getNamedItem :
        (obj : NamedNodeMap)
@@ -2466,12 +2029,12 @@ namespace NamedNodeMap
   getNamedItem a b = tryJS "NamedNodeMap.getNamedItem" $
     NamedNodeMap.prim__getNamedItem a b
 
-
+  
   export
   item : (obj : NamedNodeMap) -> (index : Bits32) -> JSIO (Maybe Attr)
   item a b = tryJS "NamedNodeMap.item" $ NamedNodeMap.prim__item a b
 
-
+  
   export
   removeNamedItemNS :
        (obj : NamedNodeMap)
@@ -2481,7 +2044,7 @@ namespace NamedNodeMap
   removeNamedItemNS a b c = primJS $
     NamedNodeMap.prim__removeNamedItemNS a (toFFI b) c
 
-
+  
   export
   removeNamedItem :
        (obj : NamedNodeMap)
@@ -2489,13 +2052,13 @@ namespace NamedNodeMap
     -> JSIO Attr
   removeNamedItem a b = primJS $ NamedNodeMap.prim__removeNamedItem a b
 
-
+  
   export
   setNamedItemNS : (obj : NamedNodeMap) -> (attr : Attr) -> JSIO (Maybe Attr)
   setNamedItemNS a b = tryJS "NamedNodeMap.setNamedItemNS" $
     NamedNodeMap.prim__setNamedItemNS a b
 
-
+  
   export
   setNamedItem : (obj : NamedNodeMap) -> (attr : Attr) -> JSIO (Maybe Attr)
   setNamedItem a b = tryJS "NamedNodeMap.setNamedItem" $
@@ -2504,465 +2067,374 @@ namespace NamedNodeMap
 
 
 namespace Node
-
-  public export
+  
+  export
   ATTRIBUTE_NODE : Bits16
   ATTRIBUTE_NODE = 2
 
-
-  public export
+  
+  export
   CDATA_SECTION_NODE : Bits16
   CDATA_SECTION_NODE = 4
 
-
-  public export
+  
+  export
   COMMENT_NODE : Bits16
   COMMENT_NODE = 8
 
-
-  public export
+  
+  export
   DOCUMENT_FRAGMENT_NODE : Bits16
   DOCUMENT_FRAGMENT_NODE = 11
 
-
-  public export
+  
+  export
   DOCUMENT_NODE : Bits16
   DOCUMENT_NODE = 9
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_CONTAINED_BY : Bits16
   DOCUMENT_POSITION_CONTAINED_BY = 0x10
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_CONTAINS : Bits16
   DOCUMENT_POSITION_CONTAINS = 0x8
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_DISCONNECTED : Bits16
   DOCUMENT_POSITION_DISCONNECTED = 0x1
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_FOLLOWING : Bits16
   DOCUMENT_POSITION_FOLLOWING = 0x4
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC : Bits16
   DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20
 
-
-  public export
+  
+  export
   DOCUMENT_POSITION_PRECEDING : Bits16
   DOCUMENT_POSITION_PRECEDING = 0x2
 
-
-  public export
+  
+  export
   DOCUMENT_TYPE_NODE : Bits16
   DOCUMENT_TYPE_NODE = 10
 
-
-  public export
+  
+  export
   ELEMENT_NODE : Bits16
   ELEMENT_NODE = 1
 
-
-  public export
+  
+  export
   ENTITY_NODE : Bits16
   ENTITY_NODE = 6
 
-
-  public export
+  
+  export
   ENTITY_REFERENCE_NODE : Bits16
   ENTITY_REFERENCE_NODE = 5
 
-
-  public export
+  
+  export
   NOTATION_NODE : Bits16
   NOTATION_NODE = 12
 
-
-  public export
+  
+  export
   PROCESSING_INSTRUCTION_NODE : Bits16
   PROCESSING_INSTRUCTION_NODE = 7
 
-
-  public export
+  
+  export
   TEXT_NODE : Bits16
   TEXT_NODE = 3
 
-
+  
   export
-  baseURI :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  baseURI a = primJS $ Node.prim__baseURI (up a)
+  baseURI : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO String
+  baseURI a = primJS $ Node.prim__baseURI (cast a)
 
-
+  
   export
-  childNodes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO NodeList
-  childNodes a = primJS $ Node.prim__childNodes (up a)
+  childNodes : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO NodeList
+  childNodes a = primJS $ Node.prim__childNodes (cast a)
 
-
+  
   export
-  firstChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Node)
-  firstChild a = tryJS "Node.firstChild" $ Node.prim__firstChild (up a)
+  firstChild : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Node)
+  firstChild a = tryJS "Node.firstChild" $ Node.prim__firstChild (cast a)
 
-
+  
   export
-  isConnected :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  isConnected a = tryJS "Node.isConnected" $ Node.prim__isConnected (up a)
+  isConnected : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO Bool
+  isConnected a = tryJS "Node.isConnected" $ Node.prim__isConnected (cast a)
 
-
+  
   export
-  lastChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Node)
-  lastChild a = tryJS "Node.lastChild" $ Node.prim__lastChild (up a)
+  lastChild : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Node)
+  lastChild a = tryJS "Node.lastChild" $ Node.prim__lastChild (cast a)
 
-
+  
   export
-  nextSibling :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Node)
-  nextSibling a = tryJS "Node.nextSibling" $ Node.prim__nextSibling (up a)
+  nextSibling : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Node)
+  nextSibling a = tryJS "Node.nextSibling" $ Node.prim__nextSibling (cast a)
 
-
+  
   export
-  nodeName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  nodeName a = primJS $ Node.prim__nodeName (up a)
+  nodeName : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO String
+  nodeName a = primJS $ Node.prim__nodeName (cast a)
 
-
+  
   export
-  nodeType :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  nodeType a = primJS $ Node.prim__nodeType (up a)
+  nodeType : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO Bits16
+  nodeType a = primJS $ Node.prim__nodeType (cast a)
 
-
+  
   export
-  nodeValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Node (Types t)}
-    -> t
-    -> Attribute False Maybe String
+  nodeValue : {auto _ : Cast t Node} -> t -> Attribute False Maybe String
   nodeValue v = fromNullablePrim
                   "Node.getnodeValue"
                   prim__nodeValue
                   prim__setNodeValue
-                  (v :> Node)
+                  (cast {to = Node} v)
 
-
+  
   export
-  ownerDocument :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Document)
-  ownerDocument a = tryJS "Node.ownerDocument" $ Node.prim__ownerDocument (up a)
+  ownerDocument : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Document)
+  ownerDocument a = tryJS "Node.ownerDocument" $
+    Node.prim__ownerDocument (cast a)
 
-
+  
   export
-  parentElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Element)
-  parentElement a = tryJS "Node.parentElement" $ Node.prim__parentElement (up a)
+  parentElement : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Element)
+  parentElement a = tryJS "Node.parentElement" $
+    Node.prim__parentElement (cast a)
 
-
+  
   export
-  parentNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Node)
-  parentNode a = tryJS "Node.parentNode" $ Node.prim__parentNode (up a)
+  parentNode : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Node)
+  parentNode a = tryJS "Node.parentNode" $ Node.prim__parentNode (cast a)
 
-
+  
   export
-  previousSibling :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Node)
+  previousSibling : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO (Maybe Node)
   previousSibling a = tryJS "Node.previousSibling" $
-    Node.prim__previousSibling (up a)
+    Node.prim__previousSibling (cast a)
 
-
+  
   export
-  textContent :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Node (Types t)}
-    -> t
-    -> Attribute False Maybe String
+  textContent : {auto _ : Cast t Node} -> t -> Attribute False Maybe String
   textContent v = fromNullablePrim
                     "Node.gettextContent"
                     prim__textContent
                     prim__setTextContent
-                    (v :> Node)
+                    (cast {to = Node} v)
 
-
+  
   export
   appendChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (node : t2)
     -> JSIO Node
-  appendChild a b = primJS $ Node.prim__appendChild (up a) (up b)
+  appendChild a b = primJS $ Node.prim__appendChild (cast a) (cast b)
 
-
+  
   export
   cloneNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
+       {auto _ : Cast t1 Node}
     -> (obj : t1)
     -> (deep : Optional Bool)
     -> JSIO Node
-  cloneNode' a b = primJS $ Node.prim__cloneNode (up a) (toFFI b)
-
+  cloneNode' a b = primJS $ Node.prim__cloneNode (cast a) (toFFI b)
+  
   export
-  cloneNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO Node
-  cloneNode a = primJS $ Node.prim__cloneNode (up a) undef
+  cloneNode : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO Node
+  cloneNode a = primJS $ Node.prim__cloneNode (cast a) undef
 
-
+  
   export
   compareDocumentPosition :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (other : t2)
     -> JSIO Bits16
   compareDocumentPosition a b = primJS $
-    Node.prim__compareDocumentPosition (up a) (up b)
+    Node.prim__compareDocumentPosition (cast a) (cast b)
 
-
+  
   export
   contains :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (other : Maybe t2)
     -> JSIO Bool
-  contains a b = tryJS "Node.contains" $ Node.prim__contains (up a) (mayUp b)
+  contains a b = tryJS "Node.contains" $ Node.prim__contains (cast a) (mayUp b)
 
-
+  
   export
   getRootNode' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem GetRootNodeOptions (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 GetRootNodeOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO Node
-  getRootNode' a b = primJS $ Node.prim__getRootNode (up a) (optUp b)
-
+  getRootNode' a b = primJS $ Node.prim__getRootNode (cast a) (optUp b)
+  
   export
-  getRootNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO Node
-  getRootNode a = primJS $ Node.prim__getRootNode (up a) undef
+  getRootNode : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO Node
+  getRootNode a = primJS $ Node.prim__getRootNode (cast a) undef
 
-
+  
   export
-  hasChildNodes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  hasChildNodes a = tryJS "Node.hasChildNodes" $ Node.prim__hasChildNodes (up a)
+  hasChildNodes : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO Bool
+  hasChildNodes a = tryJS "Node.hasChildNodes" $
+    Node.prim__hasChildNodes (cast a)
 
-
+  
   export
   insertBefore :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
-    -> {auto 0 _ : Elem Node (Types t3)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
+    -> {auto _ : Cast t3 Node}
     -> (obj : t1)
     -> (node : t2)
     -> (child : Maybe t3)
     -> JSIO Node
-  insertBefore a b c = primJS $ Node.prim__insertBefore (up a) (up b) (mayUp c)
+  insertBefore a b c = primJS $
+    Node.prim__insertBefore (cast a) (cast b) (mayUp c)
 
-
+  
   export
   isDefaultNamespace :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
+       {auto _ : Cast t1 Node}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> JSIO Bool
   isDefaultNamespace a b = tryJS "Node.isDefaultNamespace" $
-    Node.prim__isDefaultNamespace (up a) (toFFI b)
+    Node.prim__isDefaultNamespace (cast a) (toFFI b)
 
-
+  
   export
   isEqualNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (otherNode : Maybe t2)
     -> JSIO Bool
   isEqualNode a b = tryJS "Node.isEqualNode" $
-    Node.prim__isEqualNode (up a) (mayUp b)
+    Node.prim__isEqualNode (cast a) (mayUp b)
 
-
+  
   export
   isSameNode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (otherNode : Maybe t2)
     -> JSIO Bool
   isSameNode a b = tryJS "Node.isSameNode" $
-    Node.prim__isSameNode (up a) (mayUp b)
+    Node.prim__isSameNode (cast a) (mayUp b)
 
-
+  
   export
   lookupNamespaceURI :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
+       {auto _ : Cast t1 Node}
     -> (obj : t1)
     -> (prefix_ : Maybe String)
     -> JSIO (Maybe String)
   lookupNamespaceURI a b = tryJS "Node.lookupNamespaceURI" $
-    Node.prim__lookupNamespaceURI (up a) (toFFI b)
+    Node.prim__lookupNamespaceURI (cast a) (toFFI b)
 
-
+  
   export
   lookupPrefix :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
+       {auto _ : Cast t1 Node}
     -> (obj : t1)
     -> (namespace_ : Maybe String)
     -> JSIO (Maybe String)
   lookupPrefix a b = tryJS "Node.lookupPrefix" $
-    Node.prim__lookupPrefix (up a) (toFFI b)
+    Node.prim__lookupPrefix (cast a) (toFFI b)
 
-
+  
   export
-  normalize :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  normalize a = primJS $ Node.prim__normalize (up a)
+  normalize : {auto _ : Cast t1 Node} -> (obj : t1) -> JSIO ()
+  normalize a = primJS $ Node.prim__normalize (cast a)
 
-
+  
   export
   removeChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (child : t2)
     -> JSIO Node
-  removeChild a b = primJS $ Node.prim__removeChild (up a) (up b)
+  removeChild a b = primJS $ Node.prim__removeChild (cast a) (cast b)
 
-
+  
   export
   replaceChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
-    -> {auto 0 _ : Elem Node (Types t3)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t2 Node}
+    -> {auto _ : Cast t3 Node}
     -> (obj : t1)
     -> (node : t2)
     -> (child : t3)
     -> JSIO Node
-  replaceChild a b c = primJS $ Node.prim__replaceChild (up a) (up b) (up c)
+  replaceChild a b c = primJS $
+    Node.prim__replaceChild (cast a) (cast b) (cast c)
 
 
 
 namespace NodeIterator
-
+  
   export
   filter : (obj : NodeIterator) -> JSIO (Maybe NodeFilter)
   filter a = tryJS "NodeIterator.filter" $ NodeIterator.prim__filter a
 
-
+  
   export
   pointerBeforeReferenceNode : (obj : NodeIterator) -> JSIO Bool
   pointerBeforeReferenceNode a = tryJS "NodeIterator.pointerBeforeReferenceNode" $
     NodeIterator.prim__pointerBeforeReferenceNode a
 
-
+  
   export
   referenceNode : (obj : NodeIterator) -> JSIO Node
   referenceNode a = primJS $ NodeIterator.prim__referenceNode a
 
-
+  
   export
   root : (obj : NodeIterator) -> JSIO Node
   root a = primJS $ NodeIterator.prim__root a
 
-
+  
   export
   whatToShow : (obj : NodeIterator) -> JSIO Bits32
   whatToShow a = primJS $ NodeIterator.prim__whatToShow a
 
-
+  
   export
   detach : (obj : NodeIterator) -> JSIO ()
   detach a = primJS $ NodeIterator.prim__detach a
 
-
+  
   export
   nextNode : (obj : NodeIterator) -> JSIO (Maybe Node)
   nextNode a = tryJS "NodeIterator.nextNode" $ NodeIterator.prim__nextNode a
 
-
+  
   export
   previousNode : (obj : NodeIterator) -> JSIO (Maybe Node)
   previousNode a = tryJS "NodeIterator.previousNode" $
@@ -2971,39 +2443,34 @@ namespace NodeIterator
 
 
 namespace NodeList
-
+  
   export
-  length :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NodeList (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  length a = primJS $ NodeList.prim__length (up a)
+  length : {auto _ : Cast t1 NodeList} -> (obj : t1) -> JSIO Bits32
+  length a = primJS $ NodeList.prim__length (cast a)
 
-
+  
   export
   item :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NodeList (Types t1)}
+       {auto _ : Cast t1 NodeList}
     -> (obj : t1)
     -> (index : Bits32)
     -> JSIO (Maybe Node)
-  item a b = tryJS "NodeList.item" $ NodeList.prim__item (up a) b
+  item a b = tryJS "NodeList.item" $ NodeList.prim__item (cast a) b
 
 
 
 namespace Performance
-
+  
   export
   timeOrigin : (obj : Performance) -> JSIO Double
   timeOrigin a = primJS $ Performance.prim__timeOrigin a
 
-
+  
   export
   now : (obj : Performance) -> JSIO Double
   now a = primJS $ Performance.prim__now a
 
-
+  
   export
   toJSON : (obj : Performance) -> JSIO Object
   toJSON a = primJS $ Performance.prim__toJSON a
@@ -3011,7 +2478,7 @@ namespace Performance
 
 
 namespace ProcessingInstruction
-
+  
   export
   target : (obj : ProcessingInstruction) -> JSIO String
   target a = primJS $ ProcessingInstruction.prim__target a
@@ -3019,56 +2486,56 @@ namespace ProcessingInstruction
 
 
 namespace Range
-
-  public export
+  
+  export
   END_TO_END : Bits16
   END_TO_END = 2
 
-
-  public export
+  
+  export
   END_TO_START : Bits16
   END_TO_START = 3
 
-
-  public export
+  
+  export
   START_TO_END : Bits16
   START_TO_END = 1
 
-
-  public export
+  
+  export
   START_TO_START : Bits16
   START_TO_START = 0
 
-
+  
   export
   new : JSIO Range
   new = primJS $ Range.prim__new
 
-
+  
   export
   commonAncestorContainer : (obj : Range) -> JSIO Node
   commonAncestorContainer a = primJS $ Range.prim__commonAncestorContainer a
 
-
+  
   export
   cloneContents : (obj : Range) -> JSIO DocumentFragment
   cloneContents a = primJS $ Range.prim__cloneContents a
 
-
+  
   export
   cloneRange : (obj : Range) -> JSIO Range
   cloneRange a = primJS $ Range.prim__cloneRange a
 
-
+  
   export
   collapse' : (obj : Range) -> (toStart : Optional Bool) -> JSIO ()
   collapse' a b = primJS $ Range.prim__collapse a (toFFI b)
-
+  
   export
   collapse : (obj : Range) -> JSIO ()
   collapse a = primJS $ Range.prim__collapse a undef
 
-
+  
   export
   compareBoundaryPoints :
        (obj : Range)
@@ -3077,18 +2544,17 @@ namespace Range
     -> JSIO Int16
   compareBoundaryPoints a b c = primJS $ Range.prim__compareBoundaryPoints a b c
 
-
+  
   export
   comparePoint :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> (offset : Bits32)
     -> JSIO Int16
-  comparePoint a b c = primJS $ Range.prim__comparePoint a (up b) c
+  comparePoint a b c = primJS $ Range.prim__comparePoint a (cast b) c
 
-
+  
   export
   createContextualFragment :
        (obj : Range)
@@ -3097,157 +2563,145 @@ namespace Range
   createContextualFragment a b = primJS $
     Range.prim__createContextualFragment a b
 
-
+  
   export
   deleteContents : (obj : Range) -> JSIO ()
   deleteContents a = primJS $ Range.prim__deleteContents a
 
-
+  
   export
   detach : (obj : Range) -> JSIO ()
   detach a = primJS $ Range.prim__detach a
 
-
+  
   export
   extractContents : (obj : Range) -> JSIO DocumentFragment
   extractContents a = primJS $ Range.prim__extractContents a
 
-
+  
   export
   getBoundingClientRect : (obj : Range) -> JSIO DOMRect
   getBoundingClientRect a = primJS $ Range.prim__getBoundingClientRect a
 
-
+  
   export
   getClientRects : (obj : Range) -> JSIO DOMRectList
   getClientRects a = primJS $ Range.prim__getClientRects a
 
-
+  
   export
   insertNode :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  insertNode a b = primJS $ Range.prim__insertNode a (up b)
+  insertNode a b = primJS $ Range.prim__insertNode a (cast b)
 
-
+  
   export
   intersectsNode :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO Bool
   intersectsNode a b = tryJS "Range.intersectsNode" $
-    Range.prim__intersectsNode a (up b)
+    Range.prim__intersectsNode a (cast b)
 
-
+  
   export
   isPointInRange :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> (offset : Bits32)
     -> JSIO Bool
   isPointInRange a b c = tryJS "Range.isPointInRange" $
-    Range.prim__isPointInRange a (up b) c
+    Range.prim__isPointInRange a (cast b) c
 
-
+  
   export
   selectNodeContents :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  selectNodeContents a b = primJS $ Range.prim__selectNodeContents a (up b)
+  selectNodeContents a b = primJS $ Range.prim__selectNodeContents a (cast b)
 
-
+  
   export
   selectNode :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  selectNode a b = primJS $ Range.prim__selectNode a (up b)
+  selectNode a b = primJS $ Range.prim__selectNode a (cast b)
 
-
+  
   export
   setEndAfter :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  setEndAfter a b = primJS $ Range.prim__setEndAfter a (up b)
+  setEndAfter a b = primJS $ Range.prim__setEndAfter a (cast b)
 
-
+  
   export
   setEndBefore :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  setEndBefore a b = primJS $ Range.prim__setEndBefore a (up b)
+  setEndBefore a b = primJS $ Range.prim__setEndBefore a (cast b)
 
-
+  
   export
   setEnd :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> (offset : Bits32)
     -> JSIO ()
-  setEnd a b c = primJS $ Range.prim__setEnd a (up b) c
+  setEnd a b c = primJS $ Range.prim__setEnd a (cast b) c
 
-
+  
   export
   setStartAfter :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  setStartAfter a b = primJS $ Range.prim__setStartAfter a (up b)
+  setStartAfter a b = primJS $ Range.prim__setStartAfter a (cast b)
 
-
+  
   export
   setStartBefore :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> JSIO ()
-  setStartBefore a b = primJS $ Range.prim__setStartBefore a (up b)
+  setStartBefore a b = primJS $ Range.prim__setStartBefore a (cast b)
 
-
+  
   export
   setStart :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (node : t2)
     -> (offset : Bits32)
     -> JSIO ()
-  setStart a b c = primJS $ Range.prim__setStart a (up b) c
+  setStart a b c = primJS $ Range.prim__setStart a (cast b) c
 
-
+  
   export
   surroundContents :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : Range)
     -> (newParent : t2)
     -> JSIO ()
-  surroundContents a b = primJS $ Range.prim__surroundContents a (up b)
+  surroundContents a b = primJS $ Range.prim__surroundContents a (cast b)
 
-
+  
   export
   toString : (obj : Range) -> JSIO String
   toString a = primJS $ Range.prim__toString a
@@ -3255,84 +2709,66 @@ namespace Range
 
 
 namespace ShadowRoot
-
+  
   export
-  host :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ShadowRoot (Types t1)}
-    -> (obj : t1)
-    -> JSIO Element
-  host a = primJS $ ShadowRoot.prim__host (up a)
+  host : {auto _ : Cast t1 ShadowRoot} -> (obj : t1) -> JSIO Element
+  host a = primJS $ ShadowRoot.prim__host (cast a)
 
-
+  
   export
-  mode :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ShadowRoot (Types t1)}
-    -> (obj : t1)
-    -> JSIO ShadowRootMode
-  mode a = tryJS "ShadowRoot.mode" $ ShadowRoot.prim__mode (up a)
+  mode : {auto _ : Cast t1 ShadowRoot} -> (obj : t1) -> JSIO ShadowRootMode
+  mode a = tryJS "ShadowRoot.mode" $ ShadowRoot.prim__mode (cast a)
 
-
+  
   export
   onslotchange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ShadowRoot (Types t)}
+       {auto _ : Cast t ShadowRoot}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onslotchange v = fromNullablePrim
                      "ShadowRoot.getonslotchange"
                      prim__onslotchange
                      prim__setOnslotchange
-                     (v :> ShadowRoot)
+                     (cast {to = ShadowRoot} v)
 
 
 
 namespace StaticRange
-
+  
   export
-  new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem StaticRangeInit (Types t1)}
-    -> (init : t1)
-    -> JSIO StaticRange
-  new a = primJS $ StaticRange.prim__new (up a)
+  new : {auto _ : Cast t1 StaticRangeInit} -> (init : t1) -> JSIO StaticRange
+  new a = primJS $ StaticRange.prim__new (cast a)
 
 
 
 namespace Text
-
+  
   export
   new' : (data_ : Optional String) -> JSIO Text
   new' a = primJS $ Text.prim__new (toFFI a)
-
+  
   export
   new : JSIO Text
   new = primJS $ Text.prim__new undef
 
-
+  
   export
-  wholeText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Text (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  wholeText a = primJS $ Text.prim__wholeText (up a)
+  wholeText : {auto _ : Cast t1 Text} -> (obj : t1) -> JSIO String
+  wholeText a = primJS $ Text.prim__wholeText (cast a)
 
-
+  
   export
   splitText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Text (Types t1)}
+       {auto _ : Cast t1 Text}
     -> (obj : t1)
     -> (offset : Bits32)
     -> JSIO Text
-  splitText a b = primJS $ Text.prim__splitText (up a) b
+  splitText a b = primJS $ Text.prim__splitText (cast a) b
 
 
 
 namespace TreeWalker
-
+  
   export
   currentNode : TreeWalker -> Attribute True Prelude.id Node
   currentNode v = fromPrim
@@ -3341,54 +2777,54 @@ namespace TreeWalker
                     prim__setCurrentNode
                     v
 
-
+  
   export
   filter : (obj : TreeWalker) -> JSIO (Maybe NodeFilter)
   filter a = tryJS "TreeWalker.filter" $ TreeWalker.prim__filter a
 
-
+  
   export
   root : (obj : TreeWalker) -> JSIO Node
   root a = primJS $ TreeWalker.prim__root a
 
-
+  
   export
   whatToShow : (obj : TreeWalker) -> JSIO Bits32
   whatToShow a = primJS $ TreeWalker.prim__whatToShow a
 
-
+  
   export
   firstChild : (obj : TreeWalker) -> JSIO (Maybe Node)
   firstChild a = tryJS "TreeWalker.firstChild" $ TreeWalker.prim__firstChild a
 
-
+  
   export
   lastChild : (obj : TreeWalker) -> JSIO (Maybe Node)
   lastChild a = tryJS "TreeWalker.lastChild" $ TreeWalker.prim__lastChild a
 
-
+  
   export
   nextNode : (obj : TreeWalker) -> JSIO (Maybe Node)
   nextNode a = tryJS "TreeWalker.nextNode" $ TreeWalker.prim__nextNode a
 
-
+  
   export
   nextSibling : (obj : TreeWalker) -> JSIO (Maybe Node)
   nextSibling a = tryJS "TreeWalker.nextSibling" $
     TreeWalker.prim__nextSibling a
 
-
+  
   export
   parentNode : (obj : TreeWalker) -> JSIO (Maybe Node)
   parentNode a = tryJS "TreeWalker.parentNode" $ TreeWalker.prim__parentNode a
 
-
+  
   export
   previousNode : (obj : TreeWalker) -> JSIO (Maybe Node)
   previousNode a = tryJS "TreeWalker.previousNode" $
     TreeWalker.prim__previousNode a
 
-
+  
   export
   previousSibling : (obj : TreeWalker) -> JSIO (Maybe Node)
   previousSibling a = tryJS "TreeWalker.previousSibling" $
@@ -3398,26 +2834,25 @@ namespace TreeWalker
 
 
 namespace XMLSerializer
-
+  
   export
   new : JSIO XMLSerializer
   new = primJS $ XMLSerializer.prim__new
 
-
+  
   export
   serializeToString :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : XMLSerializer)
     -> (root : t2)
     -> JSIO String
   serializeToString a b = primJS $
-    XMLSerializer.prim__serializeToString a (up b)
+    XMLSerializer.prim__serializeToString a (cast b)
 
 
 
 namespace XPathEvaluator
-
+  
   export
   new : JSIO XPathEvaluator
   new = primJS $ XPathEvaluator.prim__new
@@ -3425,126 +2860,124 @@ namespace XPathEvaluator
 
 
 namespace XPathExpression
-
+  
   export
   evaluate' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : XPathExpression)
     -> (contextNode : t2)
     -> (type : Optional Bits16)
     -> (result : Optional (Maybe XPathResult))
     -> JSIO XPathResult
   evaluate' a b c d = primJS $
-    XPathExpression.prim__evaluate a (up b) (toFFI c) (toFFI d)
-
+    XPathExpression.prim__evaluate a (cast b) (toFFI c) (toFFI d)
+  
   export
   evaluate :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : XPathExpression)
     -> (contextNode : t2)
     -> JSIO XPathResult
-  evaluate a b = primJS $ XPathExpression.prim__evaluate a (up b) undef undef
+  evaluate a b = primJS $ XPathExpression.prim__evaluate a (cast b) undef undef
 
 
 
 namespace XPathResult
-
-  public export
+  
+  export
   ANY_TYPE : Bits16
   ANY_TYPE = 0
 
-
-  public export
+  
+  export
   ANY_UNORDERED_NODE_TYPE : Bits16
   ANY_UNORDERED_NODE_TYPE = 8
 
-
-  public export
+  
+  export
   BOOLEAN_TYPE : Bits16
   BOOLEAN_TYPE = 3
 
-
-  public export
+  
+  export
   FIRST_ORDERED_NODE_TYPE : Bits16
   FIRST_ORDERED_NODE_TYPE = 9
 
-
-  public export
+  
+  export
   NUMBER_TYPE : Bits16
   NUMBER_TYPE = 1
 
-
-  public export
+  
+  export
   ORDERED_NODE_ITERATOR_TYPE : Bits16
   ORDERED_NODE_ITERATOR_TYPE = 5
 
-
-  public export
+  
+  export
   ORDERED_NODE_SNAPSHOT_TYPE : Bits16
   ORDERED_NODE_SNAPSHOT_TYPE = 7
 
-
-  public export
+  
+  export
   STRING_TYPE : Bits16
   STRING_TYPE = 2
 
-
-  public export
+  
+  export
   UNORDERED_NODE_ITERATOR_TYPE : Bits16
   UNORDERED_NODE_ITERATOR_TYPE = 4
 
-
-  public export
+  
+  export
   UNORDERED_NODE_SNAPSHOT_TYPE : Bits16
   UNORDERED_NODE_SNAPSHOT_TYPE = 6
 
-
+  
   export
   booleanValue : (obj : XPathResult) -> JSIO Bool
   booleanValue a = tryJS "XPathResult.booleanValue" $
     XPathResult.prim__booleanValue a
 
-
+  
   export
   invalidIteratorState : (obj : XPathResult) -> JSIO Bool
   invalidIteratorState a = tryJS "XPathResult.invalidIteratorState" $
     XPathResult.prim__invalidIteratorState a
 
-
+  
   export
   numberValue : (obj : XPathResult) -> JSIO Double
   numberValue a = primJS $ XPathResult.prim__numberValue a
 
-
+  
   export
   resultType : (obj : XPathResult) -> JSIO Bits16
   resultType a = primJS $ XPathResult.prim__resultType a
 
-
+  
   export
   singleNodeValue : (obj : XPathResult) -> JSIO (Maybe Node)
   singleNodeValue a = tryJS "XPathResult.singleNodeValue" $
     XPathResult.prim__singleNodeValue a
 
-
+  
   export
   snapshotLength : (obj : XPathResult) -> JSIO Bits32
   snapshotLength a = primJS $ XPathResult.prim__snapshotLength a
 
-
+  
   export
   stringValue : (obj : XPathResult) -> JSIO String
   stringValue a = primJS $ XPathResult.prim__stringValue a
 
-
+  
   export
   iterateNext : (obj : XPathResult) -> JSIO (Maybe Node)
   iterateNext a = tryJS "XPathResult.iterateNext" $
     XPathResult.prim__iterateNext a
 
-
+  
   export
   snapshotItem : (obj : XPathResult) -> (index : Bits32) -> JSIO (Maybe Node)
   snapshotItem a b = tryJS "XPathResult.snapshotItem" $
@@ -3558,261 +2991,227 @@ namespace XPathResult
 --------------------------------------------------------------------------------
 
 namespace ChildNode
-
+  
   export
   after :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ChildNode (Types t1)}
+       {auto _ : Cast t1 ChildNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
-  after a b = primJS $ ChildNode.prim__after (up a) (toFFI b)
+  after a b = primJS $ ChildNode.prim__after (cast a) (toFFI b)
 
-
+  
   export
   before :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ChildNode (Types t1)}
+       {auto _ : Cast t1 ChildNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
-  before a b = primJS $ ChildNode.prim__before (up a) (toFFI b)
+  before a b = primJS $ ChildNode.prim__before (cast a) (toFFI b)
 
-
+  
   export
-  remove :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ChildNode (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  remove a = primJS $ ChildNode.prim__remove (up a)
+  remove : {auto _ : Cast t1 ChildNode} -> (obj : t1) -> JSIO ()
+  remove a = primJS $ ChildNode.prim__remove (cast a)
 
-
+  
   export
   replaceWith :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ChildNode (Types t1)}
+       {auto _ : Cast t1 ChildNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
-  replaceWith a b = primJS $ ChildNode.prim__replaceWith (up a) (toFFI b)
+  replaceWith a b = primJS $ ChildNode.prim__replaceWith (cast a) (toFFI b)
 
 
 
 namespace DocumentOrShadowRoot
-
+  
   export
   styleSheets :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DocumentOrShadowRoot (Types t1)}
+       {auto _ : Cast t1 DocumentOrShadowRoot}
     -> (obj : t1)
     -> JSIO StyleSheetList
-  styleSheets a = primJS $ DocumentOrShadowRoot.prim__styleSheets (up a)
+  styleSheets a = primJS $ DocumentOrShadowRoot.prim__styleSheets (cast a)
 
 
 
 namespace InnerHTML
-
+  
   export
   innerHTML :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem InnerHTML (Types t)}
+       {auto _ : Cast t InnerHTML}
     -> t
     -> Attribute True Prelude.id String
   innerHTML v = fromPrim
                   "InnerHTML.getinnerHTML"
                   prim__innerHTML
                   prim__setInnerHTML
-                  (v :> InnerHTML)
+                  (cast {to = InnerHTML} v)
 
 
 
 namespace NonDocumentTypeChildNode
-
+  
   export
   nextElementSibling :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NonDocumentTypeChildNode (Types t1)}
+       {auto _ : Cast t1 NonDocumentTypeChildNode}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   nextElementSibling a = tryJS "NonDocumentTypeChildNode.nextElementSibling" $
-    NonDocumentTypeChildNode.prim__nextElementSibling (up a)
+    NonDocumentTypeChildNode.prim__nextElementSibling (cast a)
 
-
+  
   export
   previousElementSibling :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NonDocumentTypeChildNode (Types t1)}
+       {auto _ : Cast t1 NonDocumentTypeChildNode}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   previousElementSibling a = tryJS "NonDocumentTypeChildNode.previousElementSibling" $
-    NonDocumentTypeChildNode.prim__previousElementSibling (up a)
+    NonDocumentTypeChildNode.prim__previousElementSibling (cast a)
 
 
 
 namespace NonElementParentNode
-
+  
   export
   getElementById :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NonElementParentNode (Types t1)}
+       {auto _ : Cast t1 NonElementParentNode}
     -> (obj : t1)
     -> (elementId : String)
     -> JSIO (Maybe Element)
   getElementById a b = tryJS "NonElementParentNode.getElementById" $
-    NonElementParentNode.prim__getElementById (up a) b
+    NonElementParentNode.prim__getElementById (cast a) b
 
 
 
 namespace ParentNode
-
+  
   export
-  childElementCount :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  childElementCount a = primJS $ ParentNode.prim__childElementCount (up a)
+  childElementCount : {auto _ : Cast t1 ParentNode} -> (obj : t1) -> JSIO Bits32
+  childElementCount a = primJS $ ParentNode.prim__childElementCount (cast a)
 
-
+  
   export
-  children :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
-    -> (obj : t1)
-    -> JSIO HTMLCollection
-  children a = primJS $ ParentNode.prim__children (up a)
+  children : {auto _ : Cast t1 ParentNode} -> (obj : t1) -> JSIO HTMLCollection
+  children a = primJS $ ParentNode.prim__children (cast a)
 
-
+  
   export
   firstElementChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   firstElementChild a = tryJS "ParentNode.firstElementChild" $
-    ParentNode.prim__firstElementChild (up a)
+    ParentNode.prim__firstElementChild (cast a)
 
-
+  
   export
   lastElementChild :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   lastElementChild a = tryJS "ParentNode.lastElementChild" $
-    ParentNode.prim__lastElementChild (up a)
+    ParentNode.prim__lastElementChild (cast a)
 
-
+  
   export
   append :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
-  append a b = primJS $ ParentNode.prim__append (up a) (toFFI b)
+  append a b = primJS $ ParentNode.prim__append (cast a) (toFFI b)
 
-
+  
   export
   prepend :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
-  prepend a b = primJS $ ParentNode.prim__prepend (up a) (toFFI b)
+  prepend a b = primJS $ ParentNode.prim__prepend (cast a) (toFFI b)
 
-
+  
   export
   querySelectorAll :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> (selectors : String)
     -> JSIO NodeList
-  querySelectorAll a b = primJS $ ParentNode.prim__querySelectorAll (up a) b
+  querySelectorAll a b = primJS $ ParentNode.prim__querySelectorAll (cast a) b
 
-
+  
   export
   querySelector :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> (selectors : String)
     -> JSIO (Maybe Element)
   querySelector a b = tryJS "ParentNode.querySelector" $
-    ParentNode.prim__querySelector (up a) b
+    ParentNode.prim__querySelector (cast a) b
 
-
+  
   export
   replaceChildren :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ParentNode (Types t1)}
+       {auto _ : Cast t1 ParentNode}
     -> (obj : t1)
     -> (nodes : List (HSum [Node, String]))
     -> JSIO ()
   replaceChildren a b = primJS $
-    ParentNode.prim__replaceChildren (up a) (toFFI b)
+    ParentNode.prim__replaceChildren (cast a) (toFFI b)
 
 
 
 namespace Slottable
-
+  
   export
   assignedSlot :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Slottable (Types t1)}
+       {auto _ : Cast t1 Slottable}
     -> (obj : t1)
     -> JSIO (Maybe HTMLSlotElement)
   assignedSlot a = tryJS "Slottable.assignedSlot" $
-    Slottable.prim__assignedSlot (up a)
+    Slottable.prim__assignedSlot (cast a)
 
 
 
 namespace XPathEvaluatorBase
-
+  
   export
   createExpression' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem XPathEvaluatorBase (Types t1)}
+       {auto _ : Cast t1 XPathEvaluatorBase}
     -> (obj : t1)
     -> (expression : String)
     -> (resolver : Optional (Maybe XPathNSResolver))
     -> JSIO XPathExpression
   createExpression' a b c = primJS $
-    XPathEvaluatorBase.prim__createExpression (up a) b (toFFI c)
-
+    XPathEvaluatorBase.prim__createExpression (cast a) b (toFFI c)
+  
   export
   createExpression :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem XPathEvaluatorBase (Types t1)}
+       {auto _ : Cast t1 XPathEvaluatorBase}
     -> (obj : t1)
     -> (expression : String)
     -> JSIO XPathExpression
   createExpression a b = primJS $
-    XPathEvaluatorBase.prim__createExpression (up a) b undef
+    XPathEvaluatorBase.prim__createExpression (cast a) b undef
 
-
+  
   export
   createNSResolver :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem XPathEvaluatorBase (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t1 XPathEvaluatorBase}
+    -> {auto _ : Cast t2 Node}
     -> (obj : t1)
     -> (nodeResolver : t2)
     -> JSIO XPathNSResolver
   createNSResolver a b = primJS $
-    XPathEvaluatorBase.prim__createNSResolver (up a) (up b)
+    XPathEvaluatorBase.prim__createNSResolver (cast a) (cast b)
 
-
+  
   export
   evaluate' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem XPathEvaluatorBase (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t3)}
+       {auto _ : Cast t1 XPathEvaluatorBase}
+    -> {auto _ : Cast t3 Node}
     -> (obj : t1)
     -> (expression : String)
     -> (contextNode : t3)
@@ -3822,25 +3221,23 @@ namespace XPathEvaluatorBase
     -> JSIO XPathResult
   evaluate' a b c d e f = primJS $
     XPathEvaluatorBase.prim__evaluate
-      (up a)
+      (cast a)
       b
-      (up c)
+      (cast c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   evaluate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem XPathEvaluatorBase (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t3)}
+       {auto _ : Cast t1 XPathEvaluatorBase}
+    -> {auto _ : Cast t3 Node}
     -> (obj : t1)
     -> (expression : String)
     -> (contextNode : t3)
     -> JSIO XPathResult
   evaluate a b c = primJS $
-    XPathEvaluatorBase.prim__evaluate (up a) b (up c) undef undef undef
+    XPathEvaluatorBase.prim__evaluate (cast a) b (cast c) undef undef undef
 
 
 
@@ -3850,7 +3247,7 @@ namespace XPathEvaluatorBase
 --------------------------------------------------------------------------------
 
 namespace AddEventListenerOptions
-
+  
   export
   new' :
        (passive : Optional Bool)
@@ -3859,16 +3256,15 @@ namespace AddEventListenerOptions
     -> JSIO AddEventListenerOptions
   new' a b c = primJS $
     AddEventListenerOptions.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO AddEventListenerOptions
   new = primJS $ AddEventListenerOptions.prim__new undef undef undef
 
-
+  
   export
   once :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AddEventListenerOptions (Types t)}
+       {auto _ : Cast t AddEventListenerOptions}
     -> t
     -> Attribute True Optional Bool
   once v = fromUndefOrPrim
@@ -3876,13 +3272,12 @@ namespace AddEventListenerOptions
              prim__once
              prim__setOnce
              False
-             (v :> AddEventListenerOptions)
+             (cast {to = AddEventListenerOptions} v)
 
-
+  
   export
   passive :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AddEventListenerOptions (Types t)}
+       {auto _ : Cast t AddEventListenerOptions}
     -> t
     -> Attribute True Optional Bool
   passive v = fromUndefOrPrim
@@ -3890,76 +3285,70 @@ namespace AddEventListenerOptions
                 prim__passive
                 prim__setPassive
                 False
-                (v :> AddEventListenerOptions)
+                (cast {to = AddEventListenerOptions} v)
 
-
+  
   export
   signal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AddEventListenerOptions (Types t)}
+       {auto _ : Cast t AddEventListenerOptions}
     -> t
     -> Attribute False Optional AbortSignal
   signal v = fromUndefOrPrimNoDefault
                "AddEventListenerOptions.getsignal"
                prim__signal
                prim__setSignal
-               (v :> AddEventListenerOptions)
+               (cast {to = AddEventListenerOptions} v)
 
 
 
 namespace CustomEventInit
-
+  
   export
   new' : (detail : Optional Any) -> JSIO CustomEventInit
   new' a = primJS $ CustomEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO CustomEventInit
   new = primJS $ CustomEventInit.prim__new undef
 
-
+  
   export
-  detail :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CustomEventInit (Types t)}
-    -> t
-    -> Attribute True Optional Any
+  detail : {auto _ : Cast t CustomEventInit} -> t -> Attribute True Optional Any
   detail v = fromUndefOrPrim
                "CustomEventInit.getdetail"
                prim__detail
                prim__setDetail
                (MkAny $ null {a = ()})
-               (v :> CustomEventInit)
+               (cast {to = CustomEventInit} v)
 
 
 
 namespace ElementCreationOptions
-
+  
   export
   new' : (is : Optional String) -> JSIO ElementCreationOptions
   new' a = primJS $ ElementCreationOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ElementCreationOptions
   new = primJS $ ElementCreationOptions.prim__new undef
 
-
+  
   export
   is :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ElementCreationOptions (Types t)}
+       {auto _ : Cast t ElementCreationOptions}
     -> t
     -> Attribute False Optional String
   is v = fromUndefOrPrimNoDefault
            "ElementCreationOptions.getis"
            prim__is
            prim__setIs
-           (v :> ElementCreationOptions)
+           (cast {to = ElementCreationOptions} v)
 
 
 
 namespace EventInit
-
+  
   export
   new' :
        (bubbles : Optional Bool)
@@ -3967,70 +3356,57 @@ namespace EventInit
     -> (composed : Optional Bool)
     -> JSIO EventInit
   new' a b c = primJS $ EventInit.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO EventInit
   new = primJS $ EventInit.prim__new undef undef undef
 
-
+  
   export
-  bubbles :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventInit (Types t)}
-    -> t
-    -> Attribute True Optional Bool
+  bubbles : {auto _ : Cast t EventInit} -> t -> Attribute True Optional Bool
   bubbles v = fromUndefOrPrim
                 "EventInit.getbubbles"
                 prim__bubbles
                 prim__setBubbles
                 False
-                (v :> EventInit)
+                (cast {to = EventInit} v)
 
-
+  
   export
-  cancelable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventInit (Types t)}
-    -> t
-    -> Attribute True Optional Bool
+  cancelable : {auto _ : Cast t EventInit} -> t -> Attribute True Optional Bool
   cancelable v = fromUndefOrPrim
                    "EventInit.getcancelable"
                    prim__cancelable
                    prim__setCancelable
                    False
-                   (v :> EventInit)
+                   (cast {to = EventInit} v)
 
-
+  
   export
-  composed :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventInit (Types t)}
-    -> t
-    -> Attribute True Optional Bool
+  composed : {auto _ : Cast t EventInit} -> t -> Attribute True Optional Bool
   composed v = fromUndefOrPrim
                  "EventInit.getcomposed"
                  prim__composed
                  prim__setComposed
                  False
-                 (v :> EventInit)
+                 (cast {to = EventInit} v)
 
 
 
 namespace EventListenerOptions
-
+  
   export
   new' : (capture : Optional Bool) -> JSIO EventListenerOptions
   new' a = primJS $ EventListenerOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO EventListenerOptions
   new = primJS $ EventListenerOptions.prim__new undef
 
-
+  
   export
   capture :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventListenerOptions (Types t)}
+       {auto _ : Cast t EventListenerOptions}
     -> t
     -> Attribute True Optional Bool
   capture v = fromUndefOrPrim
@@ -4038,25 +3414,24 @@ namespace EventListenerOptions
                 prim__capture
                 prim__setCapture
                 False
-                (v :> EventListenerOptions)
+                (cast {to = EventListenerOptions} v)
 
 
 
 namespace GetRootNodeOptions
-
+  
   export
   new' : (composed : Optional Bool) -> JSIO GetRootNodeOptions
   new' a = primJS $ GetRootNodeOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO GetRootNodeOptions
   new = primJS $ GetRootNodeOptions.prim__new undef
 
-
+  
   export
   composed :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GetRootNodeOptions (Types t)}
+       {auto _ : Cast t GetRootNodeOptions}
     -> t
     -> Attribute True Optional Bool
   composed v = fromUndefOrPrim
@@ -4064,12 +3439,12 @@ namespace GetRootNodeOptions
                  prim__composed
                  prim__setComposed
                  False
-                 (v :> GetRootNodeOptions)
+                 (cast {to = GetRootNodeOptions} v)
 
 
 
 namespace MutationObserverInit
-
+  
   export
   new' :
        (childList : Optional Bool)
@@ -4089,82 +3464,76 @@ namespace MutationObserverInit
       (toFFI e)
       (toFFI f)
       (toFFI g)
-
+  
   export
   new : JSIO MutationObserverInit
   new = primJS $
     MutationObserverInit.prim__new undef undef undef undef undef undef undef
 
-
+  
   export
   attributeFilter :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute False Optional (Array String)
   attributeFilter v = fromUndefOrPrimNoDefault
                         "MutationObserverInit.getattributeFilter"
                         prim__attributeFilter
                         prim__setAttributeFilter
-                        (v :> MutationObserverInit)
+                        (cast {to = MutationObserverInit} v)
 
-
+  
   export
   attributeOldValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute False Optional Bool
   attributeOldValue v = fromUndefOrPrimNoDefault
                           "MutationObserverInit.getattributeOldValue"
                           prim__attributeOldValue
                           prim__setAttributeOldValue
-                          (v :> MutationObserverInit)
+                          (cast {to = MutationObserverInit} v)
 
-
+  
   export
   attributes :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute False Optional Bool
   attributes v = fromUndefOrPrimNoDefault
                    "MutationObserverInit.getattributes"
                    prim__attributes
                    prim__setAttributes
-                   (v :> MutationObserverInit)
+                   (cast {to = MutationObserverInit} v)
 
-
+  
   export
   characterData :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute False Optional Bool
   characterData v = fromUndefOrPrimNoDefault
                       "MutationObserverInit.getcharacterData"
                       prim__characterData
                       prim__setCharacterData
-                      (v :> MutationObserverInit)
+                      (cast {to = MutationObserverInit} v)
 
-
+  
   export
   characterDataOldValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute False Optional Bool
   characterDataOldValue v = fromUndefOrPrimNoDefault
                               "MutationObserverInit.getcharacterDataOldValue"
                               prim__characterDataOldValue
                               prim__setCharacterDataOldValue
-                              (v :> MutationObserverInit)
+                              (cast {to = MutationObserverInit} v)
 
-
+  
   export
   childList :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute True Optional Bool
   childList v = fromUndefOrPrim
@@ -4172,13 +3541,12 @@ namespace MutationObserverInit
                   prim__childList
                   prim__setChildList
                   False
-                  (v :> MutationObserverInit)
+                  (cast {to = MutationObserverInit} v)
 
-
+  
   export
   subtree :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MutationObserverInit (Types t)}
+       {auto _ : Cast t MutationObserverInit}
     -> t
     -> Attribute True Optional Bool
   subtree v = fromUndefOrPrim
@@ -4186,28 +3554,27 @@ namespace MutationObserverInit
                 prim__subtree
                 prim__setSubtree
                 False
-                (v :> MutationObserverInit)
+                (cast {to = MutationObserverInit} v)
 
 
 
 namespace ShadowRootInit
-
+  
   export
   new' :
        (mode : ShadowRootMode)
     -> (delegatesFocus : Optional Bool)
     -> JSIO ShadowRootInit
   new' a b = primJS $ ShadowRootInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : (mode : ShadowRootMode) -> JSIO ShadowRootInit
   new a = primJS $ ShadowRootInit.prim__new (toFFI a) undef
 
-
+  
   export
   delegatesFocus :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ShadowRootInit (Types t)}
+       {auto _ : Cast t ShadowRootInit}
     -> t
     -> Attribute True Optional Bool
   delegatesFocus v = fromUndefOrPrim
@@ -4215,89 +3582,82 @@ namespace ShadowRootInit
                        prim__delegatesFocus
                        prim__setDelegatesFocus
                        False
-                       (v :> ShadowRootInit)
+                       (cast {to = ShadowRootInit} v)
 
-
+  
   export
   mode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ShadowRootInit (Types t)}
+       {auto _ : Cast t ShadowRootInit}
     -> t
     -> Attribute True Prelude.id ShadowRootMode
   mode v = fromPrim
              "ShadowRootInit.getmode"
              prim__mode
              prim__setMode
-             (v :> ShadowRootInit)
+             (cast {to = ShadowRootInit} v)
 
 
 
 namespace StaticRangeInit
-
+  
   export
   new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Node (Types t1)}
-    -> {auto 0 _ : Elem Node (Types t3)}
+       {auto _ : Cast t1 Node}
+    -> {auto _ : Cast t3 Node}
     -> (startContainer : t1)
     -> (startOffset : Bits32)
     -> (endContainer : t3)
     -> (endOffset : Bits32)
     -> JSIO StaticRangeInit
-  new a b c d = primJS $ StaticRangeInit.prim__new (up a) b (up c) d
+  new a b c d = primJS $ StaticRangeInit.prim__new (cast a) b (cast c) d
 
-
+  
   export
   endContainer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StaticRangeInit (Types t)}
+       {auto _ : Cast t StaticRangeInit}
     -> t
     -> Attribute True Prelude.id Node
   endContainer v = fromPrim
                      "StaticRangeInit.getendContainer"
                      prim__endContainer
                      prim__setEndContainer
-                     (v :> StaticRangeInit)
+                     (cast {to = StaticRangeInit} v)
 
-
+  
   export
   endOffset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StaticRangeInit (Types t)}
+       {auto _ : Cast t StaticRangeInit}
     -> t
     -> Attribute True Prelude.id Bits32
   endOffset v = fromPrim
                   "StaticRangeInit.getendOffset"
                   prim__endOffset
                   prim__setEndOffset
-                  (v :> StaticRangeInit)
+                  (cast {to = StaticRangeInit} v)
 
-
+  
   export
   startContainer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StaticRangeInit (Types t)}
+       {auto _ : Cast t StaticRangeInit}
     -> t
     -> Attribute True Prelude.id Node
   startContainer v = fromPrim
                        "StaticRangeInit.getstartContainer"
                        prim__startContainer
                        prim__setStartContainer
-                       (v :> StaticRangeInit)
+                       (cast {to = StaticRangeInit} v)
 
-
+  
   export
   startOffset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StaticRangeInit (Types t)}
+       {auto _ : Cast t StaticRangeInit}
     -> t
     -> Attribute True Prelude.id Bits32
   startOffset v = fromPrim
                     "StaticRangeInit.getstartOffset"
                     prim__startOffset
                     prim__setStartOffset
-                    (v :> StaticRangeInit)
+                    (cast {to = StaticRangeInit} v)
 
 
 
@@ -4307,7 +3667,7 @@ namespace StaticRangeInit
 --------------------------------------------------------------------------------
 
 namespace EventListener
-
+  
   export
   toEventListener : (Event -> IO ()) -> JSIO EventListener
   toEventListener cb = primJS $ prim__toEventListener cb
@@ -4315,7 +3675,7 @@ namespace EventListener
 
 
 namespace MutationCallback
-
+  
   export
   toMutationCallback :
        (Array MutationRecord -> MutationObserver -> IO ())
@@ -4325,97 +3685,99 @@ namespace MutationCallback
 
 
 namespace NodeFilter
-
+  
   export
   toNodeFilter : (Node -> IO Bits16) -> JSIO NodeFilter
   toNodeFilter cb = primJS $ prim__toNodeFilter cb
 
-
-  public export
+  
+  export
   FILTER_ACCEPT : Bits16
   FILTER_ACCEPT = 1
 
-
-  public export
+  
+  export
   FILTER_REJECT : Bits16
   FILTER_REJECT = 2
 
-
-  public export
+  
+  export
   FILTER_SKIP : Bits16
   FILTER_SKIP = 3
 
-
-  public export
+  
+  export
   SHOW_ALL : Bits32
   SHOW_ALL = 0xffffffff
 
-
-  public export
+  
+  export
   SHOW_ATTRIBUTE : Bits32
   SHOW_ATTRIBUTE = 0x2
 
-
-  public export
+  
+  export
   SHOW_CDATA_SECTION : Bits32
   SHOW_CDATA_SECTION = 0x8
 
-
-  public export
+  
+  export
   SHOW_COMMENT : Bits32
   SHOW_COMMENT = 0x80
 
-
-  public export
+  
+  export
   SHOW_DOCUMENT : Bits32
   SHOW_DOCUMENT = 0x100
 
-
-  public export
+  
+  export
   SHOW_DOCUMENT_FRAGMENT : Bits32
   SHOW_DOCUMENT_FRAGMENT = 0x400
 
-
-  public export
+  
+  export
   SHOW_DOCUMENT_TYPE : Bits32
   SHOW_DOCUMENT_TYPE = 0x200
 
-
-  public export
+  
+  export
   SHOW_ELEMENT : Bits32
   SHOW_ELEMENT = 0x1
 
-
-  public export
+  
+  export
   SHOW_ENTITY : Bits32
   SHOW_ENTITY = 0x20
 
-
-  public export
+  
+  export
   SHOW_ENTITY_REFERENCE : Bits32
   SHOW_ENTITY_REFERENCE = 0x10
 
-
-  public export
+  
+  export
   SHOW_NOTATION : Bits32
   SHOW_NOTATION = 0x800
 
-
-  public export
+  
+  export
   SHOW_PROCESSING_INSTRUCTION : Bits32
   SHOW_PROCESSING_INSTRUCTION = 0x40
 
-
-  public export
+  
+  export
   SHOW_TEXT : Bits32
   SHOW_TEXT = 0x4
 
 
 
 namespace XPathNSResolver
-
+  
   export
   toXPathNSResolver :
        (Nullable String -> IO (Nullable String))
     -> JSIO XPathNSResolver
   toXPathNSResolver cb = primJS $ prim__toXPathNSResolver cb
+
+

--- a/src/Web/Raw/Fetch.idr
+++ b/src/Web/Raw/Fetch.idr
@@ -12,7 +12,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Headers
-
+  
   export
   new' :
        (init : Optional
@@ -20,12 +20,12 @@ namespace Headers
                     [Array (Array ByteString), Record ByteString ByteString]))
     -> JSIO Headers
   new' a = primJS $ Headers.prim__new (toFFI a)
-
+  
   export
   new : JSIO Headers
   new = primJS $ Headers.prim__new undef
 
-
+  
   export
   append :
        (obj : Headers)
@@ -34,22 +34,22 @@ namespace Headers
     -> JSIO ()
   append a b c = primJS $ Headers.prim__append a b c
 
-
+  
   export
   delete : (obj : Headers) -> (name : ByteString) -> JSIO ()
   delete a b = primJS $ Headers.prim__delete a b
 
-
+  
   export
   get : (obj : Headers) -> (name : ByteString) -> JSIO (Maybe ByteString)
   get a b = tryJS "Headers.get" $ Headers.prim__get a b
 
-
+  
   export
   has : (obj : Headers) -> (name : ByteString) -> JSIO Bool
   has a b = tryJS "Headers.has" $ Headers.prim__has a b
 
-
+  
   export
   set :
        (obj : Headers)
@@ -61,99 +61,98 @@ namespace Headers
 
 
 namespace Request
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem RequestInit (Types t2)}
+       {auto _ : Cast t2 RequestInit}
     -> (input : HSum [Request, String])
     -> (init : Optional t2)
     -> JSIO Request
   new' a b = primJS $ Request.prim__new (toFFI a) (optUp b)
-
+  
   export
   new : (input : HSum [Request, String]) -> JSIO Request
   new a = primJS $ Request.prim__new (toFFI a) undef
 
-
+  
   export
   cache : (obj : Request) -> JSIO RequestCache
   cache a = tryJS "Request.cache" $ Request.prim__cache a
 
-
+  
   export
   credentials : (obj : Request) -> JSIO RequestCredentials
   credentials a = tryJS "Request.credentials" $ Request.prim__credentials a
 
-
+  
   export
   destination : (obj : Request) -> JSIO RequestDestination
   destination a = tryJS "Request.destination" $ Request.prim__destination a
 
-
+  
   export
   headers : (obj : Request) -> JSIO Headers
   headers a = primJS $ Request.prim__headers a
 
-
+  
   export
   integrity : (obj : Request) -> JSIO String
   integrity a = primJS $ Request.prim__integrity a
 
-
+  
   export
   isHistoryNavigation : (obj : Request) -> JSIO Bool
   isHistoryNavigation a = tryJS "Request.isHistoryNavigation" $
     Request.prim__isHistoryNavigation a
 
-
+  
   export
   isReloadNavigation : (obj : Request) -> JSIO Bool
   isReloadNavigation a = tryJS "Request.isReloadNavigation" $
     Request.prim__isReloadNavigation a
 
-
+  
   export
   keepalive : (obj : Request) -> JSIO Bool
   keepalive a = tryJS "Request.keepalive" $ Request.prim__keepalive a
 
-
+  
   export
   method : (obj : Request) -> JSIO ByteString
   method a = primJS $ Request.prim__method a
 
-
+  
   export
   mode : (obj : Request) -> JSIO RequestMode
   mode a = tryJS "Request.mode" $ Request.prim__mode a
 
-
+  
   export
   redirect : (obj : Request) -> JSIO RequestRedirect
   redirect a = tryJS "Request.redirect" $ Request.prim__redirect a
 
-
+  
   export
   referrer : (obj : Request) -> JSIO String
   referrer a = primJS $ Request.prim__referrer a
 
-
+  
   export
   referrerPolicy : (obj : Request) -> JSIO ReferrerPolicy
   referrerPolicy a = tryJS "Request.referrerPolicy" $
     Request.prim__referrerPolicy a
 
-
+  
   export
   signal : (obj : Request) -> JSIO AbortSignal
   signal a = primJS $ Request.prim__signal a
 
-
+  
   export
   url : (obj : Request) -> JSIO String
   url a = primJS $ Request.prim__url a
 
-
+  
   export
   clone : (obj : Request) -> JSIO Request
   clone a = primJS $ Request.prim__clone a
@@ -161,11 +160,10 @@ namespace Request
 
 
 namespace Response
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ResponseInit (Types t2)}
+       {auto _ : Cast t2 ResponseInit}
     -> (body : Optional
                  (Maybe
                     (HSum
@@ -189,61 +187,61 @@ namespace Response
     -> (init : Optional t2)
     -> JSIO Response
   new' a b = primJS $ Response.prim__new (toFFI a) (optUp b)
-
+  
   export
   new : JSIO Response
   new = primJS $ Response.prim__new undef undef
 
-
+  
   export
   error : JSIO Response
   error = primJS $ Response.prim__error
 
-
+  
   export
   redirect' : (url : String) -> (status : Optional Bits16) -> JSIO Response
   redirect' a b = primJS $ Response.prim__redirect a (toFFI b)
-
+  
   export
   redirect : (url : String) -> JSIO Response
   redirect a = primJS $ Response.prim__redirect a undef
 
-
+  
   export
   headers : (obj : Response) -> JSIO Headers
   headers a = primJS $ Response.prim__headers a
 
-
+  
   export
   ok : (obj : Response) -> JSIO Bool
   ok a = tryJS "Response.ok" $ Response.prim__ok a
 
-
+  
   export
   redirected : (obj : Response) -> JSIO Bool
   redirected a = tryJS "Response.redirected" $ Response.prim__redirected a
 
-
+  
   export
   status : (obj : Response) -> JSIO Bits16
   status a = primJS $ Response.prim__status a
 
-
+  
   export
   statusText : (obj : Response) -> JSIO ByteString
   statusText a = primJS $ Response.prim__statusText a
 
-
+  
   export
   type : (obj : Response) -> JSIO ResponseType
   type a = tryJS "Response.type" $ Response.prim__type a
 
-
+  
   export
   url : (obj : Response) -> JSIO String
   url a = primJS $ Response.prim__url a
 
-
+  
   export
   clone : (obj : Response) -> JSIO Response
   clone a = primJS $ Response.prim__clone a
@@ -256,68 +254,43 @@ namespace Response
 --------------------------------------------------------------------------------
 
 namespace Body
-
+  
   export
-  body :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe ReadableStream)
-  body a = tryJS "Body.body" $ Body.prim__body (up a)
+  body : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO (Maybe ReadableStream)
+  body a = tryJS "Body.body" $ Body.prim__body (cast a)
 
-
+  
   export
-  bodyUsed :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  bodyUsed a = tryJS "Body.bodyUsed" $ Body.prim__bodyUsed (up a)
+  bodyUsed : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO Bool
+  bodyUsed a = tryJS "Body.bodyUsed" $ Body.prim__bodyUsed (cast a)
 
-
+  
   export
   arrayBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
+       {auto _ : Cast t1 Body}
     -> (obj : t1)
     -> JSIO (Promise ArrayBuffer)
-  arrayBuffer a = primJS $ Body.prim__arrayBuffer (up a)
+  arrayBuffer a = primJS $ Body.prim__arrayBuffer (cast a)
 
-
+  
   export
-  blob :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise Blob)
-  blob a = primJS $ Body.prim__blob (up a)
+  blob : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO (Promise Blob)
+  blob a = primJS $ Body.prim__blob (cast a)
 
-
+  
   export
-  formData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise FormData)
-  formData a = primJS $ Body.prim__formData (up a)
+  formData : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO (Promise FormData)
+  formData a = primJS $ Body.prim__formData (cast a)
 
-
+  
   export
-  json :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise AnyPtr)
-  json a = primJS $ Body.prim__json (up a)
+  json : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO (Promise AnyPtr)
+  json a = primJS $ Body.prim__json (cast a)
 
-
+  
   export
-  text :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Body (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise String)
-  text a = primJS $ Body.prim__text (up a)
+  text : {auto _ : Cast t1 Body} -> (obj : t1) -> JSIO (Promise String)
+  text a = primJS $ Body.prim__text (cast a)
 
 
 
@@ -327,7 +300,7 @@ namespace Body
 --------------------------------------------------------------------------------
 
 namespace RequestInit
-
+  
   export
   new' :
        (method : Optional ByteString)
@@ -382,7 +355,7 @@ namespace RequestInit
       (toFFI k)
       (toFFI l)
       (toFFI m)
-
+  
   export
   new : JSIO RequestInit
   new = primJS $
@@ -401,11 +374,10 @@ namespace RequestInit
       undef
       undef
 
-
+  
   export
   body :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional (Maybe
                                    (Union16
@@ -429,39 +401,36 @@ namespace RequestInit
              "RequestInit.getbody"
              prim__body
              prim__setBody
-             (v :> RequestInit)
+             (cast {to = RequestInit} v)
 
-
+  
   export
   cache :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional RequestCache
   cache v = fromUndefOrPrimNoDefault
               "RequestInit.getcache"
               prim__cache
               prim__setCache
-              (v :> RequestInit)
+              (cast {to = RequestInit} v)
 
-
+  
   export
   credentials :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional RequestCredentials
   credentials v = fromUndefOrPrimNoDefault
                     "RequestInit.getcredentials"
                     prim__credentials
                     prim__setCredentials
-                    (v :> RequestInit)
+                    (cast {to = RequestInit} v)
 
-
+  
   export
   headers :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional (Union2
                                    (Array (Array ByteString))
@@ -470,129 +439,117 @@ namespace RequestInit
                 "RequestInit.getheaders"
                 prim__headers
                 prim__setHeaders
-                (v :> RequestInit)
+                (cast {to = RequestInit} v)
 
-
+  
   export
   integrity :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional String
   integrity v = fromUndefOrPrimNoDefault
                   "RequestInit.getintegrity"
                   prim__integrity
                   prim__setIntegrity
-                  (v :> RequestInit)
+                  (cast {to = RequestInit} v)
 
-
+  
   export
   keepalive :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional Bool
   keepalive v = fromUndefOrPrimNoDefault
                   "RequestInit.getkeepalive"
                   prim__keepalive
                   prim__setKeepalive
-                  (v :> RequestInit)
+                  (cast {to = RequestInit} v)
 
-
+  
   export
   method :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional ByteString
   method v = fromUndefOrPrimNoDefault
                "RequestInit.getmethod"
                prim__method
                prim__setMethod
-               (v :> RequestInit)
+               (cast {to = RequestInit} v)
 
-
+  
   export
   mode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional RequestMode
   mode v = fromUndefOrPrimNoDefault
              "RequestInit.getmode"
              prim__mode
              prim__setMode
-             (v :> RequestInit)
+             (cast {to = RequestInit} v)
 
-
+  
   export
   redirect :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional RequestRedirect
   redirect v = fromUndefOrPrimNoDefault
                  "RequestInit.getredirect"
                  prim__redirect
                  prim__setRedirect
-                 (v :> RequestInit)
+                 (cast {to = RequestInit} v)
 
-
+  
   export
   referrer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional String
   referrer v = fromUndefOrPrimNoDefault
                  "RequestInit.getreferrer"
                  prim__referrer
                  prim__setReferrer
-                 (v :> RequestInit)
+                 (cast {to = RequestInit} v)
 
-
+  
   export
   referrerPolicy :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional ReferrerPolicy
   referrerPolicy v = fromUndefOrPrimNoDefault
                        "RequestInit.getreferrerPolicy"
                        prim__referrerPolicy
                        prim__setReferrerPolicy
-                       (v :> RequestInit)
+                       (cast {to = RequestInit} v)
 
-
+  
   export
   signal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
+       {auto _ : Cast t RequestInit}
     -> t
     -> Attribute False Optional (Maybe AbortSignal)
   signal v = fromUndefOrPrimNoDefault
                "RequestInit.getsignal"
                prim__signal
                prim__setSignal
-               (v :> RequestInit)
+               (cast {to = RequestInit} v)
 
-
+  
   export
-  window :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RequestInit (Types t)}
-    -> t
-    -> Attribute False Optional Any
+  window : {auto _ : Cast t RequestInit} -> t -> Attribute False Optional Any
   window v = fromUndefOrPrimNoDefault
                "RequestInit.getwindow"
                prim__window
                prim__setWindow
-               (v :> RequestInit)
+               (cast {to = RequestInit} v)
 
 
 
 namespace ResponseInit
-
+  
   export
   new' :
        (status : Optional Bits16)
@@ -604,16 +561,15 @@ namespace ResponseInit
                        ]))
     -> JSIO ResponseInit
   new' a b c = primJS $ ResponseInit.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO ResponseInit
   new = primJS $ ResponseInit.prim__new undef undef undef
 
-
+  
   export
   headers :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ResponseInit (Types t)}
+       {auto _ : Cast t ResponseInit}
     -> t
     -> Attribute False Optional (Union2
                                    (Array (Array ByteString))
@@ -622,31 +578,29 @@ namespace ResponseInit
                 "ResponseInit.getheaders"
                 prim__headers
                 prim__setHeaders
-                (v :> ResponseInit)
+                (cast {to = ResponseInit} v)
 
-
+  
   export
-  status :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ResponseInit (Types t)}
-    -> t
-    -> Attribute True Optional Bits16
+  status : {auto _ : Cast t ResponseInit} -> t -> Attribute True Optional Bits16
   status v = fromUndefOrPrim
                "ResponseInit.getstatus"
                prim__status
                prim__setStatus
                200
-               (v :> ResponseInit)
+               (cast {to = ResponseInit} v)
 
-
+  
   export
   statusText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ResponseInit (Types t)}
+       {auto _ : Cast t ResponseInit}
     -> t
     -> Attribute False Optional ByteString
   statusText v = fromUndefOrPrimNoDefault
                    "ResponseInit.getstatusText"
                    prim__statusText
                    prim__setStatusText
-                   (v :> ResponseInit)
+                   (cast {to = ResponseInit} v)
+
+
+

--- a/src/Web/Raw/File.idr
+++ b/src/Web/Raw/File.idr
@@ -12,11 +12,10 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Blob
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem BlobPropertyBag (Types t2)}
+       {auto _ : Cast t2 BlobPropertyBag}
     -> (blobParts : Optional
                       (Array
                          (Union13
@@ -36,85 +35,62 @@ namespace Blob
     -> (options : Optional t2)
     -> JSIO Blob
   new' a b = primJS $ Blob.prim__new (toFFI a) (optUp b)
-
+  
   export
   new : JSIO Blob
   new = primJS $ Blob.prim__new undef undef
 
-
+  
   export
-  size :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
-    -> (obj : t1)
-    -> JSIO JSBits64
-  size a = primJS $ Blob.prim__size (up a)
+  size : {auto _ : Cast t1 Blob} -> (obj : t1) -> JSIO JSBits64
+  size a = primJS $ Blob.prim__size (cast a)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  type a = primJS $ Blob.prim__type (up a)
+  type : {auto _ : Cast t1 Blob} -> (obj : t1) -> JSIO String
+  type a = primJS $ Blob.prim__type (cast a)
 
-
+  
   export
   arrayBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
+       {auto _ : Cast t1 Blob}
     -> (obj : t1)
     -> JSIO (Promise ArrayBuffer)
-  arrayBuffer a = primJS $ Blob.prim__arrayBuffer (up a)
+  arrayBuffer a = primJS $ Blob.prim__arrayBuffer (cast a)
 
-
+  
   export
   slice' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
+       {auto _ : Cast t1 Blob}
     -> (obj : t1)
     -> (start : Optional JSInt64)
     -> (end : Optional JSInt64)
     -> (contentType : Optional String)
     -> JSIO Blob
   slice' a b c d = primJS $
-    Blob.prim__slice (up a) (toFFI b) (toFFI c) (toFFI d)
-
+    Blob.prim__slice (cast a) (toFFI b) (toFFI c) (toFFI d)
+  
   export
-  slice :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
-    -> (obj : t1)
-    -> JSIO Blob
-  slice a = primJS $ Blob.prim__slice (up a) undef undef undef
+  slice : {auto _ : Cast t1 Blob} -> (obj : t1) -> JSIO Blob
+  slice a = primJS $ Blob.prim__slice (cast a) undef undef undef
 
-
+  
   export
-  stream :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
-    -> (obj : t1)
-    -> JSIO ReadableStream
-  stream a = primJS $ Blob.prim__stream (up a)
+  stream : {auto _ : Cast t1 Blob} -> (obj : t1) -> JSIO ReadableStream
+  stream a = primJS $ Blob.prim__stream (cast a)
 
-
+  
   export
-  text :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Blob (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Promise String)
-  text a = primJS $ Blob.prim__text (up a)
+  text : {auto _ : Cast t1 Blob} -> (obj : t1) -> JSIO (Promise String)
+  text a = primJS $ Blob.prim__text (cast a)
 
 
 
 namespace File
-
+  
   export
   new' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem FilePropertyBag (Types t3)}
+       {auto _ : Cast t3 FilePropertyBag}
     -> (fileBits : Array
                      (Union13
                         Int8Array
@@ -134,7 +110,7 @@ namespace File
     -> (options : Optional t3)
     -> JSIO File
   new' a b c = primJS $ File.prim__new a b (optUp c)
-
+  
   export
   new :
        (fileBits : Array
@@ -156,12 +132,12 @@ namespace File
     -> JSIO File
   new a b = primJS $ File.prim__new a b undef
 
-
+  
   export
   lastModified : (obj : File) -> JSIO JSInt64
   lastModified a = primJS $ File.prim__lastModified a
 
-
+  
   export
   name : (obj : File) -> JSIO String
   name a = primJS $ File.prim__name a
@@ -169,12 +145,12 @@ namespace File
 
 
 namespace FileList
-
+  
   export
   length : (obj : FileList) -> JSIO Bits32
   length a = primJS $ FileList.prim__length a
 
-
+  
   export
   item : (obj : FileList) -> (index : Bits32) -> JSIO (Maybe File)
   item a b = tryJS "FileList.item" $ FileList.prim__item a b
@@ -182,32 +158,32 @@ namespace FileList
 
 
 namespace FileReader
-
-  public export
+  
+  export
   DONE : Bits16
   DONE = 2
 
-
-  public export
+  
+  export
   EMPTY : Bits16
   EMPTY = 0
 
-
-  public export
+  
+  export
   LOADING : Bits16
   LOADING = 1
 
-
+  
   export
   new : JSIO FileReader
   new = primJS $ FileReader.prim__new
 
-
+  
   export
   error : (obj : FileReader) -> JSIO (Maybe DOMException)
   error a = tryJS "FileReader.error" $ FileReader.prim__error a
 
-
+  
   export
   onabort : FileReader -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
@@ -216,7 +192,7 @@ namespace FileReader
                 prim__setOnabort
                 v
 
-
+  
   export
   onerror : FileReader -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -225,7 +201,7 @@ namespace FileReader
                 prim__setOnerror
                 v
 
-
+  
   export
   onload : FileReader -> Attribute False Maybe EventHandlerNonNull
   onload v = fromNullablePrim
@@ -234,7 +210,7 @@ namespace FileReader
                prim__setOnload
                v
 
-
+  
   export
   onloadend : FileReader -> Attribute False Maybe EventHandlerNonNull
   onloadend v = fromNullablePrim
@@ -243,7 +219,7 @@ namespace FileReader
                   prim__setOnloadend
                   v
 
-
+  
   export
   onloadstart : FileReader -> Attribute False Maybe EventHandlerNonNull
   onloadstart v = fromNullablePrim
@@ -252,7 +228,7 @@ namespace FileReader
                     prim__setOnloadstart
                     v
 
-
+  
   export
   onprogress : FileReader -> Attribute False Maybe EventHandlerNonNull
   onprogress v = fromNullablePrim
@@ -261,131 +237,122 @@ namespace FileReader
                    prim__setOnprogress
                    v
 
-
+  
   export
   readyState : (obj : FileReader) -> JSIO Bits16
   readyState a = primJS $ FileReader.prim__readyState a
 
-
+  
   export
   result : (obj : FileReader) -> JSIO (Maybe (Union2 String ArrayBuffer))
   result a = tryJS "FileReader.result" $ FileReader.prim__result a
 
-
+  
   export
   abort : (obj : FileReader) -> JSIO ()
   abort a = primJS $ FileReader.prim__abort a
 
-
+  
   export
   readAsArrayBuffer :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReader)
     -> (blob : t2)
     -> JSIO ()
-  readAsArrayBuffer a b = primJS $ FileReader.prim__readAsArrayBuffer a (up b)
+  readAsArrayBuffer a b = primJS $ FileReader.prim__readAsArrayBuffer a (cast b)
 
-
+  
   export
   readAsBinaryString :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReader)
     -> (blob : t2)
     -> JSIO ()
-  readAsBinaryString a b = primJS $ FileReader.prim__readAsBinaryString a (up b)
+  readAsBinaryString a b = primJS $
+    FileReader.prim__readAsBinaryString a (cast b)
 
-
+  
   export
   readAsDataURL :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReader)
     -> (blob : t2)
     -> JSIO ()
-  readAsDataURL a b = primJS $ FileReader.prim__readAsDataURL a (up b)
+  readAsDataURL a b = primJS $ FileReader.prim__readAsDataURL a (cast b)
 
-
+  
   export
   readAsText' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReader)
     -> (blob : t2)
     -> (encoding : Optional String)
     -> JSIO ()
-  readAsText' a b c = primJS $ FileReader.prim__readAsText a (up b) (toFFI c)
-
+  readAsText' a b c = primJS $ FileReader.prim__readAsText a (cast b) (toFFI c)
+  
   export
   readAsText :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReader)
     -> (blob : t2)
     -> JSIO ()
-  readAsText a b = primJS $ FileReader.prim__readAsText a (up b) undef
+  readAsText a b = primJS $ FileReader.prim__readAsText a (cast b) undef
 
 
 
 namespace FileReaderSync
-
+  
   export
   new : JSIO FileReaderSync
   new = primJS $ FileReaderSync.prim__new
 
-
+  
   export
   readAsArrayBuffer :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReaderSync)
     -> (blob : t2)
     -> JSIO ArrayBuffer
   readAsArrayBuffer a b = primJS $
-    FileReaderSync.prim__readAsArrayBuffer a (up b)
+    FileReaderSync.prim__readAsArrayBuffer a (cast b)
 
-
+  
   export
   readAsBinaryString :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReaderSync)
     -> (blob : t2)
     -> JSIO String
   readAsBinaryString a b = primJS $
-    FileReaderSync.prim__readAsBinaryString a (up b)
+    FileReaderSync.prim__readAsBinaryString a (cast b)
 
-
+  
   export
   readAsDataURL :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReaderSync)
     -> (blob : t2)
     -> JSIO String
-  readAsDataURL a b = primJS $ FileReaderSync.prim__readAsDataURL a (up b)
+  readAsDataURL a b = primJS $ FileReaderSync.prim__readAsDataURL a (cast b)
 
-
+  
   export
   readAsText' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReaderSync)
     -> (blob : t2)
     -> (encoding : Optional String)
     -> JSIO String
   readAsText' a b c = primJS $
-    FileReaderSync.prim__readAsText a (up b) (toFFI c)
-
+    FileReaderSync.prim__readAsText a (cast b) (toFFI c)
+  
   export
   readAsText :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : FileReaderSync)
     -> (blob : t2)
     -> JSIO String
-  readAsText a b = primJS $ FileReaderSync.prim__readAsText a (up b) undef
+  readAsText a b = primJS $ FileReaderSync.prim__readAsText a (cast b) undef
 
 
 
@@ -396,36 +363,34 @@ namespace FileReaderSync
 --------------------------------------------------------------------------------
 
 namespace BlobPropertyBag
-
+  
   export
   new' :
        (type : Optional String)
     -> (endings : Optional EndingType)
     -> JSIO BlobPropertyBag
   new' a b = primJS $ BlobPropertyBag.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO BlobPropertyBag
   new = primJS $ BlobPropertyBag.prim__new undef undef
 
-
+  
   export
   endings :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BlobPropertyBag (Types t)}
+       {auto _ : Cast t BlobPropertyBag}
     -> t
     -> Attribute False Optional EndingType
   endings v = fromUndefOrPrimNoDefault
                 "BlobPropertyBag.getendings"
                 prim__endings
                 prim__setEndings
-                (v :> BlobPropertyBag)
+                (cast {to = BlobPropertyBag} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem BlobPropertyBag (Types t)}
+       {auto _ : Cast t BlobPropertyBag}
     -> t
     -> Attribute True Optional String
   type v = fromUndefOrPrim
@@ -433,29 +398,31 @@ namespace BlobPropertyBag
              prim__type
              prim__setType
              ""
-             (v :> BlobPropertyBag)
+             (cast {to = BlobPropertyBag} v)
 
 
 
 namespace FilePropertyBag
-
+  
   export
   new' : (lastModified : Optional JSInt64) -> JSIO FilePropertyBag
   new' a = primJS $ FilePropertyBag.prim__new (toFFI a)
-
+  
   export
   new : JSIO FilePropertyBag
   new = primJS $ FilePropertyBag.prim__new undef
 
-
+  
   export
   lastModified :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FilePropertyBag (Types t)}
+       {auto _ : Cast t FilePropertyBag}
     -> t
     -> Attribute False Optional JSInt64
   lastModified v = fromUndefOrPrimNoDefault
                      "FilePropertyBag.getlastModified"
                      prim__lastModified
                      prim__setLastModified
-                     (v :> FilePropertyBag)
+                     (cast {to = FilePropertyBag} v)
+
+
+

--- a/src/Web/Raw/Geometry.idr
+++ b/src/Web/Raw/Geometry.idr
@@ -12,63 +12,60 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace DOMMatrix
-
+  
   export
   fromFloat32Array : (array32 : Float32Array) -> JSIO DOMMatrix
   fromFloat32Array a = primJS $ DOMMatrix.prim__fromFloat32Array a
 
-
+  
   export
   fromFloat64Array : (array64 : Float64Array) -> JSIO DOMMatrix
   fromFloat64Array a = primJS $ DOMMatrix.prim__fromFloat64Array a
 
-
+  
   export
   fromMatrix' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t1)}
+       {auto _ : Cast t1 DOMMatrixInit}
     -> (other : Optional t1)
     -> JSIO DOMMatrix
   fromMatrix' a = primJS $ DOMMatrix.prim__fromMatrix (optUp a)
-
+  
   export
   fromMatrix : JSIO DOMMatrix
   fromMatrix = primJS $ DOMMatrix.prim__fromMatrix undef
 
-
+  
   export
   invertSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   invertSelf a = primJS $ DOMMatrix.prim__invertSelf a
 
-
+  
   export
   multiplySelf' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrixInit}
     -> (obj : DOMMatrix)
     -> (other : Optional t2)
     -> JSIO DOMMatrix
   multiplySelf' a b = primJS $ DOMMatrix.prim__multiplySelf a (optUp b)
-
+  
   export
   multiplySelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   multiplySelf a = primJS $ DOMMatrix.prim__multiplySelf a undef
 
-
+  
   export
   preMultiplySelf' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrixInit}
     -> (obj : DOMMatrix)
     -> (other : Optional t2)
     -> JSIO DOMMatrix
   preMultiplySelf' a b = primJS $ DOMMatrix.prim__preMultiplySelf a (optUp b)
-
+  
   export
   preMultiplySelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   preMultiplySelf a = primJS $ DOMMatrix.prim__preMultiplySelf a undef
 
-
+  
   export
   rotateAxisAngleSelf' :
        (obj : DOMMatrix)
@@ -84,13 +81,13 @@ namespace DOMMatrix
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   rotateAxisAngleSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   rotateAxisAngleSelf a = primJS $
     DOMMatrix.prim__rotateAxisAngleSelf a undef undef undef undef
 
-
+  
   export
   rotateFromVectorSelf' :
        (obj : DOMMatrix)
@@ -99,13 +96,13 @@ namespace DOMMatrix
     -> JSIO DOMMatrix
   rotateFromVectorSelf' a b c = primJS $
     DOMMatrix.prim__rotateFromVectorSelf a (toFFI b) (toFFI c)
-
+  
   export
   rotateFromVectorSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   rotateFromVectorSelf a = primJS $
     DOMMatrix.prim__rotateFromVectorSelf a undef undef
 
-
+  
   export
   rotateSelf' :
        (obj : DOMMatrix)
@@ -115,12 +112,12 @@ namespace DOMMatrix
     -> JSIO DOMMatrix
   rotateSelf' a b c d = primJS $
     DOMMatrix.prim__rotateSelf a (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   rotateSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   rotateSelf a = primJS $ DOMMatrix.prim__rotateSelf a undef undef undef
 
-
+  
   export
   scale3dSelf' :
        (obj : DOMMatrix)
@@ -131,12 +128,12 @@ namespace DOMMatrix
     -> JSIO DOMMatrix
   scale3dSelf' a b c d e = primJS $
     DOMMatrix.prim__scale3dSelf a (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   scale3dSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   scale3dSelf a = primJS $ DOMMatrix.prim__scale3dSelf a undef undef undef undef
 
-
+  
   export
   scaleSelf' :
        (obj : DOMMatrix)
@@ -156,13 +153,13 @@ namespace DOMMatrix
       (toFFI e)
       (toFFI f)
       (toFFI g)
-
+  
   export
   scaleSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   scaleSelf a = primJS $
     DOMMatrix.prim__scaleSelf a undef undef undef undef undef undef
 
-
+  
   export
   setMatrixValue :
        (obj : DOMMatrix)
@@ -170,25 +167,25 @@ namespace DOMMatrix
     -> JSIO DOMMatrix
   setMatrixValue a b = primJS $ DOMMatrix.prim__setMatrixValue a b
 
-
+  
   export
   skewXSelf' : (obj : DOMMatrix) -> (sx : Optional Double) -> JSIO DOMMatrix
   skewXSelf' a b = primJS $ DOMMatrix.prim__skewXSelf a (toFFI b)
-
+  
   export
   skewXSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   skewXSelf a = primJS $ DOMMatrix.prim__skewXSelf a undef
 
-
+  
   export
   skewYSelf' : (obj : DOMMatrix) -> (sy : Optional Double) -> JSIO DOMMatrix
   skewYSelf' a b = primJS $ DOMMatrix.prim__skewYSelf a (toFFI b)
-
+  
   export
   skewYSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   skewYSelf a = primJS $ DOMMatrix.prim__skewYSelf a undef
 
-
+  
   export
   translateSelf' :
        (obj : DOMMatrix)
@@ -198,7 +195,7 @@ namespace DOMMatrix
     -> JSIO DOMMatrix
   translateSelf' a b c d = primJS $
     DOMMatrix.prim__translateSelf a (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   translateSelf : (obj : DOMMatrix) -> JSIO DOMMatrix
   translateSelf a = primJS $ DOMMatrix.prim__translateSelf a undef undef undef
@@ -206,298 +203,186 @@ namespace DOMMatrix
 
 
 namespace DOMMatrixReadOnly
-
+  
   export
   fromFloat32Array : (array32 : Float32Array) -> JSIO DOMMatrixReadOnly
   fromFloat32Array a = primJS $ DOMMatrixReadOnly.prim__fromFloat32Array a
 
-
+  
   export
   fromFloat64Array : (array64 : Float64Array) -> JSIO DOMMatrixReadOnly
   fromFloat64Array a = primJS $ DOMMatrixReadOnly.prim__fromFloat64Array a
 
-
+  
   export
   fromMatrix' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t1)}
+       {auto _ : Cast t1 DOMMatrixInit}
     -> (other : Optional t1)
     -> JSIO DOMMatrixReadOnly
   fromMatrix' a = primJS $ DOMMatrixReadOnly.prim__fromMatrix (optUp a)
-
+  
   export
   fromMatrix : JSIO DOMMatrixReadOnly
   fromMatrix = primJS $ DOMMatrixReadOnly.prim__fromMatrix undef
 
-
+  
   export
-  a :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  a b = primJS $ DOMMatrixReadOnly.prim__a (up b)
+  a : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  a b = primJS $ DOMMatrixReadOnly.prim__a (cast b)
 
-
+  
   export
-  b :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  b a = primJS $ DOMMatrixReadOnly.prim__b (up a)
+  b : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  b a = primJS $ DOMMatrixReadOnly.prim__b (cast a)
 
-
+  
   export
-  c :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  c a = primJS $ DOMMatrixReadOnly.prim__c (up a)
+  c : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  c a = primJS $ DOMMatrixReadOnly.prim__c (cast a)
 
-
+  
   export
-  d :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  d a = primJS $ DOMMatrixReadOnly.prim__d (up a)
+  d : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  d a = primJS $ DOMMatrixReadOnly.prim__d (cast a)
 
-
+  
   export
-  e :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  e a = primJS $ DOMMatrixReadOnly.prim__e (up a)
+  e : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  e a = primJS $ DOMMatrixReadOnly.prim__e (cast a)
 
-
+  
   export
-  f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  f a = primJS $ DOMMatrixReadOnly.prim__f (up a)
+  f : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  f a = primJS $ DOMMatrixReadOnly.prim__f (cast a)
 
-
+  
   export
-  is2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  is2D a = tryJS "DOMMatrixReadOnly.is2D" $ DOMMatrixReadOnly.prim__is2D (up a)
+  is2D : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Bool
+  is2D a = tryJS "DOMMatrixReadOnly.is2D" $
+    DOMMatrixReadOnly.prim__is2D (cast a)
 
-
+  
   export
-  isIdentity :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  isIdentity : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Bool
   isIdentity a = tryJS "DOMMatrixReadOnly.isIdentity" $
-    DOMMatrixReadOnly.prim__isIdentity (up a)
+    DOMMatrixReadOnly.prim__isIdentity (cast a)
 
-
+  
   export
-  m11 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m11 a = primJS $ DOMMatrixReadOnly.prim__m11 (up a)
+  m11 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m11 a = primJS $ DOMMatrixReadOnly.prim__m11 (cast a)
 
-
+  
   export
-  m12 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m12 a = primJS $ DOMMatrixReadOnly.prim__m12 (up a)
+  m12 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m12 a = primJS $ DOMMatrixReadOnly.prim__m12 (cast a)
 
-
+  
   export
-  m13 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m13 a = primJS $ DOMMatrixReadOnly.prim__m13 (up a)
+  m13 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m13 a = primJS $ DOMMatrixReadOnly.prim__m13 (cast a)
 
-
+  
   export
-  m14 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m14 a = primJS $ DOMMatrixReadOnly.prim__m14 (up a)
+  m14 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m14 a = primJS $ DOMMatrixReadOnly.prim__m14 (cast a)
 
-
+  
   export
-  m21 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m21 a = primJS $ DOMMatrixReadOnly.prim__m21 (up a)
+  m21 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m21 a = primJS $ DOMMatrixReadOnly.prim__m21 (cast a)
 
-
+  
   export
-  m22 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m22 a = primJS $ DOMMatrixReadOnly.prim__m22 (up a)
+  m22 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m22 a = primJS $ DOMMatrixReadOnly.prim__m22 (cast a)
 
-
+  
   export
-  m23 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m23 a = primJS $ DOMMatrixReadOnly.prim__m23 (up a)
+  m23 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m23 a = primJS $ DOMMatrixReadOnly.prim__m23 (cast a)
 
-
+  
   export
-  m24 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m24 a = primJS $ DOMMatrixReadOnly.prim__m24 (up a)
+  m24 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m24 a = primJS $ DOMMatrixReadOnly.prim__m24 (cast a)
 
-
+  
   export
-  m31 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m31 a = primJS $ DOMMatrixReadOnly.prim__m31 (up a)
+  m31 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m31 a = primJS $ DOMMatrixReadOnly.prim__m31 (cast a)
 
-
+  
   export
-  m32 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m32 a = primJS $ DOMMatrixReadOnly.prim__m32 (up a)
+  m32 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m32 a = primJS $ DOMMatrixReadOnly.prim__m32 (cast a)
 
-
+  
   export
-  m33 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m33 a = primJS $ DOMMatrixReadOnly.prim__m33 (up a)
+  m33 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m33 a = primJS $ DOMMatrixReadOnly.prim__m33 (cast a)
 
-
+  
   export
-  m34 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m34 a = primJS $ DOMMatrixReadOnly.prim__m34 (up a)
+  m34 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m34 a = primJS $ DOMMatrixReadOnly.prim__m34 (cast a)
 
-
+  
   export
-  m41 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m41 a = primJS $ DOMMatrixReadOnly.prim__m41 (up a)
+  m41 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m41 a = primJS $ DOMMatrixReadOnly.prim__m41 (cast a)
 
-
+  
   export
-  m42 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m42 a = primJS $ DOMMatrixReadOnly.prim__m42 (up a)
+  m42 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m42 a = primJS $ DOMMatrixReadOnly.prim__m42 (cast a)
 
-
+  
   export
-  m43 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m43 a = primJS $ DOMMatrixReadOnly.prim__m43 (up a)
+  m43 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m43 a = primJS $ DOMMatrixReadOnly.prim__m43 (cast a)
 
-
+  
   export
-  m44 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  m44 a = primJS $ DOMMatrixReadOnly.prim__m44 (up a)
+  m44 : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Double
+  m44 a = primJS $ DOMMatrixReadOnly.prim__m44 (cast a)
 
-
+  
   export
-  flipX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  flipX a = primJS $ DOMMatrixReadOnly.prim__flipX (up a)
+  flipX : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  flipX a = primJS $ DOMMatrixReadOnly.prim__flipX (cast a)
 
-
+  
   export
-  flipY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  flipY a = primJS $ DOMMatrixReadOnly.prim__flipY (up a)
+  flipY : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  flipY a = primJS $ DOMMatrixReadOnly.prim__flipY (cast a)
 
-
+  
   export
-  inverse :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  inverse a = primJS $ DOMMatrixReadOnly.prim__inverse (up a)
+  inverse : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  inverse a = primJS $ DOMMatrixReadOnly.prim__inverse (cast a)
 
-
+  
   export
   multiply' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t2)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
+    -> {auto _ : Cast t2 DOMMatrixInit}
     -> (obj : t1)
     -> (other : Optional t2)
     -> JSIO DOMMatrix
-  multiply' a b = primJS $ DOMMatrixReadOnly.prim__multiply (up a) (optUp b)
-
+  multiply' a b = primJS $ DOMMatrixReadOnly.prim__multiply (cast a) (optUp b)
+  
   export
   multiply :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMMatrix
-  multiply a = primJS $ DOMMatrixReadOnly.prim__multiply (up a) undef
+  multiply a = primJS $ DOMMatrixReadOnly.prim__multiply (cast a) undef
 
-
+  
   export
   rotateAxisAngle' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (x : Optional Double)
     -> (y : Optional Double)
@@ -506,68 +391,59 @@ namespace DOMMatrixReadOnly
     -> JSIO DOMMatrix
   rotateAxisAngle' a b c d e = primJS $
     DOMMatrixReadOnly.prim__rotateAxisAngle
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   rotateAxisAngle :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMMatrix
   rotateAxisAngle a = primJS $
-    DOMMatrixReadOnly.prim__rotateAxisAngle (up a) undef undef undef undef
+    DOMMatrixReadOnly.prim__rotateAxisAngle (cast a) undef undef undef undef
 
-
+  
   export
   rotate' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (rotX : Optional Double)
     -> (rotY : Optional Double)
     -> (rotZ : Optional Double)
     -> JSIO DOMMatrix
   rotate' a b c d = primJS $
-    DOMMatrixReadOnly.prim__rotate (up a) (toFFI b) (toFFI c) (toFFI d)
-
+    DOMMatrixReadOnly.prim__rotate (cast a) (toFFI b) (toFFI c) (toFFI d)
+  
   export
-  rotate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  rotate a = primJS $ DOMMatrixReadOnly.prim__rotate (up a) undef undef undef
+  rotate : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  rotate a = primJS $ DOMMatrixReadOnly.prim__rotate (cast a) undef undef undef
 
-
+  
   export
   rotateFromVector' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (x : Optional Double)
     -> (y : Optional Double)
     -> JSIO DOMMatrix
   rotateFromVector' a b c = primJS $
-    DOMMatrixReadOnly.prim__rotateFromVector (up a) (toFFI b) (toFFI c)
-
+    DOMMatrixReadOnly.prim__rotateFromVector (cast a) (toFFI b) (toFFI c)
+  
   export
   rotateFromVector :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMMatrix
   rotateFromVector a = primJS $
-    DOMMatrixReadOnly.prim__rotateFromVector (up a) undef undef
+    DOMMatrixReadOnly.prim__rotateFromVector (cast a) undef undef
 
-
+  
   export
   scale3d' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (scale : Optional Double)
     -> (originX : Optional Double)
@@ -576,26 +452,21 @@ namespace DOMMatrixReadOnly
     -> JSIO DOMMatrix
   scale3d' a b c d e = primJS $
     DOMMatrixReadOnly.prim__scale3d
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
-  scale3d :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
+  scale3d : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
   scale3d a = primJS $
-    DOMMatrixReadOnly.prim__scale3d (up a) undef undef undef undef
+    DOMMatrixReadOnly.prim__scale3d (cast a) undef undef undef undef
 
-
+  
   export
   scale' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (scaleX : Optional Double)
     -> (scaleY : Optional Double)
@@ -606,172 +477,140 @@ namespace DOMMatrixReadOnly
     -> JSIO DOMMatrix
   scale' a b c d e f g = primJS $
     DOMMatrixReadOnly.prim__scale
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
       (toFFI g)
-
+  
   export
-  scale :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
+  scale : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
   scale a = primJS $
-    DOMMatrixReadOnly.prim__scale (up a) undef undef undef undef undef undef
+    DOMMatrixReadOnly.prim__scale (cast a) undef undef undef undef undef undef
 
-
+  
   export
   scaleNonUniform' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (scaleX : Optional Double)
     -> (scaleY : Optional Double)
     -> JSIO DOMMatrix
   scaleNonUniform' a b c = primJS $
-    DOMMatrixReadOnly.prim__scaleNonUniform (up a) (toFFI b) (toFFI c)
-
+    DOMMatrixReadOnly.prim__scaleNonUniform (cast a) (toFFI b) (toFFI c)
+  
   export
   scaleNonUniform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMMatrix
   scaleNonUniform a = primJS $
-    DOMMatrixReadOnly.prim__scaleNonUniform (up a) undef undef
+    DOMMatrixReadOnly.prim__scaleNonUniform (cast a) undef undef
 
-
+  
   export
   skewX' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (sx : Optional Double)
     -> JSIO DOMMatrix
-  skewX' a b = primJS $ DOMMatrixReadOnly.prim__skewX (up a) (toFFI b)
-
+  skewX' a b = primJS $ DOMMatrixReadOnly.prim__skewX (cast a) (toFFI b)
+  
   export
-  skewX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  skewX a = primJS $ DOMMatrixReadOnly.prim__skewX (up a) undef
+  skewX : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  skewX a = primJS $ DOMMatrixReadOnly.prim__skewX (cast a) undef
 
-
+  
   export
   skewY' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (sy : Optional Double)
     -> JSIO DOMMatrix
-  skewY' a b = primJS $ DOMMatrixReadOnly.prim__skewY (up a) (toFFI b)
-
+  skewY' a b = primJS $ DOMMatrixReadOnly.prim__skewY (cast a) (toFFI b)
+  
   export
-  skewY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMMatrix
-  skewY a = primJS $ DOMMatrixReadOnly.prim__skewY (up a) undef
+  skewY : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO DOMMatrix
+  skewY a = primJS $ DOMMatrixReadOnly.prim__skewY (cast a) undef
 
-
+  
   export
   toFloat32Array :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO Float32Array
-  toFloat32Array a = primJS $ DOMMatrixReadOnly.prim__toFloat32Array (up a)
+  toFloat32Array a = primJS $ DOMMatrixReadOnly.prim__toFloat32Array (cast a)
 
-
+  
   export
   toFloat64Array :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO Float64Array
-  toFloat64Array a = primJS $ DOMMatrixReadOnly.prim__toFloat64Array (up a)
+  toFloat64Array a = primJS $ DOMMatrixReadOnly.prim__toFloat64Array (cast a)
 
-
+  
   export
-  toJSON :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Object
-  toJSON a = primJS $ DOMMatrixReadOnly.prim__toJSON (up a)
+  toJSON : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO Object
+  toJSON a = primJS $ DOMMatrixReadOnly.prim__toJSON (cast a)
 
-
+  
   export
-  toString :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  toString a = primJS $ DOMMatrixReadOnly.prim__toString (up a)
+  toString : {auto _ : Cast t1 DOMMatrixReadOnly} -> (obj : t1) -> JSIO String
+  toString a = primJS $ DOMMatrixReadOnly.prim__toString (cast a)
 
-
+  
   export
   transformPoint' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
+    -> {auto _ : Cast t2 DOMPointInit}
     -> (obj : t1)
     -> (point : Optional t2)
     -> JSIO DOMPoint
   transformPoint' a b = primJS $
-    DOMMatrixReadOnly.prim__transformPoint (up a) (optUp b)
-
+    DOMMatrixReadOnly.prim__transformPoint (cast a) (optUp b)
+  
   export
   transformPoint :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMPoint
   transformPoint a = primJS $
-    DOMMatrixReadOnly.prim__transformPoint (up a) undef
+    DOMMatrixReadOnly.prim__transformPoint (cast a) undef
 
-
+  
   export
   translate' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> (tx : Optional Double)
     -> (ty : Optional Double)
     -> (tz : Optional Double)
     -> JSIO DOMMatrix
   translate' a b c d = primJS $
-    DOMMatrixReadOnly.prim__translate (up a) (toFFI b) (toFFI c) (toFFI d)
-
+    DOMMatrixReadOnly.prim__translate (cast a) (toFFI b) (toFFI c) (toFFI d)
+  
   export
   translate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMMatrixReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMMatrixReadOnly}
     -> (obj : t1)
     -> JSIO DOMMatrix
   translate a = primJS $
-    DOMMatrixReadOnly.prim__translate (up a) undef undef undef
+    DOMMatrixReadOnly.prim__translate (cast a) undef undef undef
 
 
 
 namespace DOMPoint
-
+  
   export
   fromPoint' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointInit (Types t1)}
+       {auto _ : Cast t1 DOMPointInit}
     -> (other : Optional t1)
     -> JSIO DOMPoint
   fromPoint' a = primJS $ DOMPoint.prim__fromPoint (optUp a)
-
+  
   export
   fromPoint : JSIO DOMPoint
   fromPoint = primJS $ DOMPoint.prim__fromPoint undef
@@ -779,141 +618,115 @@ namespace DOMPoint
 
 
 namespace DOMPointReadOnly
-
+  
   export
   fromPoint' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointInit (Types t1)}
+       {auto _ : Cast t1 DOMPointInit}
     -> (other : Optional t1)
     -> JSIO DOMPointReadOnly
   fromPoint' a = primJS $ DOMPointReadOnly.prim__fromPoint (optUp a)
-
+  
   export
   fromPoint : JSIO DOMPointReadOnly
   fromPoint = primJS $ DOMPointReadOnly.prim__fromPoint undef
 
-
+  
   export
-  w :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  w a = primJS $ DOMPointReadOnly.prim__w (up a)
+  w : {auto _ : Cast t1 DOMPointReadOnly} -> (obj : t1) -> JSIO Double
+  w a = primJS $ DOMPointReadOnly.prim__w (cast a)
 
-
+  
   export
-  x :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  x a = primJS $ DOMPointReadOnly.prim__x (up a)
+  x : {auto _ : Cast t1 DOMPointReadOnly} -> (obj : t1) -> JSIO Double
+  x a = primJS $ DOMPointReadOnly.prim__x (cast a)
 
-
+  
   export
-  y :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  y a = primJS $ DOMPointReadOnly.prim__y (up a)
+  y : {auto _ : Cast t1 DOMPointReadOnly} -> (obj : t1) -> JSIO Double
+  y a = primJS $ DOMPointReadOnly.prim__y (cast a)
 
-
+  
   export
-  z :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  z a = primJS $ DOMPointReadOnly.prim__z (up a)
+  z : {auto _ : Cast t1 DOMPointReadOnly} -> (obj : t1) -> JSIO Double
+  z a = primJS $ DOMPointReadOnly.prim__z (cast a)
 
-
+  
   export
   matrixTransform' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t2)}
+       {auto _ : Cast t1 DOMPointReadOnly}
+    -> {auto _ : Cast t2 DOMMatrixInit}
     -> (obj : t1)
     -> (matrix : Optional t2)
     -> JSIO DOMPoint
   matrixTransform' a b = primJS $
-    DOMPointReadOnly.prim__matrixTransform (up a) (optUp b)
-
+    DOMPointReadOnly.prim__matrixTransform (cast a) (optUp b)
+  
   export
   matrixTransform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
+       {auto _ : Cast t1 DOMPointReadOnly}
     -> (obj : t1)
     -> JSIO DOMPoint
   matrixTransform a = primJS $
-    DOMPointReadOnly.prim__matrixTransform (up a) undef
+    DOMPointReadOnly.prim__matrixTransform (cast a) undef
 
-
+  
   export
-  toJSON :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMPointReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Object
-  toJSON a = primJS $ DOMPointReadOnly.prim__toJSON (up a)
+  toJSON : {auto _ : Cast t1 DOMPointReadOnly} -> (obj : t1) -> JSIO Object
+  toJSON a = primJS $ DOMPointReadOnly.prim__toJSON (cast a)
 
 
 
 namespace DOMQuad
-
+  
   export
   fromQuad' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t1)}
+       {auto _ : Cast t1 DOMQuadInit}
     -> (other : Optional t1)
     -> JSIO DOMQuad
   fromQuad' a = primJS $ DOMQuad.prim__fromQuad (optUp a)
-
+  
   export
   fromQuad : JSIO DOMQuad
   fromQuad = primJS $ DOMQuad.prim__fromQuad undef
 
-
+  
   export
   fromRect' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectInit (Types t1)}
+       {auto _ : Cast t1 DOMRectInit}
     -> (other : Optional t1)
     -> JSIO DOMQuad
   fromRect' a = primJS $ DOMQuad.prim__fromRect (optUp a)
-
+  
   export
   fromRect : JSIO DOMQuad
   fromRect = primJS $ DOMQuad.prim__fromRect undef
 
-
+  
   export
   p1 : (obj : DOMQuad) -> JSIO DOMPoint
   p1 a = primJS $ DOMQuad.prim__p1 a
 
-
+  
   export
   p2 : (obj : DOMQuad) -> JSIO DOMPoint
   p2 a = primJS $ DOMQuad.prim__p2 a
 
-
+  
   export
   p3 : (obj : DOMQuad) -> JSIO DOMPoint
   p3 a = primJS $ DOMQuad.prim__p3 a
 
-
+  
   export
   p4 : (obj : DOMQuad) -> JSIO DOMPoint
   p4 a = primJS $ DOMQuad.prim__p4 a
 
-
+  
   export
   getBounds : (obj : DOMQuad) -> JSIO DOMRect
   getBounds a = primJS $ DOMQuad.prim__getBounds a
 
-
+  
   export
   toJSON : (obj : DOMQuad) -> JSIO Object
   toJSON a = primJS $ DOMQuad.prim__toJSON a
@@ -921,15 +734,14 @@ namespace DOMQuad
 
 
 namespace DOMRect
-
+  
   export
   fromRect' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectInit (Types t1)}
+       {auto _ : Cast t1 DOMRectInit}
     -> (other : Optional t1)
     -> JSIO DOMRect
   fromRect' a = primJS $ DOMRect.prim__fromRect (optUp a)
-
+  
   export
   fromRect : JSIO DOMRect
   fromRect = primJS $ DOMRect.prim__fromRect undef
@@ -937,12 +749,12 @@ namespace DOMRect
 
 
 namespace DOMRectList
-
+  
   export
   length : (obj : DOMRectList) -> JSIO Bits32
   length a = primJS $ DOMRectList.prim__length a
 
-
+  
   export
   item : (obj : DOMRectList) -> (index : Bits32) -> JSIO (Maybe DOMRect)
   item a b = tryJS "DOMRectList.item" $ DOMRectList.prim__item a b
@@ -950,99 +762,62 @@ namespace DOMRectList
 
 
 namespace DOMRectReadOnly
-
+  
   export
   fromRect' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectInit (Types t1)}
+       {auto _ : Cast t1 DOMRectInit}
     -> (other : Optional t1)
     -> JSIO DOMRectReadOnly
   fromRect' a = primJS $ DOMRectReadOnly.prim__fromRect (optUp a)
-
+  
   export
   fromRect : JSIO DOMRectReadOnly
   fromRect = primJS $ DOMRectReadOnly.prim__fromRect undef
 
-
+  
   export
-  bottom :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  bottom a = primJS $ DOMRectReadOnly.prim__bottom (up a)
+  bottom : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  bottom a = primJS $ DOMRectReadOnly.prim__bottom (cast a)
 
-
+  
   export
-  height :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  height a = primJS $ DOMRectReadOnly.prim__height (up a)
+  height : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  height a = primJS $ DOMRectReadOnly.prim__height (cast a)
 
-
+  
   export
-  left :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  left a = primJS $ DOMRectReadOnly.prim__left (up a)
+  left : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  left a = primJS $ DOMRectReadOnly.prim__left (cast a)
 
-
+  
   export
-  right :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  right a = primJS $ DOMRectReadOnly.prim__right (up a)
+  right : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  right a = primJS $ DOMRectReadOnly.prim__right (cast a)
 
-
+  
   export
-  top :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  top a = primJS $ DOMRectReadOnly.prim__top (up a)
+  top : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  top a = primJS $ DOMRectReadOnly.prim__top (cast a)
 
-
+  
   export
-  width :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  width a = primJS $ DOMRectReadOnly.prim__width (up a)
+  width : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  width a = primJS $ DOMRectReadOnly.prim__width (cast a)
 
-
+  
   export
-  x :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  x a = primJS $ DOMRectReadOnly.prim__x (up a)
+  x : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  x a = primJS $ DOMRectReadOnly.prim__x (cast a)
 
-
+  
   export
-  y :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  y a = primJS $ DOMRectReadOnly.prim__y (up a)
+  y : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Double
+  y a = primJS $ DOMRectReadOnly.prim__y (cast a)
 
-
+  
   export
-  toJSON :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t1)}
-    -> (obj : t1)
-    -> JSIO Object
-  toJSON a = primJS $ DOMRectReadOnly.prim__toJSON (up a)
+  toJSON : {auto _ : Cast t1 DOMRectReadOnly} -> (obj : t1) -> JSIO Object
+  toJSON a = primJS $ DOMRectReadOnly.prim__toJSON (cast a)
 
 
 
@@ -1053,7 +828,7 @@ namespace DOMRectReadOnly
 --------------------------------------------------------------------------------
 
 namespace DOMMatrix2DInit
-
+  
   export
   new' :
        (a : Optional Double)
@@ -1083,7 +858,7 @@ namespace DOMMatrix2DInit
       (toFFI j)
       (toFFI k)
       (toFFI l)
-
+  
   export
   new : JSIO DOMMatrix2DInit
   new = primJS $
@@ -1101,166 +876,136 @@ namespace DOMMatrix2DInit
       undef
       undef
 
-
+  
   export
-  a :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  a : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   a v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.geta"
           prim__a
           prim__setA
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
-  b :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  b : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   b v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.getb"
           prim__b
           prim__setB
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
-  c :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  c : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   c v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.getc"
           prim__c
           prim__setC
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
-  d :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  d : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   d v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.getd"
           prim__d
           prim__setD
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
-  e :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  e : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   e v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.gete"
           prim__e
           prim__setE
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
-  f :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  f : {auto _ : Cast t DOMMatrix2DInit} -> t -> Attribute False Optional Double
   f v = fromUndefOrPrimNoDefault
           "DOMMatrix2DInit.getf"
           prim__f
           prim__setF
-          (v :> DOMMatrix2DInit)
+          (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m11 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m11 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm11"
             prim__m11
             prim__setM11
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m12 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m12 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm12"
             prim__m12
             prim__setM12
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m21 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m21 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm21"
             prim__m21
             prim__setM21
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m22 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m22 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm22"
             prim__m22
             prim__setM22
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m41 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m41 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm41"
             prim__m41
             prim__setM41
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
-
+  
   export
   m42 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t)}
+       {auto _ : Cast t DOMMatrix2DInit}
     -> t
     -> Attribute False Optional Double
   m42 v = fromUndefOrPrimNoDefault
             "DOMMatrix2DInit.getm42"
             prim__m42
             prim__setM42
-            (v :> DOMMatrix2DInit)
+            (cast {to = DOMMatrix2DInit} v)
 
 
 
 namespace DOMMatrixInit
-
+  
   export
   new' :
        (m13 : Optional Double)
@@ -1288,7 +1033,7 @@ namespace DOMMatrixInit
       (toFFI i)
       (toFFI j)
       (toFFI k)
-
+  
   export
   new : JSIO DOMMatrixInit
   new = primJS $
@@ -1305,163 +1050,119 @@ namespace DOMMatrixInit
       undef
       undef
 
-
+  
   export
-  is2D :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute False Optional Bool
+  is2D : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute False Optional Bool
   is2D v = fromUndefOrPrimNoDefault
              "DOMMatrixInit.getis2D"
              prim__is2D
              prim__setIs2D
-             (v :> DOMMatrixInit)
+             (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m13 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m13 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m13 v = fromUndefOrPrim
             "DOMMatrixInit.getm13"
             prim__m13
             prim__setM13
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m14 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m14 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m14 v = fromUndefOrPrim
             "DOMMatrixInit.getm14"
             prim__m14
             prim__setM14
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m23 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m23 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m23 v = fromUndefOrPrim
             "DOMMatrixInit.getm23"
             prim__m23
             prim__setM23
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m24 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m24 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m24 v = fromUndefOrPrim
             "DOMMatrixInit.getm24"
             prim__m24
             prim__setM24
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m31 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m31 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m31 v = fromUndefOrPrim
             "DOMMatrixInit.getm31"
             prim__m31
             prim__setM31
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m32 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m32 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m32 v = fromUndefOrPrim
             "DOMMatrixInit.getm32"
             prim__m32
             prim__setM32
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m33 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m33 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m33 v = fromUndefOrPrim
             "DOMMatrixInit.getm33"
             prim__m33
             prim__setM33
             1
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m34 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m34 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m34 v = fromUndefOrPrim
             "DOMMatrixInit.getm34"
             prim__m34
             prim__setM34
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m43 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m43 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m43 v = fromUndefOrPrim
             "DOMMatrixInit.getm43"
             prim__m43
             prim__setM43
             0
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
-
+  
   export
-  m44 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMMatrixInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  m44 : {auto _ : Cast t DOMMatrixInit} -> t -> Attribute True Optional Double
   m44 v = fromUndefOrPrim
             "DOMMatrixInit.getm44"
             prim__m44
             prim__setM44
             1
-            (v :> DOMMatrixInit)
+            (cast {to = DOMMatrixInit} v)
 
 
 
 namespace DOMPointInit
-
+  
   export
   new' :
        (x : Optional Double)
@@ -1471,81 +1172,61 @@ namespace DOMPointInit
     -> JSIO DOMPointInit
   new' a b c d = primJS $
     DOMPointInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO DOMPointInit
   new = primJS $ DOMPointInit.prim__new undef undef undef undef
 
-
+  
   export
-  w :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMPointInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  w : {auto _ : Cast t DOMPointInit} -> t -> Attribute True Optional Double
   w v = fromUndefOrPrim
           "DOMPointInit.getw"
           prim__w
           prim__setW
           1
-          (v :> DOMPointInit)
+          (cast {to = DOMPointInit} v)
 
-
+  
   export
-  x :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMPointInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  x : {auto _ : Cast t DOMPointInit} -> t -> Attribute True Optional Double
   x v = fromUndefOrPrim
           "DOMPointInit.getx"
           prim__x
           prim__setX
           0
-          (v :> DOMPointInit)
+          (cast {to = DOMPointInit} v)
 
-
+  
   export
-  y :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMPointInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  y : {auto _ : Cast t DOMPointInit} -> t -> Attribute True Optional Double
   y v = fromUndefOrPrim
           "DOMPointInit.gety"
           prim__y
           prim__setY
           0
-          (v :> DOMPointInit)
+          (cast {to = DOMPointInit} v)
 
-
+  
   export
-  z :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMPointInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  z : {auto _ : Cast t DOMPointInit} -> t -> Attribute True Optional Double
   z v = fromUndefOrPrim
           "DOMPointInit.getz"
           prim__z
           prim__setZ
           0
-          (v :> DOMPointInit)
+          (cast {to = DOMPointInit} v)
 
 
 
 namespace DOMQuadInit
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem DOMPointInit (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t3)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t4)}
+       {auto _ : Cast t1 DOMPointInit}
+    -> {auto _ : Cast t2 DOMPointInit}
+    -> {auto _ : Cast t3 DOMPointInit}
+    -> {auto _ : Cast t4 DOMPointInit}
     -> (p1 : Optional t1)
     -> (p2 : Optional t2)
     -> (p3 : Optional t3)
@@ -1553,67 +1234,63 @@ namespace DOMQuadInit
     -> JSIO DOMQuadInit
   new' a b c d = primJS $
     DOMQuadInit.prim__new (optUp a) (optUp b) (optUp c) (optUp d)
-
+  
   export
   new : JSIO DOMQuadInit
   new = primJS $ DOMQuadInit.prim__new undef undef undef undef
 
-
+  
   export
   p1 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t)}
+       {auto _ : Cast t DOMQuadInit}
     -> t
     -> Attribute False Optional DOMPointInit
   p1 v = fromUndefOrPrimNoDefault
            "DOMQuadInit.getp1"
            prim__p1
            prim__setP1
-           (v :> DOMQuadInit)
+           (cast {to = DOMQuadInit} v)
 
-
+  
   export
   p2 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t)}
+       {auto _ : Cast t DOMQuadInit}
     -> t
     -> Attribute False Optional DOMPointInit
   p2 v = fromUndefOrPrimNoDefault
            "DOMQuadInit.getp2"
            prim__p2
            prim__setP2
-           (v :> DOMQuadInit)
+           (cast {to = DOMQuadInit} v)
 
-
+  
   export
   p3 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t)}
+       {auto _ : Cast t DOMQuadInit}
     -> t
     -> Attribute False Optional DOMPointInit
   p3 v = fromUndefOrPrimNoDefault
            "DOMQuadInit.getp3"
            prim__p3
            prim__setP3
-           (v :> DOMQuadInit)
+           (cast {to = DOMQuadInit} v)
 
-
+  
   export
   p4 :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMQuadInit (Types t)}
+       {auto _ : Cast t DOMQuadInit}
     -> t
     -> Attribute False Optional DOMPointInit
   p4 v = fromUndefOrPrimNoDefault
            "DOMQuadInit.getp4"
            prim__p4
            prim__setP4
-           (v :> DOMQuadInit)
+           (cast {to = DOMQuadInit} v)
 
 
 
 namespace DOMRectInit
-
+  
   export
   new' :
        (x : Optional Double)
@@ -1623,63 +1300,50 @@ namespace DOMRectInit
     -> JSIO DOMRectInit
   new' a b c d = primJS $
     DOMRectInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO DOMRectInit
   new = primJS $ DOMRectInit.prim__new undef undef undef undef
 
-
+  
   export
-  height :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMRectInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  height : {auto _ : Cast t DOMRectInit} -> t -> Attribute True Optional Double
   height v = fromUndefOrPrim
                "DOMRectInit.getheight"
                prim__height
                prim__setHeight
                0
-               (v :> DOMRectInit)
+               (cast {to = DOMRectInit} v)
 
-
+  
   export
-  width :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMRectInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  width : {auto _ : Cast t DOMRectInit} -> t -> Attribute True Optional Double
   width v = fromUndefOrPrim
               "DOMRectInit.getwidth"
               prim__width
               prim__setWidth
               0
-              (v :> DOMRectInit)
+              (cast {to = DOMRectInit} v)
 
-
+  
   export
-  x :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMRectInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  x : {auto _ : Cast t DOMRectInit} -> t -> Attribute True Optional Double
   x v = fromUndefOrPrim
           "DOMRectInit.getx"
           prim__x
           prim__setX
           0
-          (v :> DOMRectInit)
+          (cast {to = DOMRectInit} v)
 
-
+  
   export
-  y :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DOMRectInit (Types t)}
-    -> t
-    -> Attribute True Optional Double
+  y : {auto _ : Cast t DOMRectInit} -> t -> Attribute True Optional Double
   y v = fromUndefOrPrim
           "DOMRectInit.gety"
           prim__y
           prim__setY
           0
-          (v :> DOMRectInit)
+          (cast {to = DOMRectInit} v)
+
+
+

--- a/src/Web/Raw/Html.idr
+++ b/src/Web/Raw/Html.idr
@@ -12,32 +12,32 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace AudioTrack
-
+  
   export
   enabled : AudioTrack -> Attribute True Prelude.id Bool
   enabled v = fromPrim "AudioTrack.getenabled" prim__enabled prim__setEnabled v
 
-
+  
   export
   id : (obj : AudioTrack) -> JSIO String
   id a = primJS $ AudioTrack.prim__id a
 
-
+  
   export
   kind : (obj : AudioTrack) -> JSIO String
   kind a = primJS $ AudioTrack.prim__kind a
 
-
+  
   export
   label : (obj : AudioTrack) -> JSIO String
   label a = primJS $ AudioTrack.prim__label a
 
-
+  
   export
   language : (obj : AudioTrack) -> JSIO String
   language a = primJS $ AudioTrack.prim__language a
 
-
+  
   export
   sourceBuffer : (obj : AudioTrack) -> JSIO (Maybe SourceBuffer)
   sourceBuffer a = tryJS "AudioTrack.sourceBuffer" $
@@ -46,17 +46,17 @@ namespace AudioTrack
 
 
 namespace AudioTrackList
-
+  
   export
   get : (obj : AudioTrackList) -> (index : Bits32) -> JSIO AudioTrack
   get a b = primJS $ AudioTrackList.prim__get a b
 
-
+  
   export
   length : (obj : AudioTrackList) -> JSIO Bits32
   length a = primJS $ AudioTrackList.prim__length a
 
-
+  
   export
   onaddtrack : AudioTrackList -> Attribute False Maybe EventHandlerNonNull
   onaddtrack v = fromNullablePrim
@@ -65,7 +65,7 @@ namespace AudioTrackList
                    prim__setOnaddtrack
                    v
 
-
+  
   export
   onchange : AudioTrackList -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
@@ -74,7 +74,7 @@ namespace AudioTrackList
                  prim__setOnchange
                  v
 
-
+  
   export
   onremovetrack : AudioTrackList -> Attribute False Maybe EventHandlerNonNull
   onremovetrack v = fromNullablePrim
@@ -83,7 +83,7 @@ namespace AudioTrackList
                       prim__setOnremovetrack
                       v
 
-
+  
   export
   getTrackById :
        (obj : AudioTrackList)
@@ -95,7 +95,7 @@ namespace AudioTrackList
 
 
 namespace BarProp
-
+  
   export
   visible : (obj : BarProp) -> JSIO Bool
   visible a = tryJS "BarProp.visible" $ BarProp.prim__visible a
@@ -103,7 +103,7 @@ namespace BarProp
 
 
 namespace BeforeUnloadEvent
-
+  
   export
   returnValue : BeforeUnloadEvent -> Attribute True Prelude.id String
   returnValue v = fromPrim
@@ -115,17 +115,17 @@ namespace BeforeUnloadEvent
 
 
 namespace BroadcastChannel
-
+  
   export
   new : (name : String) -> JSIO BroadcastChannel
   new a = primJS $ BroadcastChannel.prim__new a
 
-
+  
   export
   name : (obj : BroadcastChannel) -> JSIO String
   name a = primJS $ BroadcastChannel.prim__name a
 
-
+  
   export
   onmessage : BroadcastChannel -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
@@ -134,7 +134,7 @@ namespace BroadcastChannel
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror : BroadcastChannel -> Attribute False Maybe EventHandlerNonNull
   onmessageerror v = fromNullablePrim
@@ -143,12 +143,12 @@ namespace BroadcastChannel
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   close : (obj : BroadcastChannel) -> JSIO ()
   close a = primJS $ BroadcastChannel.prim__close a
 
-
+  
   export
   postMessage : (obj : BroadcastChannel) -> (message : Any) -> JSIO ()
   postMessage a b = primJS $ BroadcastChannel.prim__postMessage a (toFFI b)
@@ -156,7 +156,7 @@ namespace BroadcastChannel
 
 
 namespace CanvasGradient
-
+  
   export
   addColorStop :
        (obj : CanvasGradient)
@@ -168,16 +168,15 @@ namespace CanvasGradient
 
 
 namespace CanvasPattern
-
+  
   export
   setTransform' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrix2DInit}
     -> (obj : CanvasPattern)
     -> (transform : Optional t2)
     -> JSIO ()
   setTransform' a b = primJS $ CanvasPattern.prim__setTransform a (optUp b)
-
+  
   export
   setTransform : (obj : CanvasPattern) -> JSIO ()
   setTransform a = primJS $ CanvasPattern.prim__setTransform a undef
@@ -185,12 +184,12 @@ namespace CanvasPattern
 
 
 namespace CanvasRenderingContext2D
-
+  
   export
   canvas : (obj : CanvasRenderingContext2D) -> JSIO HTMLCanvasElement
   canvas a = primJS $ CanvasRenderingContext2D.prim__canvas a
 
-
+  
   export
   getContextAttributes :
        (obj : CanvasRenderingContext2D)
@@ -201,31 +200,30 @@ namespace CanvasRenderingContext2D
 
 
 namespace CloseEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem CloseEventInit (Types t2)}
+       {auto _ : Cast t2 CloseEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO CloseEvent
   new' a b = primJS $ CloseEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO CloseEvent
   new a = primJS $ CloseEvent.prim__new a undef
 
-
+  
   export
   code : (obj : CloseEvent) -> JSIO Bits16
   code a = primJS $ CloseEvent.prim__code a
 
-
+  
   export
   reason : (obj : CloseEvent) -> JSIO String
   reason a = primJS $ CloseEvent.prim__reason a
 
-
+  
   export
   wasClean : (obj : CloseEvent) -> JSIO Bool
   wasClean a = tryJS "CloseEvent.wasClean" $ CloseEvent.prim__wasClean a
@@ -233,18 +231,17 @@ namespace CloseEvent
 
 
 namespace CustomElementRegistry
-
+  
   export
   define' :
-       {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem ElementDefinitionOptions (Types t4)}
+       {auto _ : Cast t4 ElementDefinitionOptions}
     -> (obj : CustomElementRegistry)
     -> (name : String)
     -> (constructor : CustomElementConstructor)
     -> (options : Optional t4)
     -> JSIO ()
   define' a b c d = primJS $ CustomElementRegistry.prim__define a b c (optUp d)
-
+  
   export
   define :
        (obj : CustomElementRegistry)
@@ -253,7 +250,7 @@ namespace CustomElementRegistry
     -> JSIO ()
   define a b c = primJS $ CustomElementRegistry.prim__define a b c undef
 
-
+  
   export
   get :
        (obj : CustomElementRegistry)
@@ -261,17 +258,16 @@ namespace CustomElementRegistry
     -> JSIO (Union2 CustomElementConstructor Undefined)
   get a b = primJS $ CustomElementRegistry.prim__get a b
 
-
+  
   export
   upgrade :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Node (Types t2)}
+       {auto _ : Cast t2 Node}
     -> (obj : CustomElementRegistry)
     -> (root : t2)
     -> JSIO ()
-  upgrade a b = primJS $ CustomElementRegistry.prim__upgrade a (up b)
+  upgrade a b = primJS $ CustomElementRegistry.prim__upgrade a (cast b)
 
-
+  
   export
   whenDefined :
        (obj : CustomElementRegistry)
@@ -282,12 +278,12 @@ namespace CustomElementRegistry
 
 
 namespace DOMParser
-
+  
   export
   new : JSIO DOMParser
   new = primJS $ DOMParser.prim__new
 
-
+  
   export
   parseFromString :
        (obj : DOMParser)
@@ -299,18 +295,18 @@ namespace DOMParser
 
 
 namespace DOMStringList
-
+  
   export
   length : (obj : DOMStringList) -> JSIO Bits32
   length a = primJS $ DOMStringList.prim__length a
 
-
+  
   export
   contains : (obj : DOMStringList) -> (string : String) -> JSIO Bool
   contains a b = tryJS "DOMStringList.contains" $
     DOMStringList.prim__contains a b
 
-
+  
   export
   item : (obj : DOMStringList) -> (index : Bits32) -> JSIO (Maybe String)
   item a b = tryJS "DOMStringList.item" $ DOMStringList.prim__item a b
@@ -318,12 +314,12 @@ namespace DOMStringList
 
 
 namespace DOMStringMap
-
+  
   export
   get : (obj : DOMStringMap) -> (name : String) -> JSIO String
   get a b = primJS $ DOMStringMap.prim__get a b
 
-
+  
   export
   set : (obj : DOMStringMap) -> (name : String) -> (value : String) -> JSIO ()
   set a b c = primJS $ DOMStringMap.prim__set a b c
@@ -331,12 +327,12 @@ namespace DOMStringMap
 
 
 namespace DataTransfer
-
+  
   export
   new : JSIO DataTransfer
   new = primJS $ DataTransfer.prim__new
 
-
+  
   export
   dropEffect : DataTransfer -> Attribute True Prelude.id String
   dropEffect v = fromPrim
@@ -345,7 +341,7 @@ namespace DataTransfer
                    prim__setDropEffect
                    v
 
-
+  
   export
   effectAllowed : DataTransfer -> Attribute True Prelude.id String
   effectAllowed v = fromPrim
@@ -354,36 +350,36 @@ namespace DataTransfer
                       prim__setEffectAllowed
                       v
 
-
+  
   export
   files : (obj : DataTransfer) -> JSIO FileList
   files a = primJS $ DataTransfer.prim__files a
 
-
+  
   export
   items : (obj : DataTransfer) -> JSIO DataTransferItemList
   items a = primJS $ DataTransfer.prim__items a
 
-
+  
   export
   types : (obj : DataTransfer) -> JSIO (Array String)
   types a = primJS $ DataTransfer.prim__types a
 
-
+  
   export
   clearData' : (obj : DataTransfer) -> (format : Optional String) -> JSIO ()
   clearData' a b = primJS $ DataTransfer.prim__clearData a (toFFI b)
-
+  
   export
   clearData : (obj : DataTransfer) -> JSIO ()
   clearData a = primJS $ DataTransfer.prim__clearData a undef
 
-
+  
   export
   getData : (obj : DataTransfer) -> (format : String) -> JSIO String
   getData a b = primJS $ DataTransfer.prim__getData a b
 
-
+  
   export
   setData :
        (obj : DataTransfer)
@@ -392,38 +388,37 @@ namespace DataTransfer
     -> JSIO ()
   setData a b c = primJS $ DataTransfer.prim__setData a b c
 
-
+  
   export
   setDragImage :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t2)}
+       {auto _ : Cast t2 Element}
     -> (obj : DataTransfer)
     -> (image : t2)
     -> (x : Int32)
     -> (y : Int32)
     -> JSIO ()
-  setDragImage a b c d = primJS $ DataTransfer.prim__setDragImage a (up b) c d
+  setDragImage a b c d = primJS $ DataTransfer.prim__setDragImage a (cast b) c d
 
 
 
 namespace DataTransferItem
-
+  
   export
   kind : (obj : DataTransferItem) -> JSIO String
   kind a = primJS $ DataTransferItem.prim__kind a
 
-
+  
   export
   type : (obj : DataTransferItem) -> JSIO String
   type a = primJS $ DataTransferItem.prim__type a
 
-
+  
   export
   getAsFile : (obj : DataTransferItem) -> JSIO (Maybe File)
   getAsFile a = tryJS "DataTransferItem.getAsFile" $
     DataTransferItem.prim__getAsFile a
 
-
+  
   export
   getAsString :
        (obj : DataTransferItem)
@@ -434,7 +429,7 @@ namespace DataTransferItem
 
 
 namespace DataTransferItemList
-
+  
   export
   get :
        (obj : DataTransferItemList)
@@ -442,12 +437,12 @@ namespace DataTransferItemList
     -> JSIO DataTransferItem
   get a b = primJS $ DataTransferItemList.prim__get a b
 
-
+  
   export
   length : (obj : DataTransferItemList) -> JSIO Bits32
   length a = primJS $ DataTransferItemList.prim__length a
 
-
+  
   export
   add :
        (obj : DataTransferItemList)
@@ -457,7 +452,7 @@ namespace DataTransferItemList
   add a b c = tryJS "DataTransferItemList.add" $
     DataTransferItemList.prim__add a b c
 
-
+  
   export
   add1 :
        (obj : DataTransferItemList)
@@ -466,12 +461,12 @@ namespace DataTransferItemList
   add1 a b = tryJS "DataTransferItemList.add1" $
     DataTransferItemList.prim__add1 a b
 
-
+  
   export
   clear : (obj : DataTransferItemList) -> JSIO ()
   clear a = primJS $ DataTransferItemList.prim__clear a
 
-
+  
   export
   remove : (obj : DataTransferItemList) -> (index : Bits32) -> JSIO ()
   remove a b = primJS $ DataTransferItemList.prim__remove a b
@@ -479,12 +474,12 @@ namespace DataTransferItemList
 
 
 namespace DedicatedWorkerGlobalScope
-
+  
   export
   name : (obj : DedicatedWorkerGlobalScope) -> JSIO String
   name a = primJS $ DedicatedWorkerGlobalScope.prim__name a
 
-
+  
   export
   onmessage :
        DedicatedWorkerGlobalScope
@@ -495,7 +490,7 @@ namespace DedicatedWorkerGlobalScope
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror :
        DedicatedWorkerGlobalScope
@@ -506,12 +501,12 @@ namespace DedicatedWorkerGlobalScope
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   close : (obj : DedicatedWorkerGlobalScope) -> JSIO ()
   close a = primJS $ DedicatedWorkerGlobalScope.prim__close a
 
-
+  
   export
   postMessage :
        (obj : DedicatedWorkerGlobalScope)
@@ -521,18 +516,17 @@ namespace DedicatedWorkerGlobalScope
   postMessage a b c = primJS $
     DedicatedWorkerGlobalScope.prim__postMessage a (toFFI b) c
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t3)}
+       {auto _ : Cast t3 PostMessageOptions}
     -> (obj : DedicatedWorkerGlobalScope)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $
     DedicatedWorkerGlobalScope.prim__postMessage1 a (toFFI b) (optUp c)
-
+  
   export
   postMessage1 :
        (obj : DedicatedWorkerGlobalScope)
@@ -544,21 +538,20 @@ namespace DedicatedWorkerGlobalScope
 
 
 namespace DragEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DragEventInit (Types t2)}
+       {auto _ : Cast t2 DragEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO DragEvent
   new' a b = primJS $ DragEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO DragEvent
   new a = primJS $ DragEvent.prim__new a undef
 
-
+  
   export
   dataTransfer : (obj : DragEvent) -> JSIO (Maybe DataTransfer)
   dataTransfer a = tryJS "DragEvent.dataTransfer" $
@@ -567,51 +560,51 @@ namespace DragEvent
 
 
 namespace ElementInternals
-
+  
   export
   form : (obj : ElementInternals) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "ElementInternals.form" $ ElementInternals.prim__form a
 
-
+  
   export
   labels : (obj : ElementInternals) -> JSIO NodeList
   labels a = primJS $ ElementInternals.prim__labels a
 
-
+  
   export
   shadowRoot : (obj : ElementInternals) -> JSIO (Maybe ShadowRoot)
   shadowRoot a = tryJS "ElementInternals.shadowRoot" $
     ElementInternals.prim__shadowRoot a
 
-
+  
   export
   validationMessage : (obj : ElementInternals) -> JSIO String
   validationMessage a = primJS $ ElementInternals.prim__validationMessage a
 
-
+  
   export
   validity : (obj : ElementInternals) -> JSIO ValidityState
   validity a = primJS $ ElementInternals.prim__validity a
 
-
+  
   export
   willValidate : (obj : ElementInternals) -> JSIO Bool
   willValidate a = tryJS "ElementInternals.willValidate" $
     ElementInternals.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : ElementInternals) -> JSIO Bool
   checkValidity a = tryJS "ElementInternals.checkValidity" $
     ElementInternals.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : ElementInternals) -> JSIO Bool
   reportValidity a = tryJS "ElementInternals.reportValidity" $
     ElementInternals.prim__reportValidity a
 
-
+  
   export
   setFormValue' :
        (obj : ElementInternals)
@@ -620,7 +613,7 @@ namespace ElementInternals
     -> JSIO ()
   setFormValue' a b c = primJS $
     ElementInternals.prim__setFormValue a (toFFI b) (toFFI c)
-
+  
   export
   setFormValue :
        (obj : ElementInternals)
@@ -629,13 +622,11 @@ namespace ElementInternals
   setFormValue a b = primJS $
     ElementInternals.prim__setFormValue a (toFFI b) undef
 
-
+  
   export
   setValidity' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t2)}
-    -> {auto 0 _ : Elem HTMLElement (Types t4)}
+       {auto _ : Cast t2 ValidityStateFlags}
+    -> {auto _ : Cast t4 HTMLElement}
     -> (obj : ElementInternals)
     -> (flags : Optional t2)
     -> (message : Optional String)
@@ -643,7 +634,7 @@ namespace ElementInternals
     -> JSIO ()
   setValidity' a b c d = primJS $
     ElementInternals.prim__setValidity a (optUp b) (toFFI c) (optUp d)
-
+  
   export
   setValidity : (obj : ElementInternals) -> JSIO ()
   setValidity a = primJS $
@@ -652,41 +643,40 @@ namespace ElementInternals
 
 
 namespace ErrorEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t2)}
+       {auto _ : Cast t2 ErrorEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO ErrorEvent
   new' a b = primJS $ ErrorEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO ErrorEvent
   new a = primJS $ ErrorEvent.prim__new a undef
 
-
+  
   export
   colno : (obj : ErrorEvent) -> JSIO Bits32
   colno a = primJS $ ErrorEvent.prim__colno a
 
-
+  
   export
   error : (obj : ErrorEvent) -> JSIO Any
   error a = tryJS "ErrorEvent.error" $ ErrorEvent.prim__error a
 
-
+  
   export
   filename : (obj : ErrorEvent) -> JSIO String
   filename a = primJS $ ErrorEvent.prim__filename a
 
-
+  
   export
   lineno : (obj : ErrorEvent) -> JSIO Bits32
   lineno a = primJS $ ErrorEvent.prim__lineno a
 
-
+  
   export
   message : (obj : ErrorEvent) -> JSIO String
   message a = primJS $ ErrorEvent.prim__message a
@@ -694,36 +684,35 @@ namespace ErrorEvent
 
 
 namespace EventSource
-
-  public export
+  
+  export
   CLOSED : Bits16
   CLOSED = 2
 
-
-  public export
+  
+  export
   CONNECTING : Bits16
   CONNECTING = 0
 
-
-  public export
+  
+  export
   OPEN : Bits16
   OPEN = 1
 
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem EventSourceInit (Types t2)}
+       {auto _ : Cast t2 EventSourceInit}
     -> (url : String)
     -> (eventSourceInitDict : Optional t2)
     -> JSIO EventSource
   new' a b = primJS $ EventSource.prim__new a (optUp b)
-
+  
   export
   new : (url : String) -> JSIO EventSource
   new a = primJS $ EventSource.prim__new a undef
 
-
+  
   export
   onerror : EventSource -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -732,7 +721,7 @@ namespace EventSource
                 prim__setOnerror
                 v
 
-
+  
   export
   onmessage : EventSource -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
@@ -741,7 +730,7 @@ namespace EventSource
                   prim__setOnmessage
                   v
 
-
+  
   export
   onopen : EventSource -> Attribute False Maybe EventHandlerNonNull
   onopen v = fromNullablePrim
@@ -750,23 +739,23 @@ namespace EventSource
                prim__setOnopen
                v
 
-
+  
   export
   readyState : (obj : EventSource) -> JSIO Bits16
   readyState a = primJS $ EventSource.prim__readyState a
 
-
+  
   export
   url : (obj : EventSource) -> JSIO String
   url a = primJS $ EventSource.prim__url a
 
-
+  
   export
   withCredentials : (obj : EventSource) -> JSIO Bool
   withCredentials a = tryJS "EventSource.withCredentials" $
     EventSource.prim__withCredentials a
 
-
+  
   export
   close : (obj : EventSource) -> JSIO ()
   close a = primJS $ EventSource.prim__close a
@@ -774,12 +763,12 @@ namespace EventSource
 
 
 namespace External
-
+  
   export
   AddSearchProvider : (obj : External) -> JSIO ()
   AddSearchProvider a = primJS $ External.prim__AddSearchProvider a
 
-
+  
   export
   IsSearchProviderInstalled : (obj : External) -> JSIO ()
   IsSearchProviderInstalled a = primJS $
@@ -788,17 +777,16 @@ namespace External
 
 
 namespace FormDataEvent
-
+  
   export
   new :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem FormDataEventInit (Types t2)}
+       {auto _ : Cast t2 FormDataEventInit}
     -> (type : String)
     -> (eventInitDict : t2)
     -> JSIO FormDataEvent
-  new a b = primJS $ FormDataEvent.prim__new a (up b)
+  new a b = primJS $ FormDataEvent.prim__new a (cast b)
 
-
+  
   export
   formData : (obj : FormDataEvent) -> JSIO FormData
   formData a = primJS $ FormDataEvent.prim__formData a
@@ -806,17 +794,17 @@ namespace FormDataEvent
 
 
 namespace HTMLAllCollection
-
+  
   export
   get : (obj : HTMLAllCollection) -> (index : Bits32) -> JSIO Element
   get a b = primJS $ HTMLAllCollection.prim__get a b
 
-
+  
   export
   length : (obj : HTMLAllCollection) -> JSIO Bits32
   length a = primJS $ HTMLAllCollection.prim__length a
 
-
+  
   export
   item' :
        (obj : HTMLAllCollection)
@@ -824,14 +812,14 @@ namespace HTMLAllCollection
     -> JSIO (Maybe (HSum [HTMLCollection, Element]))
   item' a b = tryJS "HTMLAllCollection.item'" $
     HTMLAllCollection.prim__item a (toFFI b)
-
+  
   export
   item :
        (obj : HTMLAllCollection)
     -> JSIO (Maybe (HSum [HTMLCollection, Element]))
   item a = tryJS "HTMLAllCollection.item" $ HTMLAllCollection.prim__item a undef
 
-
+  
   export
   namedItem :
        (obj : HTMLAllCollection)
@@ -843,12 +831,12 @@ namespace HTMLAllCollection
 
 
 namespace HTMLAnchorElement
-
+  
   export
   new : JSIO HTMLAnchorElement
   new = primJS $ HTMLAnchorElement.prim__new
 
-
+  
   export
   charset : HTMLAnchorElement -> Attribute True Prelude.id String
   charset v = fromPrim
@@ -857,7 +845,7 @@ namespace HTMLAnchorElement
                 prim__setCharset
                 v
 
-
+  
   export
   coords : HTMLAnchorElement -> Attribute True Prelude.id String
   coords v = fromPrim
@@ -866,7 +854,7 @@ namespace HTMLAnchorElement
                prim__setCoords
                v
 
-
+  
   export
   download : HTMLAnchorElement -> Attribute True Prelude.id String
   download v = fromPrim
@@ -875,7 +863,7 @@ namespace HTMLAnchorElement
                  prim__setDownload
                  v
 
-
+  
   export
   hreflang : HTMLAnchorElement -> Attribute True Prelude.id String
   hreflang v = fromPrim
@@ -884,17 +872,17 @@ namespace HTMLAnchorElement
                  prim__setHreflang
                  v
 
-
+  
   export
   name : HTMLAnchorElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLAnchorElement.getname" prim__name prim__setName v
 
-
+  
   export
   ping : HTMLAnchorElement -> Attribute True Prelude.id String
   ping v = fromPrim "HTMLAnchorElement.getping" prim__ping prim__setPing v
 
-
+  
   export
   referrerPolicy : HTMLAnchorElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -903,27 +891,27 @@ namespace HTMLAnchorElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   rel : HTMLAnchorElement -> Attribute True Prelude.id String
   rel v = fromPrim "HTMLAnchorElement.getrel" prim__rel prim__setRel v
 
-
+  
   export
   relList : (obj : HTMLAnchorElement) -> JSIO DOMTokenList
   relList a = primJS $ HTMLAnchorElement.prim__relList a
 
-
+  
   export
   rev : HTMLAnchorElement -> Attribute True Prelude.id String
   rev v = fromPrim "HTMLAnchorElement.getrev" prim__rev prim__setRev v
 
-
+  
   export
   shape : HTMLAnchorElement -> Attribute True Prelude.id String
   shape v = fromPrim "HTMLAnchorElement.getshape" prim__shape prim__setShape v
 
-
+  
   export
   target : HTMLAnchorElement -> Attribute True Prelude.id String
   target v = fromPrim
@@ -932,12 +920,12 @@ namespace HTMLAnchorElement
                prim__setTarget
                v
 
-
+  
   export
   text : HTMLAnchorElement -> Attribute True Prelude.id String
   text v = fromPrim "HTMLAnchorElement.gettext" prim__text prim__setText v
 
-
+  
   export
   type : HTMLAnchorElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLAnchorElement.gettype" prim__type prim__setType v
@@ -945,22 +933,22 @@ namespace HTMLAnchorElement
 
 
 namespace HTMLAreaElement
-
+  
   export
   new : JSIO HTMLAreaElement
   new = primJS $ HTMLAreaElement.prim__new
 
-
+  
   export
   alt : HTMLAreaElement -> Attribute True Prelude.id String
   alt v = fromPrim "HTMLAreaElement.getalt" prim__alt prim__setAlt v
 
-
+  
   export
   coords : HTMLAreaElement -> Attribute True Prelude.id String
   coords v = fromPrim "HTMLAreaElement.getcoords" prim__coords prim__setCoords v
 
-
+  
   export
   download : HTMLAreaElement -> Attribute True Prelude.id String
   download v = fromPrim
@@ -969,17 +957,17 @@ namespace HTMLAreaElement
                  prim__setDownload
                  v
 
-
+  
   export
   noHref : HTMLAreaElement -> Attribute True Prelude.id Bool
   noHref v = fromPrim "HTMLAreaElement.getnoHref" prim__noHref prim__setNoHref v
 
-
+  
   export
   ping : HTMLAreaElement -> Attribute True Prelude.id String
   ping v = fromPrim "HTMLAreaElement.getping" prim__ping prim__setPing v
 
-
+  
   export
   referrerPolicy : HTMLAreaElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -988,22 +976,22 @@ namespace HTMLAreaElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   rel : HTMLAreaElement -> Attribute True Prelude.id String
   rel v = fromPrim "HTMLAreaElement.getrel" prim__rel prim__setRel v
 
-
+  
   export
   relList : (obj : HTMLAreaElement) -> JSIO DOMTokenList
   relList a = primJS $ HTMLAreaElement.prim__relList a
 
-
+  
   export
   shape : HTMLAreaElement -> Attribute True Prelude.id String
   shape v = fromPrim "HTMLAreaElement.getshape" prim__shape prim__setShape v
 
-
+  
   export
   target : HTMLAreaElement -> Attribute True Prelude.id String
   target v = fromPrim "HTMLAreaElement.gettarget" prim__target prim__setTarget v
@@ -1011,7 +999,7 @@ namespace HTMLAreaElement
 
 
 namespace HTMLAudioElement
-
+  
   export
   new : JSIO HTMLAudioElement
   new = primJS $ HTMLAudioElement.prim__new
@@ -1019,12 +1007,12 @@ namespace HTMLAudioElement
 
 
 namespace HTMLBRElement
-
+  
   export
   new : JSIO HTMLBRElement
   new = primJS $ HTMLBRElement.prim__new
 
-
+  
   export
   clear : HTMLBRElement -> Attribute True Prelude.id String
   clear v = fromPrim "HTMLBRElement.getclear" prim__clear prim__setClear v
@@ -1032,17 +1020,17 @@ namespace HTMLBRElement
 
 
 namespace HTMLBaseElement
-
+  
   export
   new : JSIO HTMLBaseElement
   new = primJS $ HTMLBaseElement.prim__new
 
-
+  
   export
   href : HTMLBaseElement -> Attribute True Prelude.id String
   href v = fromPrim "HTMLBaseElement.gethref" prim__href prim__setHref v
 
-
+  
   export
   target : HTMLBaseElement -> Attribute True Prelude.id String
   target v = fromPrim "HTMLBaseElement.gettarget" prim__target prim__setTarget v
@@ -1050,17 +1038,17 @@ namespace HTMLBaseElement
 
 
 namespace HTMLBodyElement
-
+  
   export
   new : JSIO HTMLBodyElement
   new = primJS $ HTMLBodyElement.prim__new
 
-
+  
   export
   aLink : HTMLBodyElement -> Attribute True Prelude.id String
   aLink v = fromPrim "HTMLBodyElement.getaLink" prim__aLink prim__setALink v
 
-
+  
   export
   background : HTMLBodyElement -> Attribute True Prelude.id String
   background v = fromPrim
@@ -1069,7 +1057,7 @@ namespace HTMLBodyElement
                    prim__setBackground
                    v
 
-
+  
   export
   bgColor : HTMLBodyElement -> Attribute True Prelude.id String
   bgColor v = fromPrim
@@ -1078,17 +1066,17 @@ namespace HTMLBodyElement
                 prim__setBgColor
                 v
 
-
+  
   export
   link : HTMLBodyElement -> Attribute True Prelude.id String
   link v = fromPrim "HTMLBodyElement.getlink" prim__link prim__setLink v
 
-
+  
   export
   text : HTMLBodyElement -> Attribute True Prelude.id String
   text v = fromPrim "HTMLBodyElement.gettext" prim__text prim__setText v
 
-
+  
   export
   vLink : HTMLBodyElement -> Attribute True Prelude.id String
   vLink v = fromPrim "HTMLBodyElement.getvLink" prim__vLink prim__setVLink v
@@ -1096,12 +1084,12 @@ namespace HTMLBodyElement
 
 
 namespace HTMLButtonElement
-
+  
   export
   new : JSIO HTMLButtonElement
   new = primJS $ HTMLButtonElement.prim__new
 
-
+  
   export
   disabled : HTMLButtonElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -1110,12 +1098,12 @@ namespace HTMLButtonElement
                  prim__setDisabled
                  v
 
-
+  
   export
   form : (obj : HTMLButtonElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLButtonElement.form" $ HTMLButtonElement.prim__form a
 
-
+  
   export
   formAction : HTMLButtonElement -> Attribute True Prelude.id String
   formAction v = fromPrim
@@ -1124,7 +1112,7 @@ namespace HTMLButtonElement
                    prim__setFormAction
                    v
 
-
+  
   export
   formEnctype : HTMLButtonElement -> Attribute True Prelude.id String
   formEnctype v = fromPrim
@@ -1133,7 +1121,7 @@ namespace HTMLButtonElement
                     prim__setFormEnctype
                     v
 
-
+  
   export
   formMethod : HTMLButtonElement -> Attribute True Prelude.id String
   formMethod v = fromPrim
@@ -1142,7 +1130,7 @@ namespace HTMLButtonElement
                    prim__setFormMethod
                    v
 
-
+  
   export
   formNoValidate : HTMLButtonElement -> Attribute True Prelude.id Bool
   formNoValidate v = fromPrim
@@ -1151,7 +1139,7 @@ namespace HTMLButtonElement
                        prim__setFormNoValidate
                        v
 
-
+  
   export
   formTarget : HTMLButtonElement -> Attribute True Prelude.id String
   formTarget v = fromPrim
@@ -1160,55 +1148,55 @@ namespace HTMLButtonElement
                    prim__setFormTarget
                    v
 
-
+  
   export
   labels : (obj : HTMLButtonElement) -> JSIO NodeList
   labels a = primJS $ HTMLButtonElement.prim__labels a
 
-
+  
   export
   name : HTMLButtonElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLButtonElement.getname" prim__name prim__setName v
 
-
+  
   export
   type : HTMLButtonElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLButtonElement.gettype" prim__type prim__setType v
 
-
+  
   export
   validationMessage : (obj : HTMLButtonElement) -> JSIO String
   validationMessage a = primJS $ HTMLButtonElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLButtonElement) -> JSIO ValidityState
   validity a = primJS $ HTMLButtonElement.prim__validity a
 
-
+  
   export
   value : HTMLButtonElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLButtonElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   willValidate : (obj : HTMLButtonElement) -> JSIO Bool
   willValidate a = tryJS "HTMLButtonElement.willValidate" $
     HTMLButtonElement.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : HTMLButtonElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLButtonElement.checkValidity" $
     HTMLButtonElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLButtonElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLButtonElement.reportValidity" $
     HTMLButtonElement.prim__reportValidity a
 
-
+  
   export
   setCustomValidity : (obj : HTMLButtonElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $ HTMLButtonElement.prim__setCustomValidity a b
@@ -1216,12 +1204,12 @@ namespace HTMLButtonElement
 
 
 namespace HTMLCanvasElement
-
+  
   export
   new : JSIO HTMLCanvasElement
   new = primJS $ HTMLCanvasElement.prim__new
 
-
+  
   export
   height : HTMLCanvasElement -> Attribute True Prelude.id Bits32
   height v = fromPrim
@@ -1230,12 +1218,12 @@ namespace HTMLCanvasElement
                prim__setHeight
                v
 
-
+  
   export
   width : HTMLCanvasElement -> Attribute True Prelude.id Bits32
   width v = fromPrim "HTMLCanvasElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   getContext' :
        (obj : HTMLCanvasElement)
@@ -1251,7 +1239,7 @@ namespace HTMLCanvasElement
                ]))
   getContext' a b c = tryJS "HTMLCanvasElement.getContext'" $
     HTMLCanvasElement.prim__getContext a b (toFFI c)
-
+  
   export
   getContext :
        (obj : HTMLCanvasElement)
@@ -1267,7 +1255,7 @@ namespace HTMLCanvasElement
   getContext a b = tryJS "HTMLCanvasElement.getContext" $
     HTMLCanvasElement.prim__getContext a b undef
 
-
+  
   export
   toBlob' :
        (obj : HTMLCanvasElement)
@@ -1277,12 +1265,12 @@ namespace HTMLCanvasElement
     -> JSIO ()
   toBlob' a b c d = primJS $
     HTMLCanvasElement.prim__toBlob a b (toFFI c) (toFFI d)
-
+  
   export
   toBlob : (obj : HTMLCanvasElement) -> (callback : BlobCallback) -> JSIO ()
   toBlob a b = primJS $ HTMLCanvasElement.prim__toBlob a b undef undef
 
-
+  
   export
   toDataURL' :
        (obj : HTMLCanvasElement)
@@ -1291,12 +1279,12 @@ namespace HTMLCanvasElement
     -> JSIO String
   toDataURL' a b c = primJS $
     HTMLCanvasElement.prim__toDataURL a (toFFI b) (toFFI c)
-
+  
   export
   toDataURL : (obj : HTMLCanvasElement) -> JSIO String
   toDataURL a = primJS $ HTMLCanvasElement.prim__toDataURL a undef undef
 
-
+  
   export
   transferControlToOffscreen : (obj : HTMLCanvasElement) -> JSIO OffscreenCanvas
   transferControlToOffscreen a = primJS $
@@ -1305,12 +1293,12 @@ namespace HTMLCanvasElement
 
 
 namespace HTMLDListElement
-
+  
   export
   new : JSIO HTMLDListElement
   new = primJS $ HTMLDListElement.prim__new
 
-
+  
   export
   compact : HTMLDListElement -> Attribute True Prelude.id Bool
   compact v = fromPrim
@@ -1322,12 +1310,12 @@ namespace HTMLDListElement
 
 
 namespace HTMLDataElement
-
+  
   export
   new : JSIO HTMLDataElement
   new = primJS $ HTMLDataElement.prim__new
 
-
+  
   export
   value : HTMLDataElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLDataElement.getvalue" prim__value prim__setValue v
@@ -1335,12 +1323,12 @@ namespace HTMLDataElement
 
 
 namespace HTMLDataListElement
-
+  
   export
   new : JSIO HTMLDataListElement
   new = primJS $ HTMLDataListElement.prim__new
 
-
+  
   export
   options : (obj : HTMLDataListElement) -> JSIO HTMLCollection
   options a = primJS $ HTMLDataListElement.prim__options a
@@ -1348,12 +1336,12 @@ namespace HTMLDataListElement
 
 
 namespace HTMLDetailsElement
-
+  
   export
   new : JSIO HTMLDetailsElement
   new = primJS $ HTMLDetailsElement.prim__new
 
-
+  
   export
   open_ : HTMLDetailsElement -> Attribute True Prelude.id Bool
   open_ v = fromPrim "HTMLDetailsElement.getopen" prim__open prim__setOpen v
@@ -1361,17 +1349,17 @@ namespace HTMLDetailsElement
 
 
 namespace HTMLDialogElement
-
+  
   export
   new : JSIO HTMLDialogElement
   new = primJS $ HTMLDialogElement.prim__new
 
-
+  
   export
   open_ : HTMLDialogElement -> Attribute True Prelude.id Bool
   open_ v = fromPrim "HTMLDialogElement.getopen" prim__open prim__setOpen v
 
-
+  
   export
   returnValue : HTMLDialogElement -> Attribute True Prelude.id String
   returnValue v = fromPrim
@@ -1380,24 +1368,24 @@ namespace HTMLDialogElement
                     prim__setReturnValue
                     v
 
-
+  
   export
   close' :
        (obj : HTMLDialogElement)
     -> (returnValue : Optional String)
     -> JSIO ()
   close' a b = primJS $ HTMLDialogElement.prim__close a (toFFI b)
-
+  
   export
   close : (obj : HTMLDialogElement) -> JSIO ()
   close a = primJS $ HTMLDialogElement.prim__close a undef
 
-
+  
   export
   show : (obj : HTMLDialogElement) -> JSIO ()
   show a = primJS $ HTMLDialogElement.prim__show a
 
-
+  
   export
   showModal : (obj : HTMLDialogElement) -> JSIO ()
   showModal a = primJS $ HTMLDialogElement.prim__showModal a
@@ -1405,12 +1393,12 @@ namespace HTMLDialogElement
 
 
 namespace HTMLDirectoryElement
-
+  
   export
   new : JSIO HTMLDirectoryElement
   new = primJS $ HTMLDirectoryElement.prim__new
 
-
+  
   export
   compact : HTMLDirectoryElement -> Attribute True Prelude.id Bool
   compact v = fromPrim
@@ -1422,12 +1410,12 @@ namespace HTMLDirectoryElement
 
 
 namespace HTMLDivElement
-
+  
   export
   new : JSIO HTMLDivElement
   new = primJS $ HTMLDivElement.prim__new
 
-
+  
   export
   align : HTMLDivElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLDivElement.getalign" prim__align prim__setAlign v
@@ -1435,228 +1423,180 @@ namespace HTMLDivElement
 
 
 namespace HTMLElement
-
+  
   export
   new : JSIO HTMLElement
   new = primJS $ HTMLElement.prim__new
 
-
+  
   export
   accessKey :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id String
   accessKey v = fromPrim
                   "HTMLElement.getaccessKey"
                   prim__accessKey
                   prim__setAccessKey
-                  (v :> HTMLElement)
+                  (cast {to = HTMLElement} v)
 
-
+  
   export
-  accessKeyLabel :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  accessKeyLabel a = primJS $ HTMLElement.prim__accessKeyLabel (up a)
+  accessKeyLabel : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO String
+  accessKeyLabel a = primJS $ HTMLElement.prim__accessKeyLabel (cast a)
 
-
+  
   export
   autocapitalize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id String
   autocapitalize v = fromPrim
                        "HTMLElement.getautocapitalize"
                        prim__autocapitalize
                        prim__setAutocapitalize
-                       (v :> HTMLElement)
+                       (cast {to = HTMLElement} v)
 
-
+  
   export
-  dir :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  dir : {auto _ : Cast t HTMLElement} -> t -> Attribute True Prelude.id String
   dir v = fromPrim
             "HTMLElement.getdir"
             prim__dir
             prim__setDir
-            (v :> HTMLElement)
+            (cast {to = HTMLElement} v)
 
-
+  
   export
   draggable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id Bool
   draggable v = fromPrim
                   "HTMLElement.getdraggable"
                   prim__draggable
                   prim__setDraggable
-                  (v :> HTMLElement)
+                  (cast {to = HTMLElement} v)
 
-
+  
   export
-  hidden :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
-    -> t
-    -> Attribute True Prelude.id Bool
+  hidden : {auto _ : Cast t HTMLElement} -> t -> Attribute True Prelude.id Bool
   hidden v = fromPrim
                "HTMLElement.gethidden"
                prim__hidden
                prim__setHidden
-               (v :> HTMLElement)
+               (cast {to = HTMLElement} v)
 
-
+  
   export
   innerText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id String
   innerText v = fromPrim
                   "HTMLElement.getinnerText"
                   prim__innerText
                   prim__setInnerText
-                  (v :> HTMLElement)
+                  (cast {to = HTMLElement} v)
 
-
+  
   export
-  lang :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  lang : {auto _ : Cast t HTMLElement} -> t -> Attribute True Prelude.id String
   lang v = fromPrim
              "HTMLElement.getlang"
              prim__lang
              prim__setLang
-             (v :> HTMLElement)
+             (cast {to = HTMLElement} v)
 
-
+  
   export
-  offsetHeight :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  offsetHeight a = primJS $ HTMLElement.prim__offsetHeight (up a)
+  offsetHeight : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO Int32
+  offsetHeight a = primJS $ HTMLElement.prim__offsetHeight (cast a)
 
-
+  
   export
-  offsetLeft :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  offsetLeft a = primJS $ HTMLElement.prim__offsetLeft (up a)
+  offsetLeft : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO Int32
+  offsetLeft a = primJS $ HTMLElement.prim__offsetLeft (cast a)
 
-
+  
   export
   offsetParent :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
+       {auto _ : Cast t1 HTMLElement}
     -> (obj : t1)
     -> JSIO (Maybe Element)
   offsetParent a = tryJS "HTMLElement.offsetParent" $
-    HTMLElement.prim__offsetParent (up a)
+    HTMLElement.prim__offsetParent (cast a)
 
-
+  
   export
-  offsetTop :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  offsetTop a = primJS $ HTMLElement.prim__offsetTop (up a)
+  offsetTop : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO Int32
+  offsetTop a = primJS $ HTMLElement.prim__offsetTop (cast a)
 
-
+  
   export
-  offsetWidth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  offsetWidth a = primJS $ HTMLElement.prim__offsetWidth (up a)
+  offsetWidth : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO Int32
+  offsetWidth a = primJS $ HTMLElement.prim__offsetWidth (cast a)
 
-
+  
   export
   spellcheck :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id Bool
   spellcheck v = fromPrim
                    "HTMLElement.getspellcheck"
                    prim__spellcheck
                    prim__setSpellcheck
-                   (v :> HTMLElement)
+                   (cast {to = HTMLElement} v)
 
-
+  
   export
-  title :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
-    -> t
-    -> Attribute True Prelude.id String
+  title : {auto _ : Cast t HTMLElement} -> t -> Attribute True Prelude.id String
   title v = fromPrim
               "HTMLElement.gettitle"
               prim__title
               prim__setTitle
-              (v :> HTMLElement)
+              (cast {to = HTMLElement} v)
 
-
+  
   export
   translate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLElement (Types t)}
+       {auto _ : Cast t HTMLElement}
     -> t
     -> Attribute True Prelude.id Bool
   translate v = fromPrim
                   "HTMLElement.gettranslate"
                   prim__translate
                   prim__setTranslate
-                  (v :> HTMLElement)
+                  (cast {to = HTMLElement} v)
 
-
+  
   export
   attachInternals :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
+       {auto _ : Cast t1 HTMLElement}
     -> (obj : t1)
     -> JSIO ElementInternals
-  attachInternals a = primJS $ HTMLElement.prim__attachInternals (up a)
+  attachInternals a = primJS $ HTMLElement.prim__attachInternals (cast a)
 
-
+  
   export
-  click :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  click a = primJS $ HTMLElement.prim__click (up a)
+  click : {auto _ : Cast t1 HTMLElement} -> (obj : t1) -> JSIO ()
+  click a = primJS $ HTMLElement.prim__click (cast a)
 
 
 
 namespace HTMLEmbedElement
-
+  
   export
   new : JSIO HTMLEmbedElement
   new = primJS $ HTMLEmbedElement.prim__new
 
-
+  
   export
   align : HTMLEmbedElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLEmbedElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   height : HTMLEmbedElement -> Attribute True Prelude.id String
   height v = fromPrim
@@ -1665,27 +1605,27 @@ namespace HTMLEmbedElement
                prim__setHeight
                v
 
-
+  
   export
   name : HTMLEmbedElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLEmbedElement.getname" prim__name prim__setName v
 
-
+  
   export
   src : HTMLEmbedElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLEmbedElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   type : HTMLEmbedElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLEmbedElement.gettype" prim__type prim__setType v
 
-
+  
   export
   width : HTMLEmbedElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLEmbedElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   getSVGDocument : (obj : HTMLEmbedElement) -> JSIO (Maybe Document)
   getSVGDocument a = tryJS "HTMLEmbedElement.getSVGDocument" $
@@ -1694,12 +1634,12 @@ namespace HTMLEmbedElement
 
 
 namespace HTMLFieldSetElement
-
+  
   export
   new : JSIO HTMLFieldSetElement
   new = primJS $ HTMLFieldSetElement.prim__new
 
-
+  
   export
   disabled : HTMLFieldSetElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -1708,55 +1648,55 @@ namespace HTMLFieldSetElement
                  prim__setDisabled
                  v
 
-
+  
   export
   elements : (obj : HTMLFieldSetElement) -> JSIO HTMLCollection
   elements a = primJS $ HTMLFieldSetElement.prim__elements a
 
-
+  
   export
   form : (obj : HTMLFieldSetElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLFieldSetElement.form" $ HTMLFieldSetElement.prim__form a
 
-
+  
   export
   name : HTMLFieldSetElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLFieldSetElement.getname" prim__name prim__setName v
 
-
+  
   export
   type : (obj : HTMLFieldSetElement) -> JSIO String
   type a = primJS $ HTMLFieldSetElement.prim__type a
 
-
+  
   export
   validationMessage : (obj : HTMLFieldSetElement) -> JSIO String
   validationMessage a = primJS $ HTMLFieldSetElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLFieldSetElement) -> JSIO ValidityState
   validity a = primJS $ HTMLFieldSetElement.prim__validity a
 
-
+  
   export
   willValidate : (obj : HTMLFieldSetElement) -> JSIO Bool
   willValidate a = tryJS "HTMLFieldSetElement.willValidate" $
     HTMLFieldSetElement.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : HTMLFieldSetElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLFieldSetElement.checkValidity" $
     HTMLFieldSetElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLFieldSetElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLFieldSetElement.reportValidity" $
     HTMLFieldSetElement.prim__reportValidity a
 
-
+  
   export
   setCustomValidity : (obj : HTMLFieldSetElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $
@@ -1765,22 +1705,22 @@ namespace HTMLFieldSetElement
 
 
 namespace HTMLFontElement
-
+  
   export
   new : JSIO HTMLFontElement
   new = primJS $ HTMLFontElement.prim__new
 
-
+  
   export
   color : HTMLFontElement -> Attribute True Prelude.id String
   color v = fromPrim "HTMLFontElement.getcolor" prim__color prim__setColor v
 
-
+  
   export
   face : HTMLFontElement -> Attribute True Prelude.id String
   face v = fromPrim "HTMLFontElement.getface" prim__face prim__setFace v
 
-
+  
   export
   size : HTMLFontElement -> Attribute True Prelude.id String
   size v = fromPrim "HTMLFontElement.getsize" prim__size prim__setSize v
@@ -1788,7 +1728,7 @@ namespace HTMLFontElement
 
 
 namespace HTMLFormControlsCollection
-
+  
   export
   namedItem :
        (obj : HTMLFormControlsCollection)
@@ -1800,17 +1740,17 @@ namespace HTMLFormControlsCollection
 
 
 namespace HTMLFormElement
-
+  
   export
   new : JSIO HTMLFormElement
   new = primJS $ HTMLFormElement.prim__new
 
-
+  
   export
   get : (obj : HTMLFormElement) -> (index : Bits32) -> JSIO Element
   get a b = primJS $ HTMLFormElement.prim__get a b
 
-
+  
   export
   get1 :
        (obj : HTMLFormElement)
@@ -1818,7 +1758,7 @@ namespace HTMLFormElement
     -> JSIO (HSum [RadioNodeList, Element])
   get1 a b = tryJS "HTMLFormElement.get1" $ HTMLFormElement.prim__get1 a b
 
-
+  
   export
   acceptCharset : HTMLFormElement -> Attribute True Prelude.id String
   acceptCharset v = fromPrim
@@ -1827,12 +1767,12 @@ namespace HTMLFormElement
                       prim__setAcceptCharset
                       v
 
-
+  
   export
   action : HTMLFormElement -> Attribute True Prelude.id String
   action v = fromPrim "HTMLFormElement.getaction" prim__action prim__setAction v
 
-
+  
   export
   autocomplete : HTMLFormElement -> Attribute True Prelude.id String
   autocomplete v = fromPrim
@@ -1841,12 +1781,12 @@ namespace HTMLFormElement
                      prim__setAutocomplete
                      v
 
-
+  
   export
   elements : (obj : HTMLFormElement) -> JSIO HTMLFormControlsCollection
   elements a = primJS $ HTMLFormElement.prim__elements a
 
-
+  
   export
   encoding : HTMLFormElement -> Attribute True Prelude.id String
   encoding v = fromPrim
@@ -1855,7 +1795,7 @@ namespace HTMLFormElement
                  prim__setEncoding
                  v
 
-
+  
   export
   enctype : HTMLFormElement -> Attribute True Prelude.id String
   enctype v = fromPrim
@@ -1864,22 +1804,22 @@ namespace HTMLFormElement
                 prim__setEnctype
                 v
 
-
+  
   export
   length : (obj : HTMLFormElement) -> JSIO Bits32
   length a = primJS $ HTMLFormElement.prim__length a
 
-
+  
   export
   method : HTMLFormElement -> Attribute True Prelude.id String
   method v = fromPrim "HTMLFormElement.getmethod" prim__method prim__setMethod v
 
-
+  
   export
   name : HTMLFormElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLFormElement.getname" prim__name prim__setName v
 
-
+  
   export
   noValidate : HTMLFormElement -> Attribute True Prelude.id Bool
   noValidate v = fromPrim
@@ -1888,53 +1828,52 @@ namespace HTMLFormElement
                    prim__setNoValidate
                    v
 
-
+  
   export
   rel : HTMLFormElement -> Attribute True Prelude.id String
   rel v = fromPrim "HTMLFormElement.getrel" prim__rel prim__setRel v
 
-
+  
   export
   relList : (obj : HTMLFormElement) -> JSIO DOMTokenList
   relList a = primJS $ HTMLFormElement.prim__relList a
 
-
+  
   export
   target : HTMLFormElement -> Attribute True Prelude.id String
   target v = fromPrim "HTMLFormElement.gettarget" prim__target prim__setTarget v
 
-
+  
   export
   checkValidity : (obj : HTMLFormElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLFormElement.checkValidity" $
     HTMLFormElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLFormElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLFormElement.reportValidity" $
     HTMLFormElement.prim__reportValidity a
 
-
+  
   export
   requestSubmit' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem HTMLElement (Types t2)}
+       {auto _ : Cast t2 HTMLElement}
     -> (obj : HTMLFormElement)
     -> (submitter : Optional (Maybe t2))
     -> JSIO ()
   requestSubmit' a b = primJS $ HTMLFormElement.prim__requestSubmit a (omyUp b)
-
+  
   export
   requestSubmit : (obj : HTMLFormElement) -> JSIO ()
   requestSubmit a = primJS $ HTMLFormElement.prim__requestSubmit a undef
 
-
+  
   export
   reset : (obj : HTMLFormElement) -> JSIO ()
   reset a = primJS $ HTMLFormElement.prim__reset a
 
-
+  
   export
   submit : (obj : HTMLFormElement) -> JSIO ()
   submit a = primJS $ HTMLFormElement.prim__submit a
@@ -1942,24 +1881,24 @@ namespace HTMLFormElement
 
 
 namespace HTMLFrameElement
-
+  
   export
   new : JSIO HTMLFrameElement
   new = primJS $ HTMLFrameElement.prim__new
 
-
+  
   export
   contentDocument : (obj : HTMLFrameElement) -> JSIO (Maybe Document)
   contentDocument a = tryJS "HTMLFrameElement.contentDocument" $
     HTMLFrameElement.prim__contentDocument a
 
-
+  
   export
   contentWindow : (obj : HTMLFrameElement) -> JSIO (Maybe WindowProxy)
   contentWindow a = tryJS "HTMLFrameElement.contentWindow" $
     HTMLFrameElement.prim__contentWindow a
 
-
+  
   export
   frameBorder : HTMLFrameElement -> Attribute True Prelude.id String
   frameBorder v = fromPrim
@@ -1968,7 +1907,7 @@ namespace HTMLFrameElement
                     prim__setFrameBorder
                     v
 
-
+  
   export
   longDesc : HTMLFrameElement -> Attribute True Prelude.id String
   longDesc v = fromPrim
@@ -1977,7 +1916,7 @@ namespace HTMLFrameElement
                  prim__setLongDesc
                  v
 
-
+  
   export
   marginHeight : HTMLFrameElement -> Attribute True Prelude.id String
   marginHeight v = fromPrim
@@ -1986,7 +1925,7 @@ namespace HTMLFrameElement
                      prim__setMarginHeight
                      v
 
-
+  
   export
   marginWidth : HTMLFrameElement -> Attribute True Prelude.id String
   marginWidth v = fromPrim
@@ -1995,12 +1934,12 @@ namespace HTMLFrameElement
                     prim__setMarginWidth
                     v
 
-
+  
   export
   name : HTMLFrameElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLFrameElement.getname" prim__name prim__setName v
 
-
+  
   export
   noResize : HTMLFrameElement -> Attribute True Prelude.id Bool
   noResize v = fromPrim
@@ -2009,7 +1948,7 @@ namespace HTMLFrameElement
                  prim__setNoResize
                  v
 
-
+  
   export
   scrolling : HTMLFrameElement -> Attribute True Prelude.id String
   scrolling v = fromPrim
@@ -2018,7 +1957,7 @@ namespace HTMLFrameElement
                   prim__setScrolling
                   v
 
-
+  
   export
   src : HTMLFrameElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLFrameElement.getsrc" prim__src prim__setSrc v
@@ -2026,17 +1965,17 @@ namespace HTMLFrameElement
 
 
 namespace HTMLFrameSetElement
-
+  
   export
   new : JSIO HTMLFrameSetElement
   new = primJS $ HTMLFrameSetElement.prim__new
 
-
+  
   export
   cols : HTMLFrameSetElement -> Attribute True Prelude.id String
   cols v = fromPrim "HTMLFrameSetElement.getcols" prim__cols prim__setCols v
 
-
+  
   export
   rows : HTMLFrameSetElement -> Attribute True Prelude.id String
   rows v = fromPrim "HTMLFrameSetElement.getrows" prim__rows prim__setRows v
@@ -2044,22 +1983,22 @@ namespace HTMLFrameSetElement
 
 
 namespace HTMLHRElement
-
+  
   export
   new : JSIO HTMLHRElement
   new = primJS $ HTMLHRElement.prim__new
 
-
+  
   export
   align : HTMLHRElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLHRElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   color : HTMLHRElement -> Attribute True Prelude.id String
   color v = fromPrim "HTMLHRElement.getcolor" prim__color prim__setColor v
 
-
+  
   export
   noShade : HTMLHRElement -> Attribute True Prelude.id Bool
   noShade v = fromPrim
@@ -2068,12 +2007,12 @@ namespace HTMLHRElement
                 prim__setNoShade
                 v
 
-
+  
   export
   size : HTMLHRElement -> Attribute True Prelude.id String
   size v = fromPrim "HTMLHRElement.getsize" prim__size prim__setSize v
 
-
+  
   export
   width : HTMLHRElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLHRElement.getwidth" prim__width prim__setWidth v
@@ -2081,7 +2020,7 @@ namespace HTMLHRElement
 
 
 namespace HTMLHeadElement
-
+  
   export
   new : JSIO HTMLHeadElement
   new = primJS $ HTMLHeadElement.prim__new
@@ -2089,12 +2028,12 @@ namespace HTMLHeadElement
 
 
 namespace HTMLHeadingElement
-
+  
   export
   new : JSIO HTMLHeadingElement
   new = primJS $ HTMLHeadingElement.prim__new
 
-
+  
   export
   align : HTMLHeadingElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLHeadingElement.getalign" prim__align prim__setAlign v
@@ -2102,12 +2041,12 @@ namespace HTMLHeadingElement
 
 
 namespace HTMLHtmlElement
-
+  
   export
   new : JSIO HTMLHtmlElement
   new = primJS $ HTMLHtmlElement.prim__new
 
-
+  
   export
   version : HTMLHtmlElement -> Attribute True Prelude.id String
   version v = fromPrim
@@ -2119,22 +2058,22 @@ namespace HTMLHtmlElement
 
 
 namespace HTMLIFrameElement
-
+  
   export
   new : JSIO HTMLIFrameElement
   new = primJS $ HTMLIFrameElement.prim__new
 
-
+  
   export
   align : HTMLIFrameElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLIFrameElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   allow : HTMLIFrameElement -> Attribute True Prelude.id String
   allow v = fromPrim "HTMLIFrameElement.getallow" prim__allow prim__setAllow v
 
-
+  
   export
   allowFullscreen : HTMLIFrameElement -> Attribute True Prelude.id Bool
   allowFullscreen v = fromPrim
@@ -2143,19 +2082,19 @@ namespace HTMLIFrameElement
                         prim__setAllowFullscreen
                         v
 
-
+  
   export
   contentDocument : (obj : HTMLIFrameElement) -> JSIO (Maybe Document)
   contentDocument a = tryJS "HTMLIFrameElement.contentDocument" $
     HTMLIFrameElement.prim__contentDocument a
 
-
+  
   export
   contentWindow : (obj : HTMLIFrameElement) -> JSIO (Maybe WindowProxy)
   contentWindow a = tryJS "HTMLIFrameElement.contentWindow" $
     HTMLIFrameElement.prim__contentWindow a
 
-
+  
   export
   frameBorder : HTMLIFrameElement -> Attribute True Prelude.id String
   frameBorder v = fromPrim
@@ -2164,7 +2103,7 @@ namespace HTMLIFrameElement
                     prim__setFrameBorder
                     v
 
-
+  
   export
   height : HTMLIFrameElement -> Attribute True Prelude.id String
   height v = fromPrim
@@ -2173,7 +2112,7 @@ namespace HTMLIFrameElement
                prim__setHeight
                v
 
-
+  
   export
   loading : HTMLIFrameElement -> Attribute True Prelude.id String
   loading v = fromPrim
@@ -2182,7 +2121,7 @@ namespace HTMLIFrameElement
                 prim__setLoading
                 v
 
-
+  
   export
   longDesc : HTMLIFrameElement -> Attribute True Prelude.id String
   longDesc v = fromPrim
@@ -2191,7 +2130,7 @@ namespace HTMLIFrameElement
                  prim__setLongDesc
                  v
 
-
+  
   export
   marginHeight : HTMLIFrameElement -> Attribute True Prelude.id String
   marginHeight v = fromPrim
@@ -2200,7 +2139,7 @@ namespace HTMLIFrameElement
                      prim__setMarginHeight
                      v
 
-
+  
   export
   marginWidth : HTMLIFrameElement -> Attribute True Prelude.id String
   marginWidth v = fromPrim
@@ -2209,12 +2148,12 @@ namespace HTMLIFrameElement
                     prim__setMarginWidth
                     v
 
-
+  
   export
   name : HTMLIFrameElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLIFrameElement.getname" prim__name prim__setName v
 
-
+  
   export
   referrerPolicy : HTMLIFrameElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -2223,12 +2162,12 @@ namespace HTMLIFrameElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   sandbox : (obj : HTMLIFrameElement) -> JSIO DOMTokenList
   sandbox a = primJS $ HTMLIFrameElement.prim__sandbox a
 
-
+  
   export
   scrolling : HTMLIFrameElement -> Attribute True Prelude.id String
   scrolling v = fromPrim
@@ -2237,12 +2176,12 @@ namespace HTMLIFrameElement
                   prim__setScrolling
                   v
 
-
+  
   export
   src : HTMLIFrameElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLIFrameElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   srcdoc : HTMLIFrameElement -> Attribute True Prelude.id String
   srcdoc v = fromPrim
@@ -2251,12 +2190,12 @@ namespace HTMLIFrameElement
                prim__setSrcdoc
                v
 
-
+  
   export
   width : HTMLIFrameElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLIFrameElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   getSVGDocument : (obj : HTMLIFrameElement) -> JSIO (Maybe Document)
   getSVGDocument a = tryJS "HTMLIFrameElement.getSVGDocument" $
@@ -2265,22 +2204,22 @@ namespace HTMLIFrameElement
 
 
 namespace HTMLImageElement
-
+  
   export
   new : JSIO HTMLImageElement
   new = primJS $ HTMLImageElement.prim__new
 
-
+  
   export
   align : HTMLImageElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLImageElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   alt : HTMLImageElement -> Attribute True Prelude.id String
   alt v = fromPrim "HTMLImageElement.getalt" prim__alt prim__setAlt v
 
-
+  
   export
   border : HTMLImageElement -> Attribute True Prelude.id String
   border v = fromPrim
@@ -2289,13 +2228,13 @@ namespace HTMLImageElement
                prim__setBorder
                v
 
-
+  
   export
   complete : (obj : HTMLImageElement) -> JSIO Bool
   complete a = tryJS "HTMLImageElement.complete" $
     HTMLImageElement.prim__complete a
 
-
+  
   export
   crossOrigin : HTMLImageElement -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
@@ -2304,12 +2243,12 @@ namespace HTMLImageElement
                     prim__setCrossOrigin
                     v
 
-
+  
   export
   currentSrc : (obj : HTMLImageElement) -> JSIO String
   currentSrc a = primJS $ HTMLImageElement.prim__currentSrc a
 
-
+  
   export
   decoding : HTMLImageElement -> Attribute True Prelude.id String
   decoding v = fromPrim
@@ -2318,7 +2257,7 @@ namespace HTMLImageElement
                  prim__setDecoding
                  v
 
-
+  
   export
   height : HTMLImageElement -> Attribute True Prelude.id Bits32
   height v = fromPrim
@@ -2327,7 +2266,7 @@ namespace HTMLImageElement
                prim__setHeight
                v
 
-
+  
   export
   hspace : HTMLImageElement -> Attribute True Prelude.id Bits32
   hspace v = fromPrim
@@ -2336,12 +2275,12 @@ namespace HTMLImageElement
                prim__setHspace
                v
 
-
+  
   export
   isMap : HTMLImageElement -> Attribute True Prelude.id Bool
   isMap v = fromPrim "HTMLImageElement.getisMap" prim__isMap prim__setIsMap v
 
-
+  
   export
   loading : HTMLImageElement -> Attribute True Prelude.id String
   loading v = fromPrim
@@ -2350,7 +2289,7 @@ namespace HTMLImageElement
                 prim__setLoading
                 v
 
-
+  
   export
   longDesc : HTMLImageElement -> Attribute True Prelude.id String
   longDesc v = fromPrim
@@ -2359,7 +2298,7 @@ namespace HTMLImageElement
                  prim__setLongDesc
                  v
 
-
+  
   export
   lowsrc : HTMLImageElement -> Attribute True Prelude.id String
   lowsrc v = fromPrim
@@ -2368,22 +2307,22 @@ namespace HTMLImageElement
                prim__setLowsrc
                v
 
-
+  
   export
   name : HTMLImageElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLImageElement.getname" prim__name prim__setName v
 
-
+  
   export
   naturalHeight : (obj : HTMLImageElement) -> JSIO Bits32
   naturalHeight a = primJS $ HTMLImageElement.prim__naturalHeight a
 
-
+  
   export
   naturalWidth : (obj : HTMLImageElement) -> JSIO Bits32
   naturalWidth a = primJS $ HTMLImageElement.prim__naturalWidth a
 
-
+  
   export
   referrerPolicy : HTMLImageElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -2392,17 +2331,17 @@ namespace HTMLImageElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   sizes : HTMLImageElement -> Attribute True Prelude.id String
   sizes v = fromPrim "HTMLImageElement.getsizes" prim__sizes prim__setSizes v
 
-
+  
   export
   src : HTMLImageElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLImageElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   srcset : HTMLImageElement -> Attribute True Prelude.id String
   srcset v = fromPrim
@@ -2411,7 +2350,7 @@ namespace HTMLImageElement
                prim__setSrcset
                v
 
-
+  
   export
   useMap : HTMLImageElement -> Attribute True Prelude.id String
   useMap v = fromPrim
@@ -2420,7 +2359,7 @@ namespace HTMLImageElement
                prim__setUseMap
                v
 
-
+  
   export
   vspace : HTMLImageElement -> Attribute True Prelude.id Bits32
   vspace v = fromPrim
@@ -2429,22 +2368,22 @@ namespace HTMLImageElement
                prim__setVspace
                v
 
-
+  
   export
   width : HTMLImageElement -> Attribute True Prelude.id Bits32
   width v = fromPrim "HTMLImageElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   x : (obj : HTMLImageElement) -> JSIO Int32
   x a = primJS $ HTMLImageElement.prim__x a
 
-
+  
   export
   y : (obj : HTMLImageElement) -> JSIO Int32
   y a = primJS $ HTMLImageElement.prim__y a
 
-
+  
   export
   decode : (obj : HTMLImageElement) -> JSIO (Promise Undefined)
   decode a = primJS $ HTMLImageElement.prim__decode a
@@ -2452,12 +2391,12 @@ namespace HTMLImageElement
 
 
 namespace HTMLInputElement
-
+  
   export
   new : JSIO HTMLInputElement
   new = primJS $ HTMLInputElement.prim__new
 
-
+  
   export
   accept : HTMLInputElement -> Attribute True Prelude.id String
   accept v = fromPrim
@@ -2466,17 +2405,17 @@ namespace HTMLInputElement
                prim__setAccept
                v
 
-
+  
   export
   align : HTMLInputElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLInputElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   alt : HTMLInputElement -> Attribute True Prelude.id String
   alt v = fromPrim "HTMLInputElement.getalt" prim__alt prim__setAlt v
 
-
+  
   export
   autocomplete : HTMLInputElement -> Attribute True Prelude.id String
   autocomplete v = fromPrim
@@ -2485,7 +2424,7 @@ namespace HTMLInputElement
                      prim__setAutocomplete
                      v
 
-
+  
   export
   checked : HTMLInputElement -> Attribute True Prelude.id Bool
   checked v = fromPrim
@@ -2494,7 +2433,7 @@ namespace HTMLInputElement
                 prim__setChecked
                 v
 
-
+  
   export
   defaultChecked : HTMLInputElement -> Attribute True Prelude.id Bool
   defaultChecked v = fromPrim
@@ -2503,7 +2442,7 @@ namespace HTMLInputElement
                        prim__setDefaultChecked
                        v
 
-
+  
   export
   defaultValue : HTMLInputElement -> Attribute True Prelude.id String
   defaultValue v = fromPrim
@@ -2512,7 +2451,7 @@ namespace HTMLInputElement
                      prim__setDefaultValue
                      v
 
-
+  
   export
   dirName : HTMLInputElement -> Attribute True Prelude.id String
   dirName v = fromPrim
@@ -2521,7 +2460,7 @@ namespace HTMLInputElement
                 prim__setDirName
                 v
 
-
+  
   export
   disabled : HTMLInputElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -2530,7 +2469,7 @@ namespace HTMLInputElement
                  prim__setDisabled
                  v
 
-
+  
   export
   files : HTMLInputElement -> Attribute False Maybe FileList
   files v = fromNullablePrim
@@ -2539,12 +2478,12 @@ namespace HTMLInputElement
               prim__setFiles
               v
 
-
+  
   export
   form : (obj : HTMLInputElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLInputElement.form" $ HTMLInputElement.prim__form a
 
-
+  
   export
   formAction : HTMLInputElement -> Attribute True Prelude.id String
   formAction v = fromPrim
@@ -2553,7 +2492,7 @@ namespace HTMLInputElement
                    prim__setFormAction
                    v
 
-
+  
   export
   formEnctype : HTMLInputElement -> Attribute True Prelude.id String
   formEnctype v = fromPrim
@@ -2562,7 +2501,7 @@ namespace HTMLInputElement
                     prim__setFormEnctype
                     v
 
-
+  
   export
   formMethod : HTMLInputElement -> Attribute True Prelude.id String
   formMethod v = fromPrim
@@ -2571,7 +2510,7 @@ namespace HTMLInputElement
                    prim__setFormMethod
                    v
 
-
+  
   export
   formNoValidate : HTMLInputElement -> Attribute True Prelude.id Bool
   formNoValidate v = fromPrim
@@ -2580,7 +2519,7 @@ namespace HTMLInputElement
                        prim__setFormNoValidate
                        v
 
-
+  
   export
   formTarget : HTMLInputElement -> Attribute True Prelude.id String
   formTarget v = fromPrim
@@ -2589,7 +2528,7 @@ namespace HTMLInputElement
                    prim__setFormTarget
                    v
 
-
+  
   export
   height : HTMLInputElement -> Attribute True Prelude.id Bits32
   height v = fromPrim
@@ -2598,7 +2537,7 @@ namespace HTMLInputElement
                prim__setHeight
                v
 
-
+  
   export
   indeterminate : HTMLInputElement -> Attribute True Prelude.id Bool
   indeterminate v = fromPrim
@@ -2607,22 +2546,22 @@ namespace HTMLInputElement
                       prim__setIndeterminate
                       v
 
-
+  
   export
   labels : (obj : HTMLInputElement) -> JSIO (Maybe NodeList)
   labels a = tryJS "HTMLInputElement.labels" $ HTMLInputElement.prim__labels a
 
-
+  
   export
   list : (obj : HTMLInputElement) -> JSIO (Maybe HTMLElement)
   list a = tryJS "HTMLInputElement.list" $ HTMLInputElement.prim__list a
 
-
+  
   export
   max : HTMLInputElement -> Attribute True Prelude.id String
   max v = fromPrim "HTMLInputElement.getmax" prim__max prim__setMax v
 
-
+  
   export
   maxLength : HTMLInputElement -> Attribute True Prelude.id Int32
   maxLength v = fromPrim
@@ -2631,12 +2570,12 @@ namespace HTMLInputElement
                   prim__setMaxLength
                   v
 
-
+  
   export
   min : HTMLInputElement -> Attribute True Prelude.id String
   min v = fromPrim "HTMLInputElement.getmin" prim__min prim__setMin v
 
-
+  
   export
   minLength : HTMLInputElement -> Attribute True Prelude.id Int32
   minLength v = fromPrim
@@ -2645,7 +2584,7 @@ namespace HTMLInputElement
                   prim__setMinLength
                   v
 
-
+  
   export
   multiple : HTMLInputElement -> Attribute True Prelude.id Bool
   multiple v = fromPrim
@@ -2654,12 +2593,12 @@ namespace HTMLInputElement
                  prim__setMultiple
                  v
 
-
+  
   export
   name : HTMLInputElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLInputElement.getname" prim__name prim__setName v
 
-
+  
   export
   pattern : HTMLInputElement -> Attribute True Prelude.id String
   pattern v = fromPrim
@@ -2668,7 +2607,7 @@ namespace HTMLInputElement
                 prim__setPattern
                 v
 
-
+  
   export
   placeholder : HTMLInputElement -> Attribute True Prelude.id String
   placeholder v = fromPrim
@@ -2677,7 +2616,7 @@ namespace HTMLInputElement
                     prim__setPlaceholder
                     v
 
-
+  
   export
   readOnly : HTMLInputElement -> Attribute True Prelude.id Bool
   readOnly v = fromPrim
@@ -2686,7 +2625,7 @@ namespace HTMLInputElement
                  prim__setReadOnly
                  v
 
-
+  
   export
   required : HTMLInputElement -> Attribute True Prelude.id Bool
   required v = fromPrim
@@ -2695,7 +2634,7 @@ namespace HTMLInputElement
                  prim__setRequired
                  v
 
-
+  
   export
   selectionDirection : HTMLInputElement -> Attribute False Maybe String
   selectionDirection v = fromNullablePrim
@@ -2704,7 +2643,7 @@ namespace HTMLInputElement
                            prim__setSelectionDirection
                            v
 
-
+  
   export
   selectionEnd : HTMLInputElement -> Attribute False Maybe Bits32
   selectionEnd v = fromNullablePrim
@@ -2713,7 +2652,7 @@ namespace HTMLInputElement
                      prim__setSelectionEnd
                      v
 
-
+  
   export
   selectionStart : HTMLInputElement -> Attribute False Maybe Bits32
   selectionStart v = fromNullablePrim
@@ -2722,27 +2661,27 @@ namespace HTMLInputElement
                        prim__setSelectionStart
                        v
 
-
+  
   export
   size : HTMLInputElement -> Attribute True Prelude.id Bits32
   size v = fromPrim "HTMLInputElement.getsize" prim__size prim__setSize v
 
-
+  
   export
   src : HTMLInputElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLInputElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   step : HTMLInputElement -> Attribute True Prelude.id String
   step v = fromPrim "HTMLInputElement.getstep" prim__step prim__setStep v
 
-
+  
   export
   type : HTMLInputElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLInputElement.gettype" prim__type prim__setType v
 
-
+  
   export
   useMap : HTMLInputElement -> Attribute True Prelude.id String
   useMap v = fromPrim
@@ -2751,22 +2690,22 @@ namespace HTMLInputElement
                prim__setUseMap
                v
 
-
+  
   export
   validationMessage : (obj : HTMLInputElement) -> JSIO String
   validationMessage a = primJS $ HTMLInputElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLInputElement) -> JSIO ValidityState
   validity a = primJS $ HTMLInputElement.prim__validity a
 
-
+  
   export
   value : HTMLInputElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLInputElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   valueAsDate : HTMLInputElement -> Attribute False Maybe Object
   valueAsDate v = fromNullablePrim
@@ -2775,7 +2714,7 @@ namespace HTMLInputElement
                     prim__setValueAsDate
                     v
 
-
+  
   export
   valueAsNumber : HTMLInputElement -> Attribute True Prelude.id Double
   valueAsNumber v = fromPrim
@@ -2784,45 +2723,45 @@ namespace HTMLInputElement
                       prim__setValueAsNumber
                       v
 
-
+  
   export
   width : HTMLInputElement -> Attribute True Prelude.id Bits32
   width v = fromPrim "HTMLInputElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   willValidate : (obj : HTMLInputElement) -> JSIO Bool
   willValidate a = tryJS "HTMLInputElement.willValidate" $
     HTMLInputElement.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : HTMLInputElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLInputElement.checkValidity" $
     HTMLInputElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLInputElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLInputElement.reportValidity" $
     HTMLInputElement.prim__reportValidity a
 
-
+  
   export
   select : (obj : HTMLInputElement) -> JSIO ()
   select a = primJS $ HTMLInputElement.prim__select a
 
-
+  
   export
   setCustomValidity : (obj : HTMLInputElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $ HTMLInputElement.prim__setCustomValidity a b
 
-
+  
   export
   setRangeText : (obj : HTMLInputElement) -> (replacement : String) -> JSIO ()
   setRangeText a b = primJS $ HTMLInputElement.prim__setRangeText a b
 
-
+  
   export
   setRangeText1' :
        (obj : HTMLInputElement)
@@ -2833,7 +2772,7 @@ namespace HTMLInputElement
     -> JSIO ()
   setRangeText1' a b c d e = primJS $
     HTMLInputElement.prim__setRangeText1 a b c d (toFFI e)
-
+  
   export
   setRangeText1 :
        (obj : HTMLInputElement)
@@ -2844,7 +2783,7 @@ namespace HTMLInputElement
   setRangeText1 a b c d = primJS $
     HTMLInputElement.prim__setRangeText1 a b c d undef
 
-
+  
   export
   setSelectionRange' :
        (obj : HTMLInputElement)
@@ -2854,7 +2793,7 @@ namespace HTMLInputElement
     -> JSIO ()
   setSelectionRange' a b c d = primJS $
     HTMLInputElement.prim__setSelectionRange a b c (toFFI d)
-
+  
   export
   setSelectionRange :
        (obj : HTMLInputElement)
@@ -2864,20 +2803,20 @@ namespace HTMLInputElement
   setSelectionRange a b c = primJS $
     HTMLInputElement.prim__setSelectionRange a b c undef
 
-
+  
   export
   stepDown' : (obj : HTMLInputElement) -> (n : Optional Int32) -> JSIO ()
   stepDown' a b = primJS $ HTMLInputElement.prim__stepDown a (toFFI b)
-
+  
   export
   stepDown : (obj : HTMLInputElement) -> JSIO ()
   stepDown a = primJS $ HTMLInputElement.prim__stepDown a undef
 
-
+  
   export
   stepUp' : (obj : HTMLInputElement) -> (n : Optional Int32) -> JSIO ()
   stepUp' a b = primJS $ HTMLInputElement.prim__stepUp a (toFFI b)
-
+  
   export
   stepUp : (obj : HTMLInputElement) -> JSIO ()
   stepUp a = primJS $ HTMLInputElement.prim__stepUp a undef
@@ -2885,17 +2824,17 @@ namespace HTMLInputElement
 
 
 namespace HTMLLIElement
-
+  
   export
   new : JSIO HTMLLIElement
   new = primJS $ HTMLLIElement.prim__new
 
-
+  
   export
   type : HTMLLIElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLLIElement.gettype" prim__type prim__setType v
 
-
+  
   export
   value : HTMLLIElement -> Attribute True Prelude.id Int32
   value v = fromPrim "HTMLLIElement.getvalue" prim__value prim__setValue v
@@ -2903,23 +2842,23 @@ namespace HTMLLIElement
 
 
 namespace HTMLLabelElement
-
+  
   export
   new : JSIO HTMLLabelElement
   new = primJS $ HTMLLabelElement.prim__new
 
-
+  
   export
   control : (obj : HTMLLabelElement) -> JSIO (Maybe HTMLElement)
   control a = tryJS "HTMLLabelElement.control" $
     HTMLLabelElement.prim__control a
 
-
+  
   export
   form : (obj : HTMLLabelElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLLabelElement.form" $ HTMLLabelElement.prim__form a
 
-
+  
   export
   htmlFor : HTMLLabelElement -> Attribute True Prelude.id String
   htmlFor v = fromPrim
@@ -2931,17 +2870,17 @@ namespace HTMLLabelElement
 
 
 namespace HTMLLegendElement
-
+  
   export
   new : JSIO HTMLLegendElement
   new = primJS $ HTMLLegendElement.prim__new
 
-
+  
   export
   align : HTMLLegendElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLLegendElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   form : (obj : HTMLLegendElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLLegendElement.form" $ HTMLLegendElement.prim__form a
@@ -2949,17 +2888,17 @@ namespace HTMLLegendElement
 
 
 namespace HTMLLinkElement
-
+  
   export
   new : JSIO HTMLLinkElement
   new = primJS $ HTMLLinkElement.prim__new
 
-
+  
   export
   as : HTMLLinkElement -> Attribute True Prelude.id String
   as v = fromPrim "HTMLLinkElement.getas" prim__as prim__setAs v
 
-
+  
   export
   charset : HTMLLinkElement -> Attribute True Prelude.id String
   charset v = fromPrim
@@ -2968,7 +2907,7 @@ namespace HTMLLinkElement
                 prim__setCharset
                 v
 
-
+  
   export
   crossOrigin : HTMLLinkElement -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
@@ -2977,7 +2916,7 @@ namespace HTMLLinkElement
                     prim__setCrossOrigin
                     v
 
-
+  
   export
   disabled : HTMLLinkElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -2986,12 +2925,12 @@ namespace HTMLLinkElement
                  prim__setDisabled
                  v
 
-
+  
   export
   href : HTMLLinkElement -> Attribute True Prelude.id String
   href v = fromPrim "HTMLLinkElement.gethref" prim__href prim__setHref v
 
-
+  
   export
   hreflang : HTMLLinkElement -> Attribute True Prelude.id String
   hreflang v = fromPrim
@@ -3000,7 +2939,7 @@ namespace HTMLLinkElement
                  prim__setHreflang
                  v
 
-
+  
   export
   imageSizes : HTMLLinkElement -> Attribute True Prelude.id String
   imageSizes v = fromPrim
@@ -3009,7 +2948,7 @@ namespace HTMLLinkElement
                    prim__setImageSizes
                    v
 
-
+  
   export
   imageSrcset : HTMLLinkElement -> Attribute True Prelude.id String
   imageSrcset v = fromPrim
@@ -3018,7 +2957,7 @@ namespace HTMLLinkElement
                     prim__setImageSrcset
                     v
 
-
+  
   export
   integrity : HTMLLinkElement -> Attribute True Prelude.id String
   integrity v = fromPrim
@@ -3027,12 +2966,12 @@ namespace HTMLLinkElement
                   prim__setIntegrity
                   v
 
-
+  
   export
   media : HTMLLinkElement -> Attribute True Prelude.id String
   media v = fromPrim "HTMLLinkElement.getmedia" prim__media prim__setMedia v
 
-
+  
   export
   referrerPolicy : HTMLLinkElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -3041,32 +2980,32 @@ namespace HTMLLinkElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   rel : HTMLLinkElement -> Attribute True Prelude.id String
   rel v = fromPrim "HTMLLinkElement.getrel" prim__rel prim__setRel v
 
-
+  
   export
   relList : (obj : HTMLLinkElement) -> JSIO DOMTokenList
   relList a = primJS $ HTMLLinkElement.prim__relList a
 
-
+  
   export
   rev : HTMLLinkElement -> Attribute True Prelude.id String
   rev v = fromPrim "HTMLLinkElement.getrev" prim__rev prim__setRev v
 
-
+  
   export
   sizes : (obj : HTMLLinkElement) -> JSIO DOMTokenList
   sizes a = primJS $ HTMLLinkElement.prim__sizes a
 
-
+  
   export
   target : HTMLLinkElement -> Attribute True Prelude.id String
   target v = fromPrim "HTMLLinkElement.gettarget" prim__target prim__setTarget v
 
-
+  
   export
   type : HTMLLinkElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLLinkElement.gettype" prim__type prim__setType v
@@ -3074,17 +3013,17 @@ namespace HTMLLinkElement
 
 
 namespace HTMLMapElement
-
+  
   export
   new : JSIO HTMLMapElement
   new = primJS $ HTMLMapElement.prim__new
 
-
+  
   export
   areas : (obj : HTMLMapElement) -> JSIO HTMLCollection
   areas a = primJS $ HTMLMapElement.prim__areas a
 
-
+  
   export
   name : HTMLMapElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLMapElement.getname" prim__name prim__setName v
@@ -3092,12 +3031,12 @@ namespace HTMLMapElement
 
 
 namespace HTMLMarqueeElement
-
+  
   export
   new : JSIO HTMLMarqueeElement
   new = primJS $ HTMLMarqueeElement.prim__new
 
-
+  
   export
   behavior : HTMLMarqueeElement -> Attribute True Prelude.id String
   behavior v = fromPrim
@@ -3106,7 +3045,7 @@ namespace HTMLMarqueeElement
                  prim__setBehavior
                  v
 
-
+  
   export
   bgColor : HTMLMarqueeElement -> Attribute True Prelude.id String
   bgColor v = fromPrim
@@ -3115,7 +3054,7 @@ namespace HTMLMarqueeElement
                 prim__setBgColor
                 v
 
-
+  
   export
   direction : HTMLMarqueeElement -> Attribute True Prelude.id String
   direction v = fromPrim
@@ -3124,7 +3063,7 @@ namespace HTMLMarqueeElement
                   prim__setDirection
                   v
 
-
+  
   export
   height : HTMLMarqueeElement -> Attribute True Prelude.id String
   height v = fromPrim
@@ -3133,7 +3072,7 @@ namespace HTMLMarqueeElement
                prim__setHeight
                v
 
-
+  
   export
   hspace : HTMLMarqueeElement -> Attribute True Prelude.id Bits32
   hspace v = fromPrim
@@ -3142,12 +3081,12 @@ namespace HTMLMarqueeElement
                prim__setHspace
                v
 
-
+  
   export
   loop : HTMLMarqueeElement -> Attribute True Prelude.id Int32
   loop v = fromPrim "HTMLMarqueeElement.getloop" prim__loop prim__setLoop v
 
-
+  
   export
   scrollAmount : HTMLMarqueeElement -> Attribute True Prelude.id Bits32
   scrollAmount v = fromPrim
@@ -3156,7 +3095,7 @@ namespace HTMLMarqueeElement
                      prim__setScrollAmount
                      v
 
-
+  
   export
   scrollDelay : HTMLMarqueeElement -> Attribute True Prelude.id Bits32
   scrollDelay v = fromPrim
@@ -3165,7 +3104,7 @@ namespace HTMLMarqueeElement
                     prim__setScrollDelay
                     v
 
-
+  
   export
   trueSpeed : HTMLMarqueeElement -> Attribute True Prelude.id Bool
   trueSpeed v = fromPrim
@@ -3174,7 +3113,7 @@ namespace HTMLMarqueeElement
                   prim__setTrueSpeed
                   v
 
-
+  
   export
   vspace : HTMLMarqueeElement -> Attribute True Prelude.id Bits32
   vspace v = fromPrim
@@ -3183,17 +3122,17 @@ namespace HTMLMarqueeElement
                prim__setVspace
                v
 
-
+  
   export
   width : HTMLMarqueeElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLMarqueeElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   start : (obj : HTMLMarqueeElement) -> JSIO ()
   start a = primJS $ HTMLMarqueeElement.prim__start a
 
-
+  
   export
   stop : (obj : HTMLMarqueeElement) -> JSIO ()
   stop a = primJS $ HTMLMarqueeElement.prim__stop a
@@ -3201,450 +3140,389 @@ namespace HTMLMarqueeElement
 
 
 namespace HTMLMediaElement
-
-  public export
+  
+  export
   HAVE_CURRENT_DATA : Bits16
   HAVE_CURRENT_DATA = 2
 
-
-  public export
+  
+  export
   HAVE_ENOUGH_DATA : Bits16
   HAVE_ENOUGH_DATA = 4
 
-
-  public export
+  
+  export
   HAVE_FUTURE_DATA : Bits16
   HAVE_FUTURE_DATA = 3
 
-
-  public export
+  
+  export
   HAVE_METADATA : Bits16
   HAVE_METADATA = 1
 
-
-  public export
+  
+  export
   HAVE_NOTHING : Bits16
   HAVE_NOTHING = 0
 
-
-  public export
+  
+  export
   NETWORK_EMPTY : Bits16
   NETWORK_EMPTY = 0
 
-
-  public export
+  
+  export
   NETWORK_IDLE : Bits16
   NETWORK_IDLE = 1
 
-
-  public export
+  
+  export
   NETWORK_LOADING : Bits16
   NETWORK_LOADING = 2
 
-
-  public export
+  
+  export
   NETWORK_NO_SOURCE : Bits16
   NETWORK_NO_SOURCE = 3
 
-
+  
   export
   audioTracks :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO AudioTrackList
-  audioTracks a = primJS $ HTMLMediaElement.prim__audioTracks (up a)
+  audioTracks a = primJS $ HTMLMediaElement.prim__audioTracks (cast a)
 
-
+  
   export
   autoplay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   autoplay v = fromPrim
                  "HTMLMediaElement.getautoplay"
                  prim__autoplay
                  prim__setAutoplay
-                 (v :> HTMLMediaElement)
+                 (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   buffered :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO TimeRanges
-  buffered a = primJS $ HTMLMediaElement.prim__buffered (up a)
+  buffered a = primJS $ HTMLMediaElement.prim__buffered (cast a)
 
-
+  
   export
   controls :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   controls v = fromPrim
                  "HTMLMediaElement.getcontrols"
                  prim__controls
                  prim__setControls
-                 (v :> HTMLMediaElement)
+                 (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   crossOrigin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
                     "HTMLMediaElement.getcrossOrigin"
                     prim__crossOrigin
                     prim__setCrossOrigin
-                    (v :> HTMLMediaElement)
+                    (cast {to = HTMLMediaElement} v)
 
-
+  
   export
-  currentSrc :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  currentSrc a = primJS $ HTMLMediaElement.prim__currentSrc (up a)
+  currentSrc : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO String
+  currentSrc a = primJS $ HTMLMediaElement.prim__currentSrc (cast a)
 
-
+  
   export
   currentTime :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Double
   currentTime v = fromPrim
                     "HTMLMediaElement.getcurrentTime"
                     prim__currentTime
                     prim__setCurrentTime
-                    (v :> HTMLMediaElement)
+                    (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   defaultMuted :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   defaultMuted v = fromPrim
                      "HTMLMediaElement.getdefaultMuted"
                      prim__defaultMuted
                      prim__setDefaultMuted
-                     (v :> HTMLMediaElement)
+                     (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   defaultPlaybackRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Double
   defaultPlaybackRate v = fromPrim
                             "HTMLMediaElement.getdefaultPlaybackRate"
                             prim__defaultPlaybackRate
                             prim__setDefaultPlaybackRate
-                            (v :> HTMLMediaElement)
+                            (cast {to = HTMLMediaElement} v)
 
-
+  
   export
-  duration :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  duration a = primJS $ HTMLMediaElement.prim__duration (up a)
+  duration : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO Double
+  duration a = primJS $ HTMLMediaElement.prim__duration (cast a)
 
-
+  
   export
-  ended :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  ended a = tryJS "HTMLMediaElement.ended" $ HTMLMediaElement.prim__ended (up a)
+  ended : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO Bool
+  ended a = tryJS "HTMLMediaElement.ended" $
+    HTMLMediaElement.prim__ended (cast a)
 
-
+  
   export
   error :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO (Maybe MediaError)
-  error a = tryJS "HTMLMediaElement.error" $ HTMLMediaElement.prim__error (up a)
+  error a = tryJS "HTMLMediaElement.error" $
+    HTMLMediaElement.prim__error (cast a)
 
-
+  
   export
   loop :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   loop v = fromPrim
              "HTMLMediaElement.getloop"
              prim__loop
              prim__setLoop
-             (v :> HTMLMediaElement)
+             (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   muted :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   muted v = fromPrim
               "HTMLMediaElement.getmuted"
               prim__muted
               prim__setMuted
-              (v :> HTMLMediaElement)
+              (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   networkState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO Bits16
-  networkState a = primJS $ HTMLMediaElement.prim__networkState (up a)
+  networkState a = primJS $ HTMLMediaElement.prim__networkState (cast a)
 
-
+  
   export
-  paused :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  paused : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO Bool
   paused a = tryJS "HTMLMediaElement.paused" $
-    HTMLMediaElement.prim__paused (up a)
+    HTMLMediaElement.prim__paused (cast a)
 
-
+  
   export
   playbackRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Double
   playbackRate v = fromPrim
                      "HTMLMediaElement.getplaybackRate"
                      prim__playbackRate
                      prim__setPlaybackRate
-                     (v :> HTMLMediaElement)
+                     (cast {to = HTMLMediaElement} v)
 
-
+  
   export
-  played :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO TimeRanges
-  played a = primJS $ HTMLMediaElement.prim__played (up a)
+  played : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO TimeRanges
+  played a = primJS $ HTMLMediaElement.prim__played (cast a)
 
-
+  
   export
   preload :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id String
   preload v = fromPrim
                 "HTMLMediaElement.getpreload"
                 prim__preload
                 prim__setPreload
-                (v :> HTMLMediaElement)
+                (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   preservesPitch :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Bool
   preservesPitch v = fromPrim
                        "HTMLMediaElement.getpreservesPitch"
                        prim__preservesPitch
                        prim__setPreservesPitch
-                       (v :> HTMLMediaElement)
+                       (cast {to = HTMLMediaElement} v)
 
-
+  
   export
-  readyState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  readyState a = primJS $ HTMLMediaElement.prim__readyState (up a)
+  readyState : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO Bits16
+  readyState a = primJS $ HTMLMediaElement.prim__readyState (cast a)
 
-
+  
   export
   seekable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO TimeRanges
-  seekable a = primJS $ HTMLMediaElement.prim__seekable (up a)
+  seekable a = primJS $ HTMLMediaElement.prim__seekable (cast a)
 
-
+  
   export
-  seeking :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  seeking : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO Bool
   seeking a = tryJS "HTMLMediaElement.seeking" $
-    HTMLMediaElement.prim__seeking (up a)
+    HTMLMediaElement.prim__seeking (cast a)
 
-
+  
   export
   src :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id String
   src v = fromPrim
             "HTMLMediaElement.getsrc"
             prim__src
             prim__setSrc
-            (v :> HTMLMediaElement)
+            (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   srcObject :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute False Maybe (HSum [MediaStream, MediaSource, Blob])
   srcObject v = fromNullablePrim
                   "HTMLMediaElement.getsrcObject"
                   prim__srcObject
                   prim__setSrcObject
-                  (v :> HTMLMediaElement)
+                  (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   textTracks :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO TextTrackList
-  textTracks a = primJS $ HTMLMediaElement.prim__textTracks (up a)
+  textTracks a = primJS $ HTMLMediaElement.prim__textTracks (cast a)
 
-
+  
   export
   videoTracks :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO VideoTrackList
-  videoTracks a = primJS $ HTMLMediaElement.prim__videoTracks (up a)
+  videoTracks a = primJS $ HTMLMediaElement.prim__videoTracks (cast a)
 
-
+  
   export
   volume :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t)}
+       {auto _ : Cast t HTMLMediaElement}
     -> t
     -> Attribute True Prelude.id Double
   volume v = fromPrim
                "HTMLMediaElement.getvolume"
                prim__volume
                prim__setVolume
-               (v :> HTMLMediaElement)
+               (cast {to = HTMLMediaElement} v)
 
-
+  
   export
   addTextTrack' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> (kind : TextTrackKind)
     -> (label : Optional String)
     -> (language : Optional String)
     -> JSIO TextTrack
   addTextTrack' a b c d = primJS $
-    HTMLMediaElement.prim__addTextTrack (up a) (toFFI b) (toFFI c) (toFFI d)
-
+    HTMLMediaElement.prim__addTextTrack (cast a) (toFFI b) (toFFI c) (toFFI d)
+  
   export
   addTextTrack :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> (kind : TextTrackKind)
     -> JSIO TextTrack
   addTextTrack a b = primJS $
-    HTMLMediaElement.prim__addTextTrack (up a) (toFFI b) undef undef
+    HTMLMediaElement.prim__addTextTrack (cast a) (toFFI b) undef undef
 
-
+  
   export
   canPlayType :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> (type : String)
     -> JSIO CanPlayTypeResult
   canPlayType a b = tryJS "HTMLMediaElement.canPlayType" $
-    HTMLMediaElement.prim__canPlayType (up a) b
+    HTMLMediaElement.prim__canPlayType (cast a) b
 
-
+  
   export
   fastSeek :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> (time : Double)
     -> JSIO ()
-  fastSeek a b = primJS $ HTMLMediaElement.prim__fastSeek (up a) b
+  fastSeek a b = primJS $ HTMLMediaElement.prim__fastSeek (cast a) b
 
-
+  
   export
   getStartDate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO Object
-  getStartDate a = primJS $ HTMLMediaElement.prim__getStartDate (up a)
+  getStartDate a = primJS $ HTMLMediaElement.prim__getStartDate (cast a)
 
-
+  
   export
-  load :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  load a = primJS $ HTMLMediaElement.prim__load (up a)
+  load : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO ()
+  load a = primJS $ HTMLMediaElement.prim__load (cast a)
 
-
+  
   export
-  pause :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  pause a = primJS $ HTMLMediaElement.prim__pause (up a)
+  pause : {auto _ : Cast t1 HTMLMediaElement} -> (obj : t1) -> JSIO ()
+  pause a = primJS $ HTMLMediaElement.prim__pause (cast a)
 
-
+  
   export
   play :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLMediaElement (Types t1)}
+       {auto _ : Cast t1 HTMLMediaElement}
     -> (obj : t1)
     -> JSIO (Promise Undefined)
-  play a = primJS $ HTMLMediaElement.prim__play (up a)
+  play a = primJS $ HTMLMediaElement.prim__play (cast a)
 
 
 
 namespace HTMLMenuElement
-
+  
   export
   new : JSIO HTMLMenuElement
   new = primJS $ HTMLMenuElement.prim__new
 
-
+  
   export
   compact : HTMLMenuElement -> Attribute True Prelude.id Bool
   compact v = fromPrim
@@ -3656,12 +3534,12 @@ namespace HTMLMenuElement
 
 
 namespace HTMLMetaElement
-
+  
   export
   new : JSIO HTMLMetaElement
   new = primJS $ HTMLMetaElement.prim__new
 
-
+  
   export
   content : HTMLMetaElement -> Attribute True Prelude.id String
   content v = fromPrim
@@ -3670,7 +3548,7 @@ namespace HTMLMetaElement
                 prim__setContent
                 v
 
-
+  
   export
   httpEquiv : HTMLMetaElement -> Attribute True Prelude.id String
   httpEquiv v = fromPrim
@@ -3679,12 +3557,12 @@ namespace HTMLMetaElement
                   prim__setHttpEquiv
                   v
 
-
+  
   export
   name : HTMLMetaElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLMetaElement.getname" prim__name prim__setName v
 
-
+  
   export
   scheme : HTMLMetaElement -> Attribute True Prelude.id String
   scheme v = fromPrim "HTMLMetaElement.getscheme" prim__scheme prim__setScheme v
@@ -3692,37 +3570,37 @@ namespace HTMLMetaElement
 
 
 namespace HTMLMeterElement
-
+  
   export
   new : JSIO HTMLMeterElement
   new = primJS $ HTMLMeterElement.prim__new
 
-
+  
   export
   high : HTMLMeterElement -> Attribute True Prelude.id Double
   high v = fromPrim "HTMLMeterElement.gethigh" prim__high prim__setHigh v
 
-
+  
   export
   labels : (obj : HTMLMeterElement) -> JSIO NodeList
   labels a = primJS $ HTMLMeterElement.prim__labels a
 
-
+  
   export
   low : HTMLMeterElement -> Attribute True Prelude.id Double
   low v = fromPrim "HTMLMeterElement.getlow" prim__low prim__setLow v
 
-
+  
   export
   max : HTMLMeterElement -> Attribute True Prelude.id Double
   max v = fromPrim "HTMLMeterElement.getmax" prim__max prim__setMax v
 
-
+  
   export
   min : HTMLMeterElement -> Attribute True Prelude.id Double
   min v = fromPrim "HTMLMeterElement.getmin" prim__min prim__setMin v
 
-
+  
   export
   optimum : HTMLMeterElement -> Attribute True Prelude.id Double
   optimum v = fromPrim
@@ -3731,7 +3609,7 @@ namespace HTMLMeterElement
                 prim__setOptimum
                 v
 
-
+  
   export
   value : HTMLMeterElement -> Attribute True Prelude.id Double
   value v = fromPrim "HTMLMeterElement.getvalue" prim__value prim__setValue v
@@ -3739,17 +3617,17 @@ namespace HTMLMeterElement
 
 
 namespace HTMLModElement
-
+  
   export
   new : JSIO HTMLModElement
   new = primJS $ HTMLModElement.prim__new
 
-
+  
   export
   cite : HTMLModElement -> Attribute True Prelude.id String
   cite v = fromPrim "HTMLModElement.getcite" prim__cite prim__setCite v
 
-
+  
   export
   dateTime : HTMLModElement -> Attribute True Prelude.id String
   dateTime v = fromPrim
@@ -3761,12 +3639,12 @@ namespace HTMLModElement
 
 
 namespace HTMLOListElement
-
+  
   export
   new : JSIO HTMLOListElement
   new = primJS $ HTMLOListElement.prim__new
 
-
+  
   export
   compact : HTMLOListElement -> Attribute True Prelude.id Bool
   compact v = fromPrim
@@ -3775,7 +3653,7 @@ namespace HTMLOListElement
                 prim__setCompact
                 v
 
-
+  
   export
   reversed : HTMLOListElement -> Attribute True Prelude.id Bool
   reversed v = fromPrim
@@ -3784,12 +3662,12 @@ namespace HTMLOListElement
                  prim__setReversed
                  v
 
-
+  
   export
   start : HTMLOListElement -> Attribute True Prelude.id Int32
   start v = fromPrim "HTMLOListElement.getstart" prim__start prim__setStart v
 
-
+  
   export
   type : HTMLOListElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLOListElement.gettype" prim__type prim__setType v
@@ -3797,17 +3675,17 @@ namespace HTMLOListElement
 
 
 namespace HTMLObjectElement
-
+  
   export
   new : JSIO HTMLObjectElement
   new = primJS $ HTMLObjectElement.prim__new
 
-
+  
   export
   align : HTMLObjectElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLObjectElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   archive : HTMLObjectElement -> Attribute True Prelude.id String
   archive v = fromPrim
@@ -3816,7 +3694,7 @@ namespace HTMLObjectElement
                 prim__setArchive
                 v
 
-
+  
   export
   border : HTMLObjectElement -> Attribute True Prelude.id String
   border v = fromPrim
@@ -3825,12 +3703,12 @@ namespace HTMLObjectElement
                prim__setBorder
                v
 
-
+  
   export
   code : HTMLObjectElement -> Attribute True Prelude.id String
   code v = fromPrim "HTMLObjectElement.getcode" prim__code prim__setCode v
 
-
+  
   export
   codeBase : HTMLObjectElement -> Attribute True Prelude.id String
   codeBase v = fromPrim
@@ -3839,7 +3717,7 @@ namespace HTMLObjectElement
                  prim__setCodeBase
                  v
 
-
+  
   export
   codeType : HTMLObjectElement -> Attribute True Prelude.id String
   codeType v = fromPrim
@@ -3848,24 +3726,24 @@ namespace HTMLObjectElement
                  prim__setCodeType
                  v
 
-
+  
   export
   contentDocument : (obj : HTMLObjectElement) -> JSIO (Maybe Document)
   contentDocument a = tryJS "HTMLObjectElement.contentDocument" $
     HTMLObjectElement.prim__contentDocument a
 
-
+  
   export
   contentWindow : (obj : HTMLObjectElement) -> JSIO (Maybe WindowProxy)
   contentWindow a = tryJS "HTMLObjectElement.contentWindow" $
     HTMLObjectElement.prim__contentWindow a
 
-
+  
   export
   data_ : HTMLObjectElement -> Attribute True Prelude.id String
   data_ v = fromPrim "HTMLObjectElement.getdata" prim__data prim__setData v
 
-
+  
   export
   declare : HTMLObjectElement -> Attribute True Prelude.id Bool
   declare v = fromPrim
@@ -3874,12 +3752,12 @@ namespace HTMLObjectElement
                 prim__setDeclare
                 v
 
-
+  
   export
   form : (obj : HTMLObjectElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLObjectElement.form" $ HTMLObjectElement.prim__form a
 
-
+  
   export
   height : HTMLObjectElement -> Attribute True Prelude.id String
   height v = fromPrim
@@ -3888,7 +3766,7 @@ namespace HTMLObjectElement
                prim__setHeight
                v
 
-
+  
   export
   hspace : HTMLObjectElement -> Attribute True Prelude.id Bits32
   hspace v = fromPrim
@@ -3897,12 +3775,12 @@ namespace HTMLObjectElement
                prim__setHspace
                v
 
-
+  
   export
   name : HTMLObjectElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLObjectElement.getname" prim__name prim__setName v
 
-
+  
   export
   standby : HTMLObjectElement -> Attribute True Prelude.id String
   standby v = fromPrim
@@ -3911,12 +3789,12 @@ namespace HTMLObjectElement
                 prim__setStandby
                 v
 
-
+  
   export
   type : HTMLObjectElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLObjectElement.gettype" prim__type prim__setType v
 
-
+  
   export
   useMap : HTMLObjectElement -> Attribute True Prelude.id String
   useMap v = fromPrim
@@ -3925,17 +3803,17 @@ namespace HTMLObjectElement
                prim__setUseMap
                v
 
-
+  
   export
   validationMessage : (obj : HTMLObjectElement) -> JSIO String
   validationMessage a = primJS $ HTMLObjectElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLObjectElement) -> JSIO ValidityState
   validity a = primJS $ HTMLObjectElement.prim__validity a
 
-
+  
   export
   vspace : HTMLObjectElement -> Attribute True Prelude.id Bits32
   vspace v = fromPrim
@@ -3944,36 +3822,36 @@ namespace HTMLObjectElement
                prim__setVspace
                v
 
-
+  
   export
   width : HTMLObjectElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLObjectElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   willValidate : (obj : HTMLObjectElement) -> JSIO Bool
   willValidate a = tryJS "HTMLObjectElement.willValidate" $
     HTMLObjectElement.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : HTMLObjectElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLObjectElement.checkValidity" $
     HTMLObjectElement.prim__checkValidity a
 
-
+  
   export
   getSVGDocument : (obj : HTMLObjectElement) -> JSIO (Maybe Document)
   getSVGDocument a = tryJS "HTMLObjectElement.getSVGDocument" $
     HTMLObjectElement.prim__getSVGDocument a
 
-
+  
   export
   reportValidity : (obj : HTMLObjectElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLObjectElement.reportValidity" $
     HTMLObjectElement.prim__reportValidity a
 
-
+  
   export
   setCustomValidity : (obj : HTMLObjectElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $ HTMLObjectElement.prim__setCustomValidity a b
@@ -3981,12 +3859,12 @@ namespace HTMLObjectElement
 
 
 namespace HTMLOptGroupElement
-
+  
   export
   new : JSIO HTMLOptGroupElement
   new = primJS $ HTMLOptGroupElement.prim__new
 
-
+  
   export
   disabled : HTMLOptGroupElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -3995,7 +3873,7 @@ namespace HTMLOptGroupElement
                  prim__setDisabled
                  v
 
-
+  
   export
   label : HTMLOptGroupElement -> Attribute True Prelude.id String
   label v = fromPrim "HTMLOptGroupElement.getlabel" prim__label prim__setLabel v
@@ -4003,12 +3881,12 @@ namespace HTMLOptGroupElement
 
 
 namespace HTMLOptionElement
-
+  
   export
   new : JSIO HTMLOptionElement
   new = primJS $ HTMLOptionElement.prim__new
 
-
+  
   export
   defaultSelected : HTMLOptionElement -> Attribute True Prelude.id Bool
   defaultSelected v = fromPrim
@@ -4017,7 +3895,7 @@ namespace HTMLOptionElement
                         prim__setDefaultSelected
                         v
 
-
+  
   export
   disabled : HTMLOptionElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -4026,22 +3904,22 @@ namespace HTMLOptionElement
                  prim__setDisabled
                  v
 
-
+  
   export
   form : (obj : HTMLOptionElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLOptionElement.form" $ HTMLOptionElement.prim__form a
 
-
+  
   export
   index : (obj : HTMLOptionElement) -> JSIO Int32
   index a = primJS $ HTMLOptionElement.prim__index a
 
-
+  
   export
   label : HTMLOptionElement -> Attribute True Prelude.id String
   label v = fromPrim "HTMLOptionElement.getlabel" prim__label prim__setLabel v
 
-
+  
   export
   selected : HTMLOptionElement -> Attribute True Prelude.id Bool
   selected v = fromPrim
@@ -4050,12 +3928,12 @@ namespace HTMLOptionElement
                  prim__setSelected
                  v
 
-
+  
   export
   text : HTMLOptionElement -> Attribute True Prelude.id String
   text v = fromPrim "HTMLOptionElement.gettext" prim__text prim__setText v
 
-
+  
   export
   value : HTMLOptionElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLOptionElement.getvalue" prim__value prim__setValue v
@@ -4063,7 +3941,7 @@ namespace HTMLOptionElement
 
 
 namespace HTMLOptionsCollection
-
+  
   export
   set :
        (obj : HTMLOptionsCollection)
@@ -4072,7 +3950,7 @@ namespace HTMLOptionsCollection
     -> JSIO ()
   set a b c = primJS $ HTMLOptionsCollection.prim__set a b (toFFI c)
 
-
+  
   export
   length : HTMLOptionsCollection -> Attribute True Prelude.id Bits32
   length v = fromPrim
@@ -4081,7 +3959,7 @@ namespace HTMLOptionsCollection
                prim__setLength
                v
 
-
+  
   export
   selectedIndex : HTMLOptionsCollection -> Attribute True Prelude.id Int32
   selectedIndex v = fromPrim
@@ -4090,7 +3968,7 @@ namespace HTMLOptionsCollection
                       prim__setSelectedIndex
                       v
 
-
+  
   export
   add' :
        (obj : HTMLOptionsCollection)
@@ -4098,7 +3976,7 @@ namespace HTMLOptionsCollection
     -> (before : Optional (Maybe (HSum [HTMLElement, Int32])))
     -> JSIO ()
   add' a b c = primJS $ HTMLOptionsCollection.prim__add a (toFFI b) (toFFI c)
-
+  
   export
   add :
        (obj : HTMLOptionsCollection)
@@ -4106,7 +3984,7 @@ namespace HTMLOptionsCollection
     -> JSIO ()
   add a b = primJS $ HTMLOptionsCollection.prim__add a (toFFI b) undef
 
-
+  
   export
   remove : (obj : HTMLOptionsCollection) -> (index : Int32) -> JSIO ()
   remove a b = primJS $ HTMLOptionsCollection.prim__remove a b
@@ -4114,12 +3992,12 @@ namespace HTMLOptionsCollection
 
 
 namespace HTMLOutputElement
-
+  
   export
   new : JSIO HTMLOutputElement
   new = primJS $ HTMLOutputElement.prim__new
 
-
+  
   export
   defaultValue : HTMLOutputElement -> Attribute True Prelude.id String
   defaultValue v = fromPrim
@@ -4128,65 +4006,65 @@ namespace HTMLOutputElement
                      prim__setDefaultValue
                      v
 
-
+  
   export
   form : (obj : HTMLOutputElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLOutputElement.form" $ HTMLOutputElement.prim__form a
 
-
+  
   export
   htmlFor : (obj : HTMLOutputElement) -> JSIO DOMTokenList
   htmlFor a = primJS $ HTMLOutputElement.prim__htmlFor a
 
-
+  
   export
   labels : (obj : HTMLOutputElement) -> JSIO NodeList
   labels a = primJS $ HTMLOutputElement.prim__labels a
 
-
+  
   export
   name : HTMLOutputElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLOutputElement.getname" prim__name prim__setName v
 
-
+  
   export
   type : (obj : HTMLOutputElement) -> JSIO String
   type a = primJS $ HTMLOutputElement.prim__type a
 
-
+  
   export
   validationMessage : (obj : HTMLOutputElement) -> JSIO String
   validationMessage a = primJS $ HTMLOutputElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLOutputElement) -> JSIO ValidityState
   validity a = primJS $ HTMLOutputElement.prim__validity a
 
-
+  
   export
   value : HTMLOutputElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLOutputElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   willValidate : (obj : HTMLOutputElement) -> JSIO Bool
   willValidate a = tryJS "HTMLOutputElement.willValidate" $
     HTMLOutputElement.prim__willValidate a
 
-
+  
   export
   checkValidity : (obj : HTMLOutputElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLOutputElement.checkValidity" $
     HTMLOutputElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLOutputElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLOutputElement.reportValidity" $
     HTMLOutputElement.prim__reportValidity a
 
-
+  
   export
   setCustomValidity : (obj : HTMLOutputElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $ HTMLOutputElement.prim__setCustomValidity a b
@@ -4194,12 +4072,12 @@ namespace HTMLOutputElement
 
 
 namespace HTMLParagraphElement
-
+  
   export
   new : JSIO HTMLParagraphElement
   new = primJS $ HTMLParagraphElement.prim__new
 
-
+  
   export
   align : HTMLParagraphElement -> Attribute True Prelude.id String
   align v = fromPrim
@@ -4211,27 +4089,27 @@ namespace HTMLParagraphElement
 
 
 namespace HTMLParamElement
-
+  
   export
   new : JSIO HTMLParamElement
   new = primJS $ HTMLParamElement.prim__new
 
-
+  
   export
   name : HTMLParamElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLParamElement.getname" prim__name prim__setName v
 
-
+  
   export
   type : HTMLParamElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLParamElement.gettype" prim__type prim__setType v
 
-
+  
   export
   value : HTMLParamElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLParamElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   valueType : HTMLParamElement -> Attribute True Prelude.id String
   valueType v = fromPrim
@@ -4243,7 +4121,7 @@ namespace HTMLParamElement
 
 
 namespace HTMLPictureElement
-
+  
   export
   new : JSIO HTMLPictureElement
   new = primJS $ HTMLPictureElement.prim__new
@@ -4251,12 +4129,12 @@ namespace HTMLPictureElement
 
 
 namespace HTMLPreElement
-
+  
   export
   new : JSIO HTMLPreElement
   new = primJS $ HTMLPreElement.prim__new
 
-
+  
   export
   width : HTMLPreElement -> Attribute True Prelude.id Int32
   width v = fromPrim "HTMLPreElement.getwidth" prim__width prim__setWidth v
@@ -4264,27 +4142,27 @@ namespace HTMLPreElement
 
 
 namespace HTMLProgressElement
-
+  
   export
   new : JSIO HTMLProgressElement
   new = primJS $ HTMLProgressElement.prim__new
 
-
+  
   export
   labels : (obj : HTMLProgressElement) -> JSIO NodeList
   labels a = primJS $ HTMLProgressElement.prim__labels a
 
-
+  
   export
   max : HTMLProgressElement -> Attribute True Prelude.id Double
   max v = fromPrim "HTMLProgressElement.getmax" prim__max prim__setMax v
 
-
+  
   export
   position : (obj : HTMLProgressElement) -> JSIO Double
   position a = primJS $ HTMLProgressElement.prim__position a
 
-
+  
   export
   value : HTMLProgressElement -> Attribute True Prelude.id Double
   value v = fromPrim "HTMLProgressElement.getvalue" prim__value prim__setValue v
@@ -4292,12 +4170,12 @@ namespace HTMLProgressElement
 
 
 namespace HTMLQuoteElement
-
+  
   export
   new : JSIO HTMLQuoteElement
   new = primJS $ HTMLQuoteElement.prim__new
 
-
+  
   export
   cite : HTMLQuoteElement -> Attribute True Prelude.id String
   cite v = fromPrim "HTMLQuoteElement.getcite" prim__cite prim__setCite v
@@ -4305,17 +4183,17 @@ namespace HTMLQuoteElement
 
 
 namespace HTMLScriptElement
-
+  
   export
   new : JSIO HTMLScriptElement
   new = primJS $ HTMLScriptElement.prim__new
 
-
+  
   export
   async : HTMLScriptElement -> Attribute True Prelude.id Bool
   async v = fromPrim "HTMLScriptElement.getasync" prim__async prim__setAsync v
 
-
+  
   export
   charset : HTMLScriptElement -> Attribute True Prelude.id String
   charset v = fromPrim
@@ -4324,7 +4202,7 @@ namespace HTMLScriptElement
                 prim__setCharset
                 v
 
-
+  
   export
   crossOrigin : HTMLScriptElement -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
@@ -4333,17 +4211,17 @@ namespace HTMLScriptElement
                     prim__setCrossOrigin
                     v
 
-
+  
   export
   defer : HTMLScriptElement -> Attribute True Prelude.id Bool
   defer v = fromPrim "HTMLScriptElement.getdefer" prim__defer prim__setDefer v
 
-
+  
   export
   event : HTMLScriptElement -> Attribute True Prelude.id String
   event v = fromPrim "HTMLScriptElement.getevent" prim__event prim__setEvent v
 
-
+  
   export
   htmlFor : HTMLScriptElement -> Attribute True Prelude.id String
   htmlFor v = fromPrim
@@ -4352,7 +4230,7 @@ namespace HTMLScriptElement
                 prim__setHtmlFor
                 v
 
-
+  
   export
   integrity : HTMLScriptElement -> Attribute True Prelude.id String
   integrity v = fromPrim
@@ -4361,7 +4239,7 @@ namespace HTMLScriptElement
                   prim__setIntegrity
                   v
 
-
+  
   export
   noModule : HTMLScriptElement -> Attribute True Prelude.id Bool
   noModule v = fromPrim
@@ -4370,7 +4248,7 @@ namespace HTMLScriptElement
                  prim__setNoModule
                  v
 
-
+  
   export
   referrerPolicy : HTMLScriptElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -4379,17 +4257,17 @@ namespace HTMLScriptElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   src : HTMLScriptElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLScriptElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   text : HTMLScriptElement -> Attribute True Prelude.id String
   text v = fromPrim "HTMLScriptElement.gettext" prim__text prim__setText v
 
-
+  
   export
   type : HTMLScriptElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLScriptElement.gettype" prim__type prim__setType v
@@ -4397,12 +4275,12 @@ namespace HTMLScriptElement
 
 
 namespace HTMLSelectElement
-
+  
   export
   new : JSIO HTMLSelectElement
   new = primJS $ HTMLSelectElement.prim__new
 
-
+  
   export
   set :
        (obj : HTMLSelectElement)
@@ -4411,7 +4289,7 @@ namespace HTMLSelectElement
     -> JSIO ()
   set a b c = primJS $ HTMLSelectElement.prim__set a b (toFFI c)
 
-
+  
   export
   autocomplete : HTMLSelectElement -> Attribute True Prelude.id String
   autocomplete v = fromPrim
@@ -4420,7 +4298,7 @@ namespace HTMLSelectElement
                      prim__setAutocomplete
                      v
 
-
+  
   export
   disabled : HTMLSelectElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -4429,17 +4307,17 @@ namespace HTMLSelectElement
                  prim__setDisabled
                  v
 
-
+  
   export
   form : (obj : HTMLSelectElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLSelectElement.form" $ HTMLSelectElement.prim__form a
 
-
+  
   export
   labels : (obj : HTMLSelectElement) -> JSIO NodeList
   labels a = primJS $ HTMLSelectElement.prim__labels a
 
-
+  
   export
   length : HTMLSelectElement -> Attribute True Prelude.id Bits32
   length v = fromPrim
@@ -4448,7 +4326,7 @@ namespace HTMLSelectElement
                prim__setLength
                v
 
-
+  
   export
   multiple : HTMLSelectElement -> Attribute True Prelude.id Bool
   multiple v = fromPrim
@@ -4457,17 +4335,17 @@ namespace HTMLSelectElement
                  prim__setMultiple
                  v
 
-
+  
   export
   name : HTMLSelectElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLSelectElement.getname" prim__name prim__setName v
 
-
+  
   export
   options : (obj : HTMLSelectElement) -> JSIO HTMLOptionsCollection
   options a = primJS $ HTMLSelectElement.prim__options a
 
-
+  
   export
   required : HTMLSelectElement -> Attribute True Prelude.id Bool
   required v = fromPrim
@@ -4476,7 +4354,7 @@ namespace HTMLSelectElement
                  prim__setRequired
                  v
 
-
+  
   export
   selectedIndex : HTMLSelectElement -> Attribute True Prelude.id Int32
   selectedIndex v = fromPrim
@@ -4485,43 +4363,43 @@ namespace HTMLSelectElement
                       prim__setSelectedIndex
                       v
 
-
+  
   export
   selectedOptions : (obj : HTMLSelectElement) -> JSIO HTMLCollection
   selectedOptions a = primJS $ HTMLSelectElement.prim__selectedOptions a
 
-
+  
   export
   size : HTMLSelectElement -> Attribute True Prelude.id Bits32
   size v = fromPrim "HTMLSelectElement.getsize" prim__size prim__setSize v
 
-
+  
   export
   type : (obj : HTMLSelectElement) -> JSIO String
   type a = primJS $ HTMLSelectElement.prim__type a
 
-
+  
   export
   validationMessage : (obj : HTMLSelectElement) -> JSIO String
   validationMessage a = primJS $ HTMLSelectElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLSelectElement) -> JSIO ValidityState
   validity a = primJS $ HTMLSelectElement.prim__validity a
 
-
+  
   export
   value : HTMLSelectElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLSelectElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   willValidate : (obj : HTMLSelectElement) -> JSIO Bool
   willValidate a = tryJS "HTMLSelectElement.willValidate" $
     HTMLSelectElement.prim__willValidate a
 
-
+  
   export
   add' :
        (obj : HTMLSelectElement)
@@ -4529,7 +4407,7 @@ namespace HTMLSelectElement
     -> (before : Optional (Maybe (HSum [HTMLElement, Int32])))
     -> JSIO ()
   add' a b c = primJS $ HTMLSelectElement.prim__add a (toFFI b) (toFFI c)
-
+  
   export
   add :
        (obj : HTMLSelectElement)
@@ -4537,18 +4415,18 @@ namespace HTMLSelectElement
     -> JSIO ()
   add a b = primJS $ HTMLSelectElement.prim__add a (toFFI b) undef
 
-
+  
   export
   checkValidity : (obj : HTMLSelectElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLSelectElement.checkValidity" $
     HTMLSelectElement.prim__checkValidity a
 
-
+  
   export
   item : (obj : HTMLSelectElement) -> (index : Bits32) -> JSIO (Maybe Element)
   item a b = tryJS "HTMLSelectElement.item" $ HTMLSelectElement.prim__item a b
 
-
+  
   export
   namedItem :
        (obj : HTMLSelectElement)
@@ -4557,23 +4435,23 @@ namespace HTMLSelectElement
   namedItem a b = tryJS "HTMLSelectElement.namedItem" $
     HTMLSelectElement.prim__namedItem a b
 
-
+  
   export
   remove : (obj : HTMLSelectElement) -> JSIO ()
   remove a = primJS $ HTMLSelectElement.prim__remove a
 
-
+  
   export
   remove1 : (obj : HTMLSelectElement) -> (index : Int32) -> JSIO ()
   remove1 a b = primJS $ HTMLSelectElement.prim__remove1 a b
 
-
+  
   export
   reportValidity : (obj : HTMLSelectElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLSelectElement.reportValidity" $
     HTMLSelectElement.prim__reportValidity a
 
-
+  
   export
   setCustomValidity : (obj : HTMLSelectElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $ HTMLSelectElement.prim__setCustomValidity a b
@@ -4581,41 +4459,39 @@ namespace HTMLSelectElement
 
 
 namespace HTMLSlotElement
-
+  
   export
   new : JSIO HTMLSlotElement
   new = primJS $ HTMLSlotElement.prim__new
 
-
+  
   export
   name : HTMLSlotElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLSlotElement.getname" prim__name prim__setName v
 
-
+  
   export
   assignedElements' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem AssignedNodesOptions (Types t2)}
+       {auto _ : Cast t2 AssignedNodesOptions}
     -> (obj : HTMLSlotElement)
     -> (options : Optional t2)
     -> JSIO (Array Element)
   assignedElements' a b = primJS $
     HTMLSlotElement.prim__assignedElements a (optUp b)
-
+  
   export
   assignedElements : (obj : HTMLSlotElement) -> JSIO (Array Element)
   assignedElements a = primJS $ HTMLSlotElement.prim__assignedElements a undef
 
-
+  
   export
   assignedNodes' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem AssignedNodesOptions (Types t2)}
+       {auto _ : Cast t2 AssignedNodesOptions}
     -> (obj : HTMLSlotElement)
     -> (options : Optional t2)
     -> JSIO (Array Node)
   assignedNodes' a b = primJS $ HTMLSlotElement.prim__assignedNodes a (optUp b)
-
+  
   export
   assignedNodes : (obj : HTMLSlotElement) -> JSIO (Array Node)
   assignedNodes a = primJS $ HTMLSlotElement.prim__assignedNodes a undef
@@ -4623,12 +4499,12 @@ namespace HTMLSlotElement
 
 
 namespace HTMLSourceElement
-
+  
   export
   new : JSIO HTMLSourceElement
   new = primJS $ HTMLSourceElement.prim__new
 
-
+  
   export
   height : HTMLSourceElement -> Attribute True Prelude.id Bits32
   height v = fromPrim
@@ -4637,22 +4513,22 @@ namespace HTMLSourceElement
                prim__setHeight
                v
 
-
+  
   export
   media : HTMLSourceElement -> Attribute True Prelude.id String
   media v = fromPrim "HTMLSourceElement.getmedia" prim__media prim__setMedia v
 
-
+  
   export
   sizes : HTMLSourceElement -> Attribute True Prelude.id String
   sizes v = fromPrim "HTMLSourceElement.getsizes" prim__sizes prim__setSizes v
 
-
+  
   export
   src : HTMLSourceElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLSourceElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   srcset : HTMLSourceElement -> Attribute True Prelude.id String
   srcset v = fromPrim
@@ -4661,12 +4537,12 @@ namespace HTMLSourceElement
                prim__setSrcset
                v
 
-
+  
   export
   type : HTMLSourceElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLSourceElement.gettype" prim__type prim__setType v
 
-
+  
   export
   width : HTMLSourceElement -> Attribute True Prelude.id Bits32
   width v = fromPrim "HTMLSourceElement.getwidth" prim__width prim__setWidth v
@@ -4674,7 +4550,7 @@ namespace HTMLSourceElement
 
 
 namespace HTMLSpanElement
-
+  
   export
   new : JSIO HTMLSpanElement
   new = primJS $ HTMLSpanElement.prim__new
@@ -4682,17 +4558,17 @@ namespace HTMLSpanElement
 
 
 namespace HTMLStyleElement
-
+  
   export
   new : JSIO HTMLStyleElement
   new = primJS $ HTMLStyleElement.prim__new
 
-
+  
   export
   media : HTMLStyleElement -> Attribute True Prelude.id String
   media v = fromPrim "HTMLStyleElement.getmedia" prim__media prim__setMedia v
 
-
+  
   export
   type : HTMLStyleElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLStyleElement.gettype" prim__type prim__setType v
@@ -4700,12 +4576,12 @@ namespace HTMLStyleElement
 
 
 namespace HTMLTableCaptionElement
-
+  
   export
   new : JSIO HTMLTableCaptionElement
   new = primJS $ HTMLTableCaptionElement.prim__new
 
-
+  
   export
   align : HTMLTableCaptionElement -> Attribute True Prelude.id String
   align v = fromPrim
@@ -4717,17 +4593,17 @@ namespace HTMLTableCaptionElement
 
 
 namespace HTMLTableCellElement
-
+  
   export
   new : JSIO HTMLTableCellElement
   new = primJS $ HTMLTableCellElement.prim__new
 
-
+  
   export
   abbr : HTMLTableCellElement -> Attribute True Prelude.id String
   abbr v = fromPrim "HTMLTableCellElement.getabbr" prim__abbr prim__setAbbr v
 
-
+  
   export
   align : HTMLTableCellElement -> Attribute True Prelude.id String
   align v = fromPrim
@@ -4736,12 +4612,12 @@ namespace HTMLTableCellElement
               prim__setAlign
               v
 
-
+  
   export
   axis : HTMLTableCellElement -> Attribute True Prelude.id String
   axis v = fromPrim "HTMLTableCellElement.getaxis" prim__axis prim__setAxis v
 
-
+  
   export
   bgColor : HTMLTableCellElement -> Attribute True Prelude.id String
   bgColor v = fromPrim
@@ -4750,17 +4626,17 @@ namespace HTMLTableCellElement
                 prim__setBgColor
                 v
 
-
+  
   export
   cellIndex : (obj : HTMLTableCellElement) -> JSIO Int32
   cellIndex a = primJS $ HTMLTableCellElement.prim__cellIndex a
 
-
+  
   export
   ch : HTMLTableCellElement -> Attribute True Prelude.id String
   ch v = fromPrim "HTMLTableCellElement.getch" prim__ch prim__setCh v
 
-
+  
   export
   chOff : HTMLTableCellElement -> Attribute True Prelude.id String
   chOff v = fromPrim
@@ -4769,7 +4645,7 @@ namespace HTMLTableCellElement
               prim__setChOff
               v
 
-
+  
   export
   colSpan : HTMLTableCellElement -> Attribute True Prelude.id Bits32
   colSpan v = fromPrim
@@ -4778,7 +4654,7 @@ namespace HTMLTableCellElement
                 prim__setColSpan
                 v
 
-
+  
   export
   headers : HTMLTableCellElement -> Attribute True Prelude.id String
   headers v = fromPrim
@@ -4787,7 +4663,7 @@ namespace HTMLTableCellElement
                 prim__setHeaders
                 v
 
-
+  
   export
   height : HTMLTableCellElement -> Attribute True Prelude.id String
   height v = fromPrim
@@ -4796,7 +4672,7 @@ namespace HTMLTableCellElement
                prim__setHeight
                v
 
-
+  
   export
   noWrap : HTMLTableCellElement -> Attribute True Prelude.id Bool
   noWrap v = fromPrim
@@ -4805,7 +4681,7 @@ namespace HTMLTableCellElement
                prim__setNoWrap
                v
 
-
+  
   export
   rowSpan : HTMLTableCellElement -> Attribute True Prelude.id Bits32
   rowSpan v = fromPrim
@@ -4814,7 +4690,7 @@ namespace HTMLTableCellElement
                 prim__setRowSpan
                 v
 
-
+  
   export
   scope : HTMLTableCellElement -> Attribute True Prelude.id String
   scope v = fromPrim
@@ -4823,7 +4699,7 @@ namespace HTMLTableCellElement
               prim__setScope
               v
 
-
+  
   export
   vAlign : HTMLTableCellElement -> Attribute True Prelude.id String
   vAlign v = fromPrim
@@ -4832,7 +4708,7 @@ namespace HTMLTableCellElement
                prim__setVAlign
                v
 
-
+  
   export
   width : HTMLTableCellElement -> Attribute True Prelude.id String
   width v = fromPrim
@@ -4844,32 +4720,32 @@ namespace HTMLTableCellElement
 
 
 namespace HTMLTableColElement
-
+  
   export
   new : JSIO HTMLTableColElement
   new = primJS $ HTMLTableColElement.prim__new
 
-
+  
   export
   align : HTMLTableColElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLTableColElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   ch : HTMLTableColElement -> Attribute True Prelude.id String
   ch v = fromPrim "HTMLTableColElement.getch" prim__ch prim__setCh v
 
-
+  
   export
   chOff : HTMLTableColElement -> Attribute True Prelude.id String
   chOff v = fromPrim "HTMLTableColElement.getchOff" prim__chOff prim__setChOff v
 
-
+  
   export
   span : HTMLTableColElement -> Attribute True Prelude.id Bits32
   span v = fromPrim "HTMLTableColElement.getspan" prim__span prim__setSpan v
 
-
+  
   export
   vAlign : HTMLTableColElement -> Attribute True Prelude.id String
   vAlign v = fromPrim
@@ -4878,7 +4754,7 @@ namespace HTMLTableColElement
                prim__setVAlign
                v
 
-
+  
   export
   width : HTMLTableColElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLTableColElement.getwidth" prim__width prim__setWidth v
@@ -4886,17 +4762,17 @@ namespace HTMLTableColElement
 
 
 namespace HTMLTableElement
-
+  
   export
   new : JSIO HTMLTableElement
   new = primJS $ HTMLTableElement.prim__new
 
-
+  
   export
   align : HTMLTableElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLTableElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   bgColor : HTMLTableElement -> Attribute True Prelude.id String
   bgColor v = fromPrim
@@ -4905,7 +4781,7 @@ namespace HTMLTableElement
                 prim__setBgColor
                 v
 
-
+  
   export
   border : HTMLTableElement -> Attribute True Prelude.id String
   border v = fromPrim
@@ -4914,7 +4790,7 @@ namespace HTMLTableElement
                prim__setBorder
                v
 
-
+  
   export
   caption : HTMLTableElement -> Attribute False Maybe HTMLTableCaptionElement
   caption v = fromNullablePrim
@@ -4923,7 +4799,7 @@ namespace HTMLTableElement
                 prim__setCaption
                 v
 
-
+  
   export
   cellPadding : HTMLTableElement -> Attribute True Prelude.id String
   cellPadding v = fromPrim
@@ -4932,7 +4808,7 @@ namespace HTMLTableElement
                     prim__setCellPadding
                     v
 
-
+  
   export
   cellSpacing : HTMLTableElement -> Attribute True Prelude.id String
   cellSpacing v = fromPrim
@@ -4941,22 +4817,22 @@ namespace HTMLTableElement
                     prim__setCellSpacing
                     v
 
-
+  
   export
   frame : HTMLTableElement -> Attribute True Prelude.id String
   frame v = fromPrim "HTMLTableElement.getframe" prim__frame prim__setFrame v
 
-
+  
   export
   rows : (obj : HTMLTableElement) -> JSIO HTMLCollection
   rows a = primJS $ HTMLTableElement.prim__rows a
 
-
+  
   export
   rules : HTMLTableElement -> Attribute True Prelude.id String
   rules v = fromPrim "HTMLTableElement.getrules" prim__rules prim__setRules v
 
-
+  
   export
   summary : HTMLTableElement -> Attribute True Prelude.id String
   summary v = fromPrim
@@ -4965,12 +4841,12 @@ namespace HTMLTableElement
                 prim__setSummary
                 v
 
-
+  
   export
   tBodies : (obj : HTMLTableElement) -> JSIO HTMLCollection
   tBodies a = primJS $ HTMLTableElement.prim__tBodies a
 
-
+  
   export
   tFoot : HTMLTableElement -> Attribute False Maybe HTMLTableSectionElement
   tFoot v = fromNullablePrim
@@ -4979,7 +4855,7 @@ namespace HTMLTableElement
               prim__setTFoot
               v
 
-
+  
   export
   tHead : HTMLTableElement -> Attribute False Maybe HTMLTableSectionElement
   tHead v = fromNullablePrim
@@ -4988,59 +4864,59 @@ namespace HTMLTableElement
               prim__setTHead
               v
 
-
+  
   export
   width : HTMLTableElement -> Attribute True Prelude.id String
   width v = fromPrim "HTMLTableElement.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   createCaption : (obj : HTMLTableElement) -> JSIO HTMLTableCaptionElement
   createCaption a = primJS $ HTMLTableElement.prim__createCaption a
 
-
+  
   export
   createTBody : (obj : HTMLTableElement) -> JSIO HTMLTableSectionElement
   createTBody a = primJS $ HTMLTableElement.prim__createTBody a
 
-
+  
   export
   createTFoot : (obj : HTMLTableElement) -> JSIO HTMLTableSectionElement
   createTFoot a = primJS $ HTMLTableElement.prim__createTFoot a
 
-
+  
   export
   createTHead : (obj : HTMLTableElement) -> JSIO HTMLTableSectionElement
   createTHead a = primJS $ HTMLTableElement.prim__createTHead a
 
-
+  
   export
   deleteCaption : (obj : HTMLTableElement) -> JSIO ()
   deleteCaption a = primJS $ HTMLTableElement.prim__deleteCaption a
 
-
+  
   export
   deleteRow : (obj : HTMLTableElement) -> (index : Int32) -> JSIO ()
   deleteRow a b = primJS $ HTMLTableElement.prim__deleteRow a b
 
-
+  
   export
   deleteTFoot : (obj : HTMLTableElement) -> JSIO ()
   deleteTFoot a = primJS $ HTMLTableElement.prim__deleteTFoot a
 
-
+  
   export
   deleteTHead : (obj : HTMLTableElement) -> JSIO ()
   deleteTHead a = primJS $ HTMLTableElement.prim__deleteTHead a
 
-
+  
   export
   insertRow' :
        (obj : HTMLTableElement)
     -> (index : Optional Int32)
     -> JSIO HTMLTableRowElement
   insertRow' a b = primJS $ HTMLTableElement.prim__insertRow a (toFFI b)
-
+  
   export
   insertRow : (obj : HTMLTableElement) -> JSIO HTMLTableRowElement
   insertRow a = primJS $ HTMLTableElement.prim__insertRow a undef
@@ -5048,17 +4924,17 @@ namespace HTMLTableElement
 
 
 namespace HTMLTableRowElement
-
+  
   export
   new : JSIO HTMLTableRowElement
   new = primJS $ HTMLTableRowElement.prim__new
 
-
+  
   export
   align : HTMLTableRowElement -> Attribute True Prelude.id String
   align v = fromPrim "HTMLTableRowElement.getalign" prim__align prim__setAlign v
 
-
+  
   export
   bgColor : HTMLTableRowElement -> Attribute True Prelude.id String
   bgColor v = fromPrim
@@ -5067,32 +4943,32 @@ namespace HTMLTableRowElement
                 prim__setBgColor
                 v
 
-
+  
   export
   cells : (obj : HTMLTableRowElement) -> JSIO HTMLCollection
   cells a = primJS $ HTMLTableRowElement.prim__cells a
 
-
+  
   export
   ch : HTMLTableRowElement -> Attribute True Prelude.id String
   ch v = fromPrim "HTMLTableRowElement.getch" prim__ch prim__setCh v
 
-
+  
   export
   chOff : HTMLTableRowElement -> Attribute True Prelude.id String
   chOff v = fromPrim "HTMLTableRowElement.getchOff" prim__chOff prim__setChOff v
 
-
+  
   export
   rowIndex : (obj : HTMLTableRowElement) -> JSIO Int32
   rowIndex a = primJS $ HTMLTableRowElement.prim__rowIndex a
 
-
+  
   export
   sectionRowIndex : (obj : HTMLTableRowElement) -> JSIO Int32
   sectionRowIndex a = primJS $ HTMLTableRowElement.prim__sectionRowIndex a
 
-
+  
   export
   vAlign : HTMLTableRowElement -> Attribute True Prelude.id String
   vAlign v = fromPrim
@@ -5101,19 +4977,19 @@ namespace HTMLTableRowElement
                prim__setVAlign
                v
 
-
+  
   export
   deleteCell : (obj : HTMLTableRowElement) -> (index : Int32) -> JSIO ()
   deleteCell a b = primJS $ HTMLTableRowElement.prim__deleteCell a b
 
-
+  
   export
   insertCell' :
        (obj : HTMLTableRowElement)
     -> (index : Optional Int32)
     -> JSIO HTMLTableCellElement
   insertCell' a b = primJS $ HTMLTableRowElement.prim__insertCell a (toFFI b)
-
+  
   export
   insertCell : (obj : HTMLTableRowElement) -> JSIO HTMLTableCellElement
   insertCell a = primJS $ HTMLTableRowElement.prim__insertCell a undef
@@ -5121,12 +4997,12 @@ namespace HTMLTableRowElement
 
 
 namespace HTMLTableSectionElement
-
+  
   export
   new : JSIO HTMLTableSectionElement
   new = primJS $ HTMLTableSectionElement.prim__new
 
-
+  
   export
   align : HTMLTableSectionElement -> Attribute True Prelude.id String
   align v = fromPrim
@@ -5135,12 +5011,12 @@ namespace HTMLTableSectionElement
               prim__setAlign
               v
 
-
+  
   export
   ch : HTMLTableSectionElement -> Attribute True Prelude.id String
   ch v = fromPrim "HTMLTableSectionElement.getch" prim__ch prim__setCh v
 
-
+  
   export
   chOff : HTMLTableSectionElement -> Attribute True Prelude.id String
   chOff v = fromPrim
@@ -5149,12 +5025,12 @@ namespace HTMLTableSectionElement
               prim__setChOff
               v
 
-
+  
   export
   rows : (obj : HTMLTableSectionElement) -> JSIO HTMLCollection
   rows a = primJS $ HTMLTableSectionElement.prim__rows a
 
-
+  
   export
   vAlign : HTMLTableSectionElement -> Attribute True Prelude.id String
   vAlign v = fromPrim
@@ -5163,19 +5039,19 @@ namespace HTMLTableSectionElement
                prim__setVAlign
                v
 
-
+  
   export
   deleteRow : (obj : HTMLTableSectionElement) -> (index : Int32) -> JSIO ()
   deleteRow a b = primJS $ HTMLTableSectionElement.prim__deleteRow a b
 
-
+  
   export
   insertRow' :
        (obj : HTMLTableSectionElement)
     -> (index : Optional Int32)
     -> JSIO HTMLTableRowElement
   insertRow' a b = primJS $ HTMLTableSectionElement.prim__insertRow a (toFFI b)
-
+  
   export
   insertRow : (obj : HTMLTableSectionElement) -> JSIO HTMLTableRowElement
   insertRow a = primJS $ HTMLTableSectionElement.prim__insertRow a undef
@@ -5183,12 +5059,12 @@ namespace HTMLTableSectionElement
 
 
 namespace HTMLTemplateElement
-
+  
   export
   new : JSIO HTMLTemplateElement
   new = primJS $ HTMLTemplateElement.prim__new
 
-
+  
   export
   content : (obj : HTMLTemplateElement) -> JSIO DocumentFragment
   content a = primJS $ HTMLTemplateElement.prim__content a
@@ -5196,12 +5072,12 @@ namespace HTMLTemplateElement
 
 
 namespace HTMLTextAreaElement
-
+  
   export
   new : JSIO HTMLTextAreaElement
   new = primJS $ HTMLTextAreaElement.prim__new
 
-
+  
   export
   autocomplete : HTMLTextAreaElement -> Attribute True Prelude.id String
   autocomplete v = fromPrim
@@ -5210,12 +5086,12 @@ namespace HTMLTextAreaElement
                      prim__setAutocomplete
                      v
 
-
+  
   export
   cols : HTMLTextAreaElement -> Attribute True Prelude.id Bits32
   cols v = fromPrim "HTMLTextAreaElement.getcols" prim__cols prim__setCols v
 
-
+  
   export
   defaultValue : HTMLTextAreaElement -> Attribute True Prelude.id String
   defaultValue v = fromPrim
@@ -5224,7 +5100,7 @@ namespace HTMLTextAreaElement
                      prim__setDefaultValue
                      v
 
-
+  
   export
   dirName : HTMLTextAreaElement -> Attribute True Prelude.id String
   dirName v = fromPrim
@@ -5233,7 +5109,7 @@ namespace HTMLTextAreaElement
                 prim__setDirName
                 v
 
-
+  
   export
   disabled : HTMLTextAreaElement -> Attribute True Prelude.id Bool
   disabled v = fromPrim
@@ -5242,17 +5118,17 @@ namespace HTMLTextAreaElement
                  prim__setDisabled
                  v
 
-
+  
   export
   form : (obj : HTMLTextAreaElement) -> JSIO (Maybe HTMLFormElement)
   form a = tryJS "HTMLTextAreaElement.form" $ HTMLTextAreaElement.prim__form a
 
-
+  
   export
   labels : (obj : HTMLTextAreaElement) -> JSIO NodeList
   labels a = primJS $ HTMLTextAreaElement.prim__labels a
 
-
+  
   export
   maxLength : HTMLTextAreaElement -> Attribute True Prelude.id Int32
   maxLength v = fromPrim
@@ -5261,7 +5137,7 @@ namespace HTMLTextAreaElement
                   prim__setMaxLength
                   v
 
-
+  
   export
   minLength : HTMLTextAreaElement -> Attribute True Prelude.id Int32
   minLength v = fromPrim
@@ -5270,12 +5146,12 @@ namespace HTMLTextAreaElement
                   prim__setMinLength
                   v
 
-
+  
   export
   name : HTMLTextAreaElement -> Attribute True Prelude.id String
   name v = fromPrim "HTMLTextAreaElement.getname" prim__name prim__setName v
 
-
+  
   export
   placeholder : HTMLTextAreaElement -> Attribute True Prelude.id String
   placeholder v = fromPrim
@@ -5284,7 +5160,7 @@ namespace HTMLTextAreaElement
                     prim__setPlaceholder
                     v
 
-
+  
   export
   readOnly : HTMLTextAreaElement -> Attribute True Prelude.id Bool
   readOnly v = fromPrim
@@ -5293,7 +5169,7 @@ namespace HTMLTextAreaElement
                  prim__setReadOnly
                  v
 
-
+  
   export
   required : HTMLTextAreaElement -> Attribute True Prelude.id Bool
   required v = fromPrim
@@ -5302,12 +5178,12 @@ namespace HTMLTextAreaElement
                  prim__setRequired
                  v
 
-
+  
   export
   rows : HTMLTextAreaElement -> Attribute True Prelude.id Bits32
   rows v = fromPrim "HTMLTextAreaElement.getrows" prim__rows prim__setRows v
 
-
+  
   export
   selectionDirection : HTMLTextAreaElement -> Attribute True Prelude.id String
   selectionDirection v = fromPrim
@@ -5316,7 +5192,7 @@ namespace HTMLTextAreaElement
                            prim__setSelectionDirection
                            v
 
-
+  
   export
   selectionEnd : HTMLTextAreaElement -> Attribute True Prelude.id Bits32
   selectionEnd v = fromPrim
@@ -5325,7 +5201,7 @@ namespace HTMLTextAreaElement
                      prim__setSelectionEnd
                      v
 
-
+  
   export
   selectionStart : HTMLTextAreaElement -> Attribute True Prelude.id Bits32
   selectionStart v = fromPrim
@@ -5334,66 +5210,66 @@ namespace HTMLTextAreaElement
                        prim__setSelectionStart
                        v
 
-
+  
   export
   textLength : (obj : HTMLTextAreaElement) -> JSIO Bits32
   textLength a = primJS $ HTMLTextAreaElement.prim__textLength a
 
-
+  
   export
   type : (obj : HTMLTextAreaElement) -> JSIO String
   type a = primJS $ HTMLTextAreaElement.prim__type a
 
-
+  
   export
   validationMessage : (obj : HTMLTextAreaElement) -> JSIO String
   validationMessage a = primJS $ HTMLTextAreaElement.prim__validationMessage a
 
-
+  
   export
   validity : (obj : HTMLTextAreaElement) -> JSIO ValidityState
   validity a = primJS $ HTMLTextAreaElement.prim__validity a
 
-
+  
   export
   value : HTMLTextAreaElement -> Attribute True Prelude.id String
   value v = fromPrim "HTMLTextAreaElement.getvalue" prim__value prim__setValue v
 
-
+  
   export
   willValidate : (obj : HTMLTextAreaElement) -> JSIO Bool
   willValidate a = tryJS "HTMLTextAreaElement.willValidate" $
     HTMLTextAreaElement.prim__willValidate a
 
-
+  
   export
   wrap : HTMLTextAreaElement -> Attribute True Prelude.id String
   wrap v = fromPrim "HTMLTextAreaElement.getwrap" prim__wrap prim__setWrap v
 
-
+  
   export
   checkValidity : (obj : HTMLTextAreaElement) -> JSIO Bool
   checkValidity a = tryJS "HTMLTextAreaElement.checkValidity" $
     HTMLTextAreaElement.prim__checkValidity a
 
-
+  
   export
   reportValidity : (obj : HTMLTextAreaElement) -> JSIO Bool
   reportValidity a = tryJS "HTMLTextAreaElement.reportValidity" $
     HTMLTextAreaElement.prim__reportValidity a
 
-
+  
   export
   select : (obj : HTMLTextAreaElement) -> JSIO ()
   select a = primJS $ HTMLTextAreaElement.prim__select a
 
-
+  
   export
   setCustomValidity : (obj : HTMLTextAreaElement) -> (error : String) -> JSIO ()
   setCustomValidity a b = primJS $
     HTMLTextAreaElement.prim__setCustomValidity a b
 
-
+  
   export
   setRangeText :
        (obj : HTMLTextAreaElement)
@@ -5401,7 +5277,7 @@ namespace HTMLTextAreaElement
     -> JSIO ()
   setRangeText a b = primJS $ HTMLTextAreaElement.prim__setRangeText a b
 
-
+  
   export
   setRangeText1' :
        (obj : HTMLTextAreaElement)
@@ -5412,7 +5288,7 @@ namespace HTMLTextAreaElement
     -> JSIO ()
   setRangeText1' a b c d e = primJS $
     HTMLTextAreaElement.prim__setRangeText1 a b c d (toFFI e)
-
+  
   export
   setRangeText1 :
        (obj : HTMLTextAreaElement)
@@ -5423,7 +5299,7 @@ namespace HTMLTextAreaElement
   setRangeText1 a b c d = primJS $
     HTMLTextAreaElement.prim__setRangeText1 a b c d undef
 
-
+  
   export
   setSelectionRange' :
        (obj : HTMLTextAreaElement)
@@ -5433,7 +5309,7 @@ namespace HTMLTextAreaElement
     -> JSIO ()
   setSelectionRange' a b c d = primJS $
     HTMLTextAreaElement.prim__setSelectionRange a b c (toFFI d)
-
+  
   export
   setSelectionRange :
        (obj : HTMLTextAreaElement)
@@ -5446,12 +5322,12 @@ namespace HTMLTextAreaElement
 
 
 namespace HTMLTimeElement
-
+  
   export
   new : JSIO HTMLTimeElement
   new = primJS $ HTMLTimeElement.prim__new
 
-
+  
   export
   dateTime : HTMLTimeElement -> Attribute True Prelude.id String
   dateTime v = fromPrim
@@ -5463,12 +5339,12 @@ namespace HTMLTimeElement
 
 
 namespace HTMLTitleElement
-
+  
   export
   new : JSIO HTMLTitleElement
   new = primJS $ HTMLTitleElement.prim__new
 
-
+  
   export
   text : HTMLTitleElement -> Attribute True Prelude.id String
   text v = fromPrim "HTMLTitleElement.gettext" prim__text prim__setText v
@@ -5476,32 +5352,32 @@ namespace HTMLTitleElement
 
 
 namespace HTMLTrackElement
-
-  public export
+  
+  export
   ERROR : Bits16
   ERROR = 3
 
-
-  public export
+  
+  export
   LOADED : Bits16
   LOADED = 2
 
-
-  public export
+  
+  export
   LOADING : Bits16
   LOADING = 1
 
-
-  public export
+  
+  export
   NONE : Bits16
   NONE = 0
 
-
+  
   export
   new : JSIO HTMLTrackElement
   new = primJS $ HTMLTrackElement.prim__new
 
-
+  
   export
   default_ : HTMLTrackElement -> Attribute True Prelude.id Bool
   default_ v = fromPrim
@@ -5510,27 +5386,27 @@ namespace HTMLTrackElement
                  prim__setDefault
                  v
 
-
+  
   export
   kind : HTMLTrackElement -> Attribute True Prelude.id String
   kind v = fromPrim "HTMLTrackElement.getkind" prim__kind prim__setKind v
 
-
+  
   export
   label : HTMLTrackElement -> Attribute True Prelude.id String
   label v = fromPrim "HTMLTrackElement.getlabel" prim__label prim__setLabel v
 
-
+  
   export
   readyState : (obj : HTMLTrackElement) -> JSIO Bits16
   readyState a = primJS $ HTMLTrackElement.prim__readyState a
 
-
+  
   export
   src : HTMLTrackElement -> Attribute True Prelude.id String
   src v = fromPrim "HTMLTrackElement.getsrc" prim__src prim__setSrc v
 
-
+  
   export
   srclang : HTMLTrackElement -> Attribute True Prelude.id String
   srclang v = fromPrim
@@ -5539,7 +5415,7 @@ namespace HTMLTrackElement
                 prim__setSrclang
                 v
 
-
+  
   export
   track : (obj : HTMLTrackElement) -> JSIO TextTrack
   track a = primJS $ HTMLTrackElement.prim__track a
@@ -5547,12 +5423,12 @@ namespace HTMLTrackElement
 
 
 namespace HTMLUListElement
-
+  
   export
   new : JSIO HTMLUListElement
   new = primJS $ HTMLUListElement.prim__new
 
-
+  
   export
   compact : HTMLUListElement -> Attribute True Prelude.id Bool
   compact v = fromPrim
@@ -5561,7 +5437,7 @@ namespace HTMLUListElement
                 prim__setCompact
                 v
 
-
+  
   export
   type : HTMLUListElement -> Attribute True Prelude.id String
   type v = fromPrim "HTMLUListElement.gettype" prim__type prim__setType v
@@ -5570,12 +5446,12 @@ namespace HTMLUListElement
 
 
 namespace HTMLVideoElement
-
+  
   export
   new : JSIO HTMLVideoElement
   new = primJS $ HTMLVideoElement.prim__new
 
-
+  
   export
   height : HTMLVideoElement -> Attribute True Prelude.id Bits32
   height v = fromPrim
@@ -5584,7 +5460,7 @@ namespace HTMLVideoElement
                prim__setHeight
                v
 
-
+  
   export
   playsInline : HTMLVideoElement -> Attribute True Prelude.id Bool
   playsInline v = fromPrim
@@ -5593,7 +5469,7 @@ namespace HTMLVideoElement
                     prim__setPlaysInline
                     v
 
-
+  
   export
   poster : HTMLVideoElement -> Attribute True Prelude.id String
   poster v = fromPrim
@@ -5602,17 +5478,17 @@ namespace HTMLVideoElement
                prim__setPoster
                v
 
-
+  
   export
   videoHeight : (obj : HTMLVideoElement) -> JSIO Bits32
   videoHeight a = primJS $ HTMLVideoElement.prim__videoHeight a
 
-
+  
   export
   videoWidth : (obj : HTMLVideoElement) -> JSIO Bits32
   videoWidth a = primJS $ HTMLVideoElement.prim__videoWidth a
 
-
+  
   export
   width : HTMLVideoElement -> Attribute True Prelude.id Bits32
   width v = fromPrim "HTMLVideoElement.getwidth" prim__width prim__setWidth v
@@ -5620,26 +5496,25 @@ namespace HTMLVideoElement
 
 
 namespace HashChangeEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem HashChangeEventInit (Types t2)}
+       {auto _ : Cast t2 HashChangeEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO HashChangeEvent
   new' a b = primJS $ HashChangeEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO HashChangeEvent
   new a = primJS $ HashChangeEvent.prim__new a undef
 
-
+  
   export
   newURL : (obj : HashChangeEvent) -> JSIO String
   newURL a = primJS $ HashChangeEvent.prim__newURL a
 
-
+  
   export
   oldURL : (obj : HashChangeEvent) -> JSIO String
   oldURL a = primJS $ HashChangeEvent.prim__oldURL a
@@ -5647,12 +5522,12 @@ namespace HashChangeEvent
 
 
 namespace History
-
+  
   export
   length : (obj : History) -> JSIO Bits32
   length a = primJS $ History.prim__length a
 
-
+  
   export
   scrollRestoration : History -> Attribute True Prelude.id ScrollRestoration
   scrollRestoration v = fromPrim
@@ -5661,31 +5536,31 @@ namespace History
                           prim__setScrollRestoration
                           v
 
-
+  
   export
   state : (obj : History) -> JSIO Any
   state a = tryJS "History.state" $ History.prim__state a
 
-
+  
   export
   back : (obj : History) -> JSIO ()
   back a = primJS $ History.prim__back a
 
-
+  
   export
   forward : (obj : History) -> JSIO ()
   forward a = primJS $ History.prim__forward a
 
-
+  
   export
   go' : (obj : History) -> (delta : Optional Int32) -> JSIO ()
   go' a b = primJS $ History.prim__go a (toFFI b)
-
+  
   export
   go : (obj : History) -> JSIO ()
   go a = primJS $ History.prim__go a undef
 
-
+  
   export
   pushState' :
        (obj : History)
@@ -5694,12 +5569,12 @@ namespace History
     -> (url : Optional (Maybe String))
     -> JSIO ()
   pushState' a b c d = primJS $ History.prim__pushState a (toFFI b) c (toFFI d)
-
+  
   export
   pushState : (obj : History) -> (data_ : Any) -> (unused : String) -> JSIO ()
   pushState a b c = primJS $ History.prim__pushState a (toFFI b) c undef
 
-
+  
   export
   replaceState' :
        (obj : History)
@@ -5709,7 +5584,7 @@ namespace History
     -> JSIO ()
   replaceState' a b c d = primJS $
     History.prim__replaceState a (toFFI b) c (toFFI d)
-
+  
   export
   replaceState :
        (obj : History)
@@ -5721,17 +5596,17 @@ namespace History
 
 
 namespace ImageBitmap
-
+  
   export
   height : (obj : ImageBitmap) -> JSIO Bits32
   height a = primJS $ ImageBitmap.prim__height a
 
-
+  
   export
   width : (obj : ImageBitmap) -> JSIO Bits32
   width a = primJS $ ImageBitmap.prim__width a
 
-
+  
   export
   close : (obj : ImageBitmap) -> JSIO ()
   close a = primJS $ ImageBitmap.prim__close a
@@ -5739,7 +5614,7 @@ namespace ImageBitmap
 
 
 namespace ImageBitmapRenderingContext
-
+  
   export
   canvas :
        (obj : ImageBitmapRenderingContext)
@@ -5747,7 +5622,7 @@ namespace ImageBitmapRenderingContext
   canvas a = tryJS "ImageBitmapRenderingContext.canvas" $
     ImageBitmapRenderingContext.prim__canvas a
 
-
+  
   export
   transferFromImageBitmap :
        (obj : ImageBitmapRenderingContext)
@@ -5759,12 +5634,12 @@ namespace ImageBitmapRenderingContext
 
 
 namespace ImageData
-
+  
   export
   new : (sw : Bits32) -> (sh : Bits32) -> JSIO ImageData
   new a b = primJS $ ImageData.prim__new a b
 
-
+  
   export
   new1' :
        (data_ : UInt8ClampedArray)
@@ -5772,22 +5647,22 @@ namespace ImageData
     -> (sh : Optional Bits32)
     -> JSIO ImageData
   new1' a b c = primJS $ ImageData.prim__new1 a b (toFFI c)
-
+  
   export
   new1 : (data_ : UInt8ClampedArray) -> (sw : Bits32) -> JSIO ImageData
   new1 a b = primJS $ ImageData.prim__new1 a b undef
 
-
+  
   export
   data_ : (obj : ImageData) -> JSIO UInt8ClampedArray
   data_ a = primJS $ ImageData.prim__data a
 
-
+  
   export
   height : (obj : ImageData) -> JSIO Bits32
   height a = primJS $ ImageData.prim__height a
 
-
+  
   export
   width : (obj : ImageData) -> JSIO Bits32
   width a = primJS $ ImageData.prim__width a
@@ -5795,22 +5670,22 @@ namespace ImageData
 
 
 namespace Location
-
+  
   export
   ancestorOrigins : (obj : Location) -> JSIO DOMStringList
   ancestorOrigins a = primJS $ Location.prim__ancestorOrigins a
 
-
+  
   export
   hash : Location -> Attribute True Prelude.id String
   hash v = fromPrim "Location.gethash" prim__hash prim__setHash v
 
-
+  
   export
   host : Location -> Attribute True Prelude.id String
   host v = fromPrim "Location.gethost" prim__host prim__setHost v
 
-
+  
   export
   hostname : Location -> Attribute True Prelude.id String
   hostname v = fromPrim
@@ -5819,17 +5694,17 @@ namespace Location
                  prim__setHostname
                  v
 
-
+  
   export
   href : Location -> Attribute True Prelude.id String
   href v = fromPrim "Location.gethref" prim__href prim__setHref v
 
-
+  
   export
   origin : (obj : Location) -> JSIO String
   origin a = primJS $ Location.prim__origin a
 
-
+  
   export
   pathname : Location -> Attribute True Prelude.id String
   pathname v = fromPrim
@@ -5838,12 +5713,12 @@ namespace Location
                  prim__setPathname
                  v
 
-
+  
   export
   port : Location -> Attribute True Prelude.id String
   port v = fromPrim "Location.getport" prim__port prim__setPort v
 
-
+  
   export
   protocol : Location -> Attribute True Prelude.id String
   protocol v = fromPrim
@@ -5852,22 +5727,22 @@ namespace Location
                  prim__setProtocol
                  v
 
-
+  
   export
   search : Location -> Attribute True Prelude.id String
   search v = fromPrim "Location.getsearch" prim__search prim__setSearch v
 
-
+  
   export
   assign : (obj : Location) -> (url : String) -> JSIO ()
   assign a b = primJS $ Location.prim__assign a b
 
-
+  
   export
   reload : (obj : Location) -> JSIO ()
   reload a = primJS $ Location.prim__reload a
 
-
+  
   export
   replace : (obj : Location) -> (url : String) -> JSIO ()
   replace a b = primJS $ Location.prim__replace a b
@@ -5875,32 +5750,32 @@ namespace Location
 
 
 namespace MediaError
-
-  public export
+  
+  export
   MEDIA_ERR_ABORTED : Bits16
   MEDIA_ERR_ABORTED = 1
 
-
-  public export
+  
+  export
   MEDIA_ERR_DECODE : Bits16
   MEDIA_ERR_DECODE = 3
 
-
-  public export
+  
+  export
   MEDIA_ERR_NETWORK : Bits16
   MEDIA_ERR_NETWORK = 2
 
-
-  public export
+  
+  export
   MEDIA_ERR_SRC_NOT_SUPPORTED : Bits16
   MEDIA_ERR_SRC_NOT_SUPPORTED = 4
 
-
+  
   export
   code : (obj : MediaError) -> JSIO Bits16
   code a = primJS $ MediaError.prim__code a
 
-
+  
   export
   message : (obj : MediaError) -> JSIO String
   message a = primJS $ MediaError.prim__message a
@@ -5908,17 +5783,17 @@ namespace MediaError
 
 
 namespace MessageChannel
-
+  
   export
   new : JSIO MessageChannel
   new = primJS $ MessageChannel.prim__new
 
-
+  
   export
   port1 : (obj : MessageChannel) -> JSIO MessagePort
   port1 a = primJS $ MessageChannel.prim__port1 a
 
-
+  
   export
   port2 : (obj : MessageChannel) -> JSIO MessagePort
   port2 a = primJS $ MessageChannel.prim__port2 a
@@ -5926,48 +5801,47 @@ namespace MessageChannel
 
 
 namespace MessageEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MessageEventInit (Types t2)}
+       {auto _ : Cast t2 MessageEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO MessageEvent
   new' a b = primJS $ MessageEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO MessageEvent
   new a = primJS $ MessageEvent.prim__new a undef
 
-
+  
   export
   data_ : (obj : MessageEvent) -> JSIO Any
   data_ a = tryJS "MessageEvent.data_" $ MessageEvent.prim__data a
 
-
+  
   export
   lastEventId : (obj : MessageEvent) -> JSIO String
   lastEventId a = primJS $ MessageEvent.prim__lastEventId a
 
-
+  
   export
   origin : (obj : MessageEvent) -> JSIO String
   origin a = primJS $ MessageEvent.prim__origin a
 
-
+  
   export
   ports : (obj : MessageEvent) -> JSIO (Array MessagePort)
   ports a = primJS $ MessageEvent.prim__ports a
 
-
+  
   export
   source :
        (obj : MessageEvent)
     -> JSIO (Maybe (Union3 WindowProxy MessagePort ServiceWorker))
   source a = tryJS "MessageEvent.source" $ MessageEvent.prim__source a
 
-
+  
   export
   initMessageEvent' :
        (obj : MessageEvent)
@@ -5992,7 +5866,7 @@ namespace MessageEvent
       (toFFI g)
       (toFFI h)
       (toFFI i)
-
+  
   export
   initMessageEvent : (obj : MessageEvent) -> (type : String) -> JSIO ()
   initMessageEvent a b = primJS $
@@ -6010,7 +5884,7 @@ namespace MessageEvent
 
 
 namespace MessagePort
-
+  
   export
   onmessage : MessagePort -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
@@ -6019,7 +5893,7 @@ namespace MessagePort
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror : MessagePort -> Attribute False Maybe EventHandlerNonNull
   onmessageerror v = fromNullablePrim
@@ -6028,12 +5902,12 @@ namespace MessagePort
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   close : (obj : MessagePort) -> JSIO ()
   close a = primJS $ MessagePort.prim__close a
 
-
+  
   export
   postMessage :
        (obj : MessagePort)
@@ -6042,23 +5916,22 @@ namespace MessagePort
     -> JSIO ()
   postMessage a b c = primJS $ MessagePort.prim__postMessage a (toFFI b) c
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t3)}
+       {auto _ : Cast t3 PostMessageOptions}
     -> (obj : MessagePort)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $
     MessagePort.prim__postMessage1 a (toFFI b) (optUp c)
-
+  
   export
   postMessage1 : (obj : MessagePort) -> (message : Any) -> JSIO ()
   postMessage1 a b = primJS $ MessagePort.prim__postMessage1 a (toFFI b) undef
 
-
+  
   export
   start : (obj : MessagePort) -> JSIO ()
   start a = primJS $ MessagePort.prim__start a
@@ -6066,22 +5939,22 @@ namespace MessagePort
 
 
 namespace MimeType
-
+  
   export
   description : (obj : MimeType) -> JSIO ()
   description a = primJS $ MimeType.prim__description a
 
-
+  
   export
   enabledPlugin : (obj : MimeType) -> JSIO ()
   enabledPlugin a = primJS $ MimeType.prim__enabledPlugin a
 
-
+  
   export
   suffixes : (obj : MimeType) -> JSIO ()
   suffixes a = primJS $ MimeType.prim__suffixes a
 
-
+  
   export
   type : (obj : MimeType) -> JSIO ()
   type a = primJS $ MimeType.prim__type a
@@ -6089,17 +5962,17 @@ namespace MimeType
 
 
 namespace MimeTypeArray
-
+  
   export
   length : (obj : MimeTypeArray) -> JSIO Bits32
   length a = primJS $ MimeTypeArray.prim__length a
 
-
+  
   export
   item : (obj : MimeTypeArray) -> (index : Bits32) -> JSIO (Maybe Object)
   item a b = tryJS "MimeTypeArray.item" $ MimeTypeArray.prim__item a b
 
-
+  
   export
   namedItem : (obj : MimeTypeArray) -> (name : String) -> JSIO (Maybe Object)
   namedItem a b = tryJS "MimeTypeArray.namedItem" $
@@ -6108,71 +5981,69 @@ namespace MimeTypeArray
 
 
 namespace Navigator
-
+  
   export
   clipboard : (obj : Navigator) -> JSIO Clipboard
   clipboard a = primJS $ Navigator.prim__clipboard a
 
-
+  
   export
   mediaDevices : (obj : Navigator) -> JSIO MediaDevices
   mediaDevices a = primJS $ Navigator.prim__mediaDevices a
 
-
+  
   export
   permissions : (obj : Navigator) -> JSIO Permissions
   permissions a = primJS $ Navigator.prim__permissions a
 
-
+  
   export
   serviceWorker : (obj : Navigator) -> JSIO ServiceWorkerContainer
   serviceWorker a = primJS $ Navigator.prim__serviceWorker a
 
-
+  
   export
   getUserMedia :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MediaStreamConstraints (Types t2)}
+       {auto _ : Cast t2 MediaStreamConstraints}
     -> (obj : Navigator)
     -> (constraints : t2)
     -> (successCallback : NavigatorUserMediaSuccessCallback)
     -> (errorCallback : NavigatorUserMediaErrorCallback)
     -> JSIO ()
-  getUserMedia a b c d = primJS $ Navigator.prim__getUserMedia a (up b) c d
+  getUserMedia a b c d = primJS $ Navigator.prim__getUserMedia a (cast b) c d
 
 
 
 namespace OffscreenCanvas
-
+  
   export
   new : (width : JSBits64) -> (height : JSBits64) -> JSIO OffscreenCanvas
   new a b = primJS $ OffscreenCanvas.prim__new a b
 
-
+  
   export
   height : OffscreenCanvas -> Attribute True Prelude.id JSBits64
   height v = fromPrim "OffscreenCanvas.getheight" prim__height prim__setHeight v
 
-
+  
   export
   width : OffscreenCanvas -> Attribute True Prelude.id JSBits64
   width v = fromPrim "OffscreenCanvas.getwidth" prim__width prim__setWidth v
 
-
+  
   export
   convertToBlob' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ImageEncodeOptions (Types t2)}
+       {auto _ : Cast t2 ImageEncodeOptions}
     -> (obj : OffscreenCanvas)
     -> (options : Optional t2)
     -> JSIO (Promise Blob)
   convertToBlob' a b = primJS $ OffscreenCanvas.prim__convertToBlob a (optUp b)
-
+  
   export
   convertToBlob : (obj : OffscreenCanvas) -> JSIO (Promise Blob)
   convertToBlob a = primJS $ OffscreenCanvas.prim__convertToBlob a undef
 
-
+  
   export
   getContext' :
        (obj : OffscreenCanvas)
@@ -6188,7 +6059,7 @@ namespace OffscreenCanvas
                ]))
   getContext' a b c = tryJS "OffscreenCanvas.getContext'" $
     OffscreenCanvas.prim__getContext a (toFFI b) (toFFI c)
-
+  
   export
   getContext :
        (obj : OffscreenCanvas)
@@ -6204,7 +6075,7 @@ namespace OffscreenCanvas
   getContext a b = tryJS "OffscreenCanvas.getContext" $
     OffscreenCanvas.prim__getContext a (toFFI b) undef
 
-
+  
   export
   transferToImageBitmap : (obj : OffscreenCanvas) -> JSIO ImageBitmap
   transferToImageBitmap a = primJS $
@@ -6213,12 +6084,12 @@ namespace OffscreenCanvas
 
 
 namespace OffscreenCanvasRenderingContext2D
-
+  
   export
   canvas : (obj : OffscreenCanvasRenderingContext2D) -> JSIO OffscreenCanvas
   canvas a = primJS $ OffscreenCanvasRenderingContext2D.prim__canvas a
 
-
+  
   export
   commit : (obj : OffscreenCanvasRenderingContext2D) -> JSIO ()
   commit a = primJS $ OffscreenCanvasRenderingContext2D.prim__commit a
@@ -6226,21 +6097,20 @@ namespace OffscreenCanvasRenderingContext2D
 
 
 namespace PageTransitionEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem PageTransitionEventInit (Types t2)}
+       {auto _ : Cast t2 PageTransitionEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO PageTransitionEvent
   new' a b = primJS $ PageTransitionEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO PageTransitionEvent
   new a = primJS $ PageTransitionEvent.prim__new a undef
 
-
+  
   export
   persisted : (obj : PageTransitionEvent) -> JSIO Bool
   persisted a = tryJS "PageTransitionEvent.persisted" $
@@ -6249,26 +6119,25 @@ namespace PageTransitionEvent
 
 
 namespace Path2D
-
+  
   export
   new' : (path : Optional (HSum [Path2D, String])) -> JSIO Path2D
   new' a = primJS $ Path2D.prim__new (toFFI a)
-
+  
   export
   new : JSIO Path2D
   new = primJS $ Path2D.prim__new undef
 
-
+  
   export
   addPath' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t3)}
+       {auto _ : Cast t3 DOMMatrix2DInit}
     -> (obj : Path2D)
     -> (path : Path2D)
     -> (transform : Optional t3)
     -> JSIO ()
   addPath' a b c = primJS $ Path2D.prim__addPath a b (optUp c)
-
+  
   export
   addPath : (obj : Path2D) -> (path : Path2D) -> JSIO ()
   addPath a b = primJS $ Path2D.prim__addPath a b undef
@@ -6276,32 +6145,32 @@ namespace Path2D
 
 
 namespace Plugin
-
+  
   export
   description : (obj : Plugin) -> JSIO ()
   description a = primJS $ Plugin.prim__description a
 
-
+  
   export
   filename : (obj : Plugin) -> JSIO ()
   filename a = primJS $ Plugin.prim__filename a
 
-
+  
   export
   length : (obj : Plugin) -> JSIO ()
   length a = primJS $ Plugin.prim__length a
 
-
+  
   export
   name : (obj : Plugin) -> JSIO ()
   name a = primJS $ Plugin.prim__name a
 
-
+  
   export
   item : (obj : Plugin) -> (index : Bits32) -> JSIO ()
   item a b = primJS $ Plugin.prim__item a b
 
-
+  
   export
   namedItem : (obj : Plugin) -> (name : String) -> JSIO ()
   namedItem a b = primJS $ Plugin.prim__namedItem a b
@@ -6309,23 +6178,23 @@ namespace Plugin
 
 
 namespace PluginArray
-
+  
   export
   length : (obj : PluginArray) -> JSIO Bits32
   length a = primJS $ PluginArray.prim__length a
 
-
+  
   export
   item : (obj : PluginArray) -> (index : Bits32) -> JSIO (Maybe Object)
   item a b = tryJS "PluginArray.item" $ PluginArray.prim__item a b
 
-
+  
   export
   namedItem : (obj : PluginArray) -> (name : String) -> JSIO (Maybe Object)
   namedItem a b = tryJS "PluginArray.namedItem" $
     PluginArray.prim__namedItem a b
 
-
+  
   export
   refresh : (obj : PluginArray) -> JSIO ()
   refresh a = primJS $ PluginArray.prim__refresh a
@@ -6333,21 +6202,20 @@ namespace PluginArray
 
 
 namespace PopStateEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem PopStateEventInit (Types t2)}
+       {auto _ : Cast t2 PopStateEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO PopStateEvent
   new' a b = primJS $ PopStateEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO PopStateEvent
   new a = primJS $ PopStateEvent.prim__new a undef
 
-
+  
   export
   state : (obj : PopStateEvent) -> JSIO Any
   state a = tryJS "PopStateEvent.state" $ PopStateEvent.prim__state a
@@ -6355,22 +6223,21 @@ namespace PopStateEvent
 
 
 namespace PromiseRejectionEvent
-
+  
   export
   new :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem PromiseRejectionEventInit (Types t2)}
+       {auto _ : Cast t2 PromiseRejectionEventInit}
     -> (type : String)
     -> (eventInitDict : t2)
     -> JSIO PromiseRejectionEvent
-  new a b = primJS $ PromiseRejectionEvent.prim__new a (up b)
+  new a b = primJS $ PromiseRejectionEvent.prim__new a (cast b)
 
-
+  
   export
   promise : (obj : PromiseRejectionEvent) -> JSIO (Promise AnyPtr)
   promise a = primJS $ PromiseRejectionEvent.prim__promise a
 
-
+  
   export
   reason : (obj : PromiseRejectionEvent) -> JSIO Any
   reason a = tryJS "PromiseRejectionEvent.reason" $
@@ -6379,7 +6246,7 @@ namespace PromiseRejectionEvent
 
 
 namespace RadioNodeList
-
+  
   export
   value : RadioNodeList -> Attribute True Prelude.id String
   value v = fromPrim "RadioNodeList.getvalue" prim__value prim__setValue v
@@ -6387,19 +6254,19 @@ namespace RadioNodeList
 
 
 namespace SharedWorker
-
+  
   export
   new' :
        (scriptURL : String)
     -> (options : Optional (HSum [String, WorkerOptions]))
     -> JSIO SharedWorker
   new' a b = primJS $ SharedWorker.prim__new a (toFFI b)
-
+  
   export
   new : (scriptURL : String) -> JSIO SharedWorker
   new a = primJS $ SharedWorker.prim__new a undef
 
-
+  
   export
   port : (obj : SharedWorker) -> JSIO MessagePort
   port a = primJS $ SharedWorker.prim__port a
@@ -6407,12 +6274,12 @@ namespace SharedWorker
 
 
 namespace SharedWorkerGlobalScope
-
+  
   export
   name : (obj : SharedWorkerGlobalScope) -> JSIO String
   name a = primJS $ SharedWorkerGlobalScope.prim__name a
 
-
+  
   export
   onconnect :
        SharedWorkerGlobalScope
@@ -6423,7 +6290,7 @@ namespace SharedWorkerGlobalScope
                   prim__setOnconnect
                   v
 
-
+  
   export
   close : (obj : SharedWorkerGlobalScope) -> JSIO ()
   close a = primJS $ SharedWorkerGlobalScope.prim__close a
@@ -6431,27 +6298,27 @@ namespace SharedWorkerGlobalScope
 
 
 namespace Storage
-
+  
   export
   length : (obj : Storage) -> JSIO Bits32
   length a = primJS $ Storage.prim__length a
 
-
+  
   export
   clear : (obj : Storage) -> JSIO ()
   clear a = primJS $ Storage.prim__clear a
 
-
+  
   export
   getItem : (obj : Storage) -> (key : String) -> JSIO (Maybe String)
   getItem a b = tryJS "Storage.getItem" $ Storage.prim__getItem a b
 
-
+  
   export
   key : (obj : Storage) -> (index : Bits32) -> JSIO (Maybe String)
   key a b = tryJS "Storage.key" $ Storage.prim__key a b
 
-
+  
   export
   setItem : (obj : Storage) -> (key : String) -> (value : String) -> JSIO ()
   setItem a b c = primJS $ Storage.prim__setItem a b c
@@ -6459,47 +6326,46 @@ namespace Storage
 
 
 namespace StorageEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem StorageEventInit (Types t2)}
+       {auto _ : Cast t2 StorageEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO StorageEvent
   new' a b = primJS $ StorageEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO StorageEvent
   new a = primJS $ StorageEvent.prim__new a undef
 
-
+  
   export
   key : (obj : StorageEvent) -> JSIO (Maybe String)
   key a = tryJS "StorageEvent.key" $ StorageEvent.prim__key a
 
-
+  
   export
   newValue : (obj : StorageEvent) -> JSIO (Maybe String)
   newValue a = tryJS "StorageEvent.newValue" $ StorageEvent.prim__newValue a
 
-
+  
   export
   oldValue : (obj : StorageEvent) -> JSIO (Maybe String)
   oldValue a = tryJS "StorageEvent.oldValue" $ StorageEvent.prim__oldValue a
 
-
+  
   export
   storageArea : (obj : StorageEvent) -> JSIO (Maybe Storage)
   storageArea a = tryJS "StorageEvent.storageArea" $
     StorageEvent.prim__storageArea a
 
-
+  
   export
   url : (obj : StorageEvent) -> JSIO String
   url a = primJS $ StorageEvent.prim__url a
 
-
+  
   export
   initStorageEvent' :
        (obj : StorageEvent)
@@ -6523,7 +6389,7 @@ namespace StorageEvent
       (toFFI g)
       (toFFI h)
       (toFFI i)
-
+  
   export
   initStorageEvent : (obj : StorageEvent) -> (type : String) -> JSIO ()
   initStorageEvent a b = primJS $
@@ -6541,21 +6407,20 @@ namespace StorageEvent
 
 
 namespace SubmitEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem SubmitEventInit (Types t2)}
+       {auto _ : Cast t2 SubmitEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO SubmitEvent
   new' a b = primJS $ SubmitEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO SubmitEvent
   new a = primJS $ SubmitEvent.prim__new a undef
 
-
+  
   export
   submitter : (obj : SubmitEvent) -> JSIO (Maybe HTMLElement)
   submitter a = tryJS "SubmitEvent.submitter" $ SubmitEvent.prim__submitter a
@@ -6563,64 +6428,64 @@ namespace SubmitEvent
 
 
 namespace TextMetrics
-
+  
   export
   actualBoundingBoxAscent : (obj : TextMetrics) -> JSIO Double
   actualBoundingBoxAscent a = primJS $
     TextMetrics.prim__actualBoundingBoxAscent a
 
-
+  
   export
   actualBoundingBoxDescent : (obj : TextMetrics) -> JSIO Double
   actualBoundingBoxDescent a = primJS $
     TextMetrics.prim__actualBoundingBoxDescent a
 
-
+  
   export
   actualBoundingBoxLeft : (obj : TextMetrics) -> JSIO Double
   actualBoundingBoxLeft a = primJS $ TextMetrics.prim__actualBoundingBoxLeft a
 
-
+  
   export
   actualBoundingBoxRight : (obj : TextMetrics) -> JSIO Double
   actualBoundingBoxRight a = primJS $ TextMetrics.prim__actualBoundingBoxRight a
 
-
+  
   export
   alphabeticBaseline : (obj : TextMetrics) -> JSIO Double
   alphabeticBaseline a = primJS $ TextMetrics.prim__alphabeticBaseline a
 
-
+  
   export
   emHeightAscent : (obj : TextMetrics) -> JSIO Double
   emHeightAscent a = primJS $ TextMetrics.prim__emHeightAscent a
 
-
+  
   export
   emHeightDescent : (obj : TextMetrics) -> JSIO Double
   emHeightDescent a = primJS $ TextMetrics.prim__emHeightDescent a
 
-
+  
   export
   fontBoundingBoxAscent : (obj : TextMetrics) -> JSIO Double
   fontBoundingBoxAscent a = primJS $ TextMetrics.prim__fontBoundingBoxAscent a
 
-
+  
   export
   fontBoundingBoxDescent : (obj : TextMetrics) -> JSIO Double
   fontBoundingBoxDescent a = primJS $ TextMetrics.prim__fontBoundingBoxDescent a
 
-
+  
   export
   hangingBaseline : (obj : TextMetrics) -> JSIO Double
   hangingBaseline a = primJS $ TextMetrics.prim__hangingBaseline a
 
-
+  
   export
   ideographicBaseline : (obj : TextMetrics) -> JSIO Double
   ideographicBaseline a = primJS $ TextMetrics.prim__ideographicBaseline a
 
-
+  
   export
   width : (obj : TextMetrics) -> JSIO Double
   width a = primJS $ TextMetrics.prim__width a
@@ -6628,48 +6493,48 @@ namespace TextMetrics
 
 
 namespace TextTrack
-
+  
   export
   activeCues : (obj : TextTrack) -> JSIO (Maybe TextTrackCueList)
   activeCues a = tryJS "TextTrack.activeCues" $ TextTrack.prim__activeCues a
 
-
+  
   export
   cues : (obj : TextTrack) -> JSIO (Maybe TextTrackCueList)
   cues a = tryJS "TextTrack.cues" $ TextTrack.prim__cues a
 
-
+  
   export
   id : (obj : TextTrack) -> JSIO String
   id a = primJS $ TextTrack.prim__id a
 
-
+  
   export
   inBandMetadataTrackDispatchType : (obj : TextTrack) -> JSIO String
   inBandMetadataTrackDispatchType a = primJS $
     TextTrack.prim__inBandMetadataTrackDispatchType a
 
-
+  
   export
   kind : (obj : TextTrack) -> JSIO TextTrackKind
   kind a = tryJS "TextTrack.kind" $ TextTrack.prim__kind a
 
-
+  
   export
   label : (obj : TextTrack) -> JSIO String
   label a = primJS $ TextTrack.prim__label a
 
-
+  
   export
   language : (obj : TextTrack) -> JSIO String
   language a = primJS $ TextTrack.prim__language a
 
-
+  
   export
   mode : TextTrack -> Attribute True Prelude.id TextTrackMode
   mode v = fromPrim "TextTrack.getmode" prim__mode prim__setMode v
 
-
+  
   export
   oncuechange : TextTrack -> Attribute False Maybe EventHandlerNonNull
   oncuechange v = fromNullablePrim
@@ -6678,18 +6543,18 @@ namespace TextTrack
                     prim__setOncuechange
                     v
 
-
+  
   export
   sourceBuffer : (obj : TextTrack) -> JSIO (Maybe SourceBuffer)
   sourceBuffer a = tryJS "TextTrack.sourceBuffer" $
     TextTrack.prim__sourceBuffer a
 
-
+  
   export
   addCue : (obj : TextTrack) -> (cue : TextTrackCue) -> JSIO ()
   addCue a b = primJS $ TextTrack.prim__addCue a b
 
-
+  
   export
   removeCue : (obj : TextTrack) -> (cue : TextTrackCue) -> JSIO ()
   removeCue a b = primJS $ TextTrack.prim__removeCue a b
@@ -6697,7 +6562,7 @@ namespace TextTrack
 
 
 namespace TextTrackCue
-
+  
   export
   endTime : TextTrackCue -> Attribute True Prelude.id Double
   endTime v = fromPrim
@@ -6706,12 +6571,12 @@ namespace TextTrackCue
                 prim__setEndTime
                 v
 
-
+  
   export
   id : TextTrackCue -> Attribute True Prelude.id String
   id v = fromPrim "TextTrackCue.getid" prim__id prim__setId v
 
-
+  
   export
   onenter : TextTrackCue -> Attribute False Maybe EventHandlerNonNull
   onenter v = fromNullablePrim
@@ -6720,7 +6585,7 @@ namespace TextTrackCue
                 prim__setOnenter
                 v
 
-
+  
   export
   onexit : TextTrackCue -> Attribute False Maybe EventHandlerNonNull
   onexit v = fromNullablePrim
@@ -6729,7 +6594,7 @@ namespace TextTrackCue
                prim__setOnexit
                v
 
-
+  
   export
   pauseOnExit : TextTrackCue -> Attribute True Prelude.id Bool
   pauseOnExit v = fromPrim
@@ -6738,7 +6603,7 @@ namespace TextTrackCue
                     prim__setPauseOnExit
                     v
 
-
+  
   export
   startTime : TextTrackCue -> Attribute True Prelude.id Double
   startTime v = fromPrim
@@ -6747,7 +6612,7 @@ namespace TextTrackCue
                   prim__setStartTime
                   v
 
-
+  
   export
   track : (obj : TextTrackCue) -> JSIO (Maybe TextTrack)
   track a = tryJS "TextTrackCue.track" $ TextTrackCue.prim__track a
@@ -6755,17 +6620,17 @@ namespace TextTrackCue
 
 
 namespace TextTrackCueList
-
+  
   export
   get : (obj : TextTrackCueList) -> (index : Bits32) -> JSIO TextTrackCue
   get a b = primJS $ TextTrackCueList.prim__get a b
 
-
+  
   export
   length : (obj : TextTrackCueList) -> JSIO Bits32
   length a = primJS $ TextTrackCueList.prim__length a
 
-
+  
   export
   getCueById :
        (obj : TextTrackCueList)
@@ -6777,17 +6642,17 @@ namespace TextTrackCueList
 
 
 namespace TextTrackList
-
+  
   export
   get : (obj : TextTrackList) -> (index : Bits32) -> JSIO TextTrack
   get a b = primJS $ TextTrackList.prim__get a b
 
-
+  
   export
   length : (obj : TextTrackList) -> JSIO Bits32
   length a = primJS $ TextTrackList.prim__length a
 
-
+  
   export
   onaddtrack : TextTrackList -> Attribute False Maybe EventHandlerNonNull
   onaddtrack v = fromNullablePrim
@@ -6796,7 +6661,7 @@ namespace TextTrackList
                    prim__setOnaddtrack
                    v
 
-
+  
   export
   onchange : TextTrackList -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
@@ -6805,7 +6670,7 @@ namespace TextTrackList
                  prim__setOnchange
                  v
 
-
+  
   export
   onremovetrack : TextTrackList -> Attribute False Maybe EventHandlerNonNull
   onremovetrack v = fromNullablePrim
@@ -6814,7 +6679,7 @@ namespace TextTrackList
                       prim__setOnremovetrack
                       v
 
-
+  
   export
   getTrackById :
        (obj : TextTrackList)
@@ -6826,17 +6691,17 @@ namespace TextTrackList
 
 
 namespace TimeRanges
-
+  
   export
   length : (obj : TimeRanges) -> JSIO Bits32
   length a = primJS $ TimeRanges.prim__length a
 
-
+  
   export
   end : (obj : TimeRanges) -> (index : Bits32) -> JSIO Double
   end a b = primJS $ TimeRanges.prim__end a b
 
-
+  
   export
   start : (obj : TimeRanges) -> (index : Bits32) -> JSIO Double
   start a b = primJS $ TimeRanges.prim__start a b
@@ -6844,21 +6709,20 @@ namespace TimeRanges
 
 
 namespace TrackEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem TrackEventInit (Types t2)}
+       {auto _ : Cast t2 TrackEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO TrackEvent
   new' a b = primJS $ TrackEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO TrackEvent
   new a = primJS $ TrackEvent.prim__new a undef
 
-
+  
   export
   track :
        (obj : TrackEvent)
@@ -6868,63 +6732,63 @@ namespace TrackEvent
 
 
 namespace ValidityState
-
+  
   export
   badInput : (obj : ValidityState) -> JSIO Bool
   badInput a = tryJS "ValidityState.badInput" $ ValidityState.prim__badInput a
 
-
+  
   export
   customError : (obj : ValidityState) -> JSIO Bool
   customError a = tryJS "ValidityState.customError" $
     ValidityState.prim__customError a
 
-
+  
   export
   patternMismatch : (obj : ValidityState) -> JSIO Bool
   patternMismatch a = tryJS "ValidityState.patternMismatch" $
     ValidityState.prim__patternMismatch a
 
-
+  
   export
   rangeOverflow : (obj : ValidityState) -> JSIO Bool
   rangeOverflow a = tryJS "ValidityState.rangeOverflow" $
     ValidityState.prim__rangeOverflow a
 
-
+  
   export
   rangeUnderflow : (obj : ValidityState) -> JSIO Bool
   rangeUnderflow a = tryJS "ValidityState.rangeUnderflow" $
     ValidityState.prim__rangeUnderflow a
 
-
+  
   export
   stepMismatch : (obj : ValidityState) -> JSIO Bool
   stepMismatch a = tryJS "ValidityState.stepMismatch" $
     ValidityState.prim__stepMismatch a
 
-
+  
   export
   tooLong : (obj : ValidityState) -> JSIO Bool
   tooLong a = tryJS "ValidityState.tooLong" $ ValidityState.prim__tooLong a
 
-
+  
   export
   tooShort : (obj : ValidityState) -> JSIO Bool
   tooShort a = tryJS "ValidityState.tooShort" $ ValidityState.prim__tooShort a
 
-
+  
   export
   typeMismatch : (obj : ValidityState) -> JSIO Bool
   typeMismatch a = tryJS "ValidityState.typeMismatch" $
     ValidityState.prim__typeMismatch a
 
-
+  
   export
   valid : (obj : ValidityState) -> JSIO Bool
   valid a = tryJS "ValidityState.valid" $ ValidityState.prim__valid a
 
-
+  
   export
   valueMissing : (obj : ValidityState) -> JSIO Bool
   valueMissing a = tryJS "ValidityState.valueMissing" $
@@ -6933,27 +6797,27 @@ namespace ValidityState
 
 
 namespace VideoTrack
-
+  
   export
   id : (obj : VideoTrack) -> JSIO String
   id a = primJS $ VideoTrack.prim__id a
 
-
+  
   export
   kind : (obj : VideoTrack) -> JSIO String
   kind a = primJS $ VideoTrack.prim__kind a
 
-
+  
   export
   label : (obj : VideoTrack) -> JSIO String
   label a = primJS $ VideoTrack.prim__label a
 
-
+  
   export
   language : (obj : VideoTrack) -> JSIO String
   language a = primJS $ VideoTrack.prim__language a
 
-
+  
   export
   selected : VideoTrack -> Attribute True Prelude.id Bool
   selected v = fromPrim
@@ -6962,7 +6826,7 @@ namespace VideoTrack
                  prim__setSelected
                  v
 
-
+  
   export
   sourceBuffer : (obj : VideoTrack) -> JSIO (Maybe SourceBuffer)
   sourceBuffer a = tryJS "VideoTrack.sourceBuffer" $
@@ -6971,17 +6835,17 @@ namespace VideoTrack
 
 
 namespace VideoTrackList
-
+  
   export
   get : (obj : VideoTrackList) -> (index : Bits32) -> JSIO VideoTrack
   get a b = primJS $ VideoTrackList.prim__get a b
 
-
+  
   export
   length : (obj : VideoTrackList) -> JSIO Bits32
   length a = primJS $ VideoTrackList.prim__length a
 
-
+  
   export
   onaddtrack : VideoTrackList -> Attribute False Maybe EventHandlerNonNull
   onaddtrack v = fromNullablePrim
@@ -6990,7 +6854,7 @@ namespace VideoTrackList
                    prim__setOnaddtrack
                    v
 
-
+  
   export
   onchange : VideoTrackList -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
@@ -6999,7 +6863,7 @@ namespace VideoTrackList
                  prim__setOnchange
                  v
 
-
+  
   export
   onremovetrack : VideoTrackList -> Attribute False Maybe EventHandlerNonNull
   onremovetrack v = fromNullablePrim
@@ -7008,12 +6872,12 @@ namespace VideoTrackList
                       prim__setOnremovetrack
                       v
 
-
+  
   export
   selectedIndex : (obj : VideoTrackList) -> JSIO Int32
   selectedIndex a = primJS $ VideoTrackList.prim__selectedIndex a
 
-
+  
   export
   getTrackById :
        (obj : VideoTrackList)
@@ -7025,39 +6889,39 @@ namespace VideoTrackList
 
 
 namespace WebSocket
-
-  public export
+  
+  export
   CLOSED : Bits16
   CLOSED = 3
 
-
-  public export
+  
+  export
   CLOSING : Bits16
   CLOSING = 2
 
-
-  public export
+  
+  export
   CONNECTING : Bits16
   CONNECTING = 0
 
-
-  public export
+  
+  export
   OPEN : Bits16
   OPEN = 1
 
-
+  
   export
   new' :
        (url : String)
     -> (protocols : Optional (HSum [String, Array String]))
     -> JSIO WebSocket
   new' a b = primJS $ WebSocket.prim__new a (toFFI b)
-
+  
   export
   new : (url : String) -> JSIO WebSocket
   new a = primJS $ WebSocket.prim__new a undef
 
-
+  
   export
   binaryType : WebSocket -> Attribute True Prelude.id BinaryType
   binaryType v = fromPrim
@@ -7066,17 +6930,17 @@ namespace WebSocket
                    prim__setBinaryType
                    v
 
-
+  
   export
   bufferedAmount : (obj : WebSocket) -> JSIO JSBits64
   bufferedAmount a = primJS $ WebSocket.prim__bufferedAmount a
 
-
+  
   export
   extensions : (obj : WebSocket) -> JSIO String
   extensions a = primJS $ WebSocket.prim__extensions a
 
-
+  
   export
   onclose : WebSocket -> Attribute False Maybe EventHandlerNonNull
   onclose v = fromNullablePrim
@@ -7085,7 +6949,7 @@ namespace WebSocket
                 prim__setOnclose
                 v
 
-
+  
   export
   onerror : WebSocket -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -7094,7 +6958,7 @@ namespace WebSocket
                 prim__setOnerror
                 v
 
-
+  
   export
   onmessage : WebSocket -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
@@ -7103,7 +6967,7 @@ namespace WebSocket
                   prim__setOnmessage
                   v
 
-
+  
   export
   onopen : WebSocket -> Attribute False Maybe EventHandlerNonNull
   onopen v = fromNullablePrim
@@ -7112,22 +6976,22 @@ namespace WebSocket
                prim__setOnopen
                v
 
-
+  
   export
   protocol : (obj : WebSocket) -> JSIO String
   protocol a = primJS $ WebSocket.prim__protocol a
 
-
+  
   export
   readyState : (obj : WebSocket) -> JSIO Bits16
   readyState a = primJS $ WebSocket.prim__readyState a
 
-
+  
   export
   url : (obj : WebSocket) -> JSIO String
   url a = primJS $ WebSocket.prim__url a
 
-
+  
   export
   close' :
        (obj : WebSocket)
@@ -7135,32 +6999,31 @@ namespace WebSocket
     -> (reason : Optional String)
     -> JSIO ()
   close' a b c = primJS $ WebSocket.prim__close a (toFFI b) (toFFI c)
-
+  
   export
   close : (obj : WebSocket) -> JSIO ()
   close a = primJS $ WebSocket.prim__close a undef undef
 
-
+  
   export
   send : (obj : WebSocket) -> (data_ : String) -> JSIO ()
   send a b = primJS $ WebSocket.prim__send a b
 
-
+  
   export
   send1 :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Blob (Types t2)}
+       {auto _ : Cast t2 Blob}
     -> (obj : WebSocket)
     -> (data_ : t2)
     -> JSIO ()
-  send1 a b = primJS $ WebSocket.prim__send1 a (up b)
+  send1 a b = primJS $ WebSocket.prim__send1 a (cast b)
 
-
+  
   export
   send2 : (obj : WebSocket) -> (data_ : ArrayBuffer) -> JSIO ()
   send2 a b = primJS $ WebSocket.prim__send2 a b
 
-
+  
   export
   send3 :
        (obj : WebSocket)
@@ -7182,289 +7045,287 @@ namespace WebSocket
 
 
 namespace Window
-
+  
   export
   get : (obj : Window) -> (name : String) -> JSIO Object
   get a b = primJS $ Window.prim__get a b
 
-
+  
   export
   closed : (obj : Window) -> JSIO Bool
   closed a = tryJS "Window.closed" $ Window.prim__closed a
 
-
+  
   export
   customElements : (obj : Window) -> JSIO CustomElementRegistry
   customElements a = primJS $ Window.prim__customElements a
 
-
+  
   export
   devicePixelRatio : (obj : Window) -> JSIO Double
   devicePixelRatio a = primJS $ Window.prim__devicePixelRatio a
 
-
+  
   export
   document : (obj : Window) -> JSIO Document
   document a = primJS $ Window.prim__document a
 
-
+  
   export
   event : (obj : Window) -> JSIO (HSum [Event, Undefined])
   event a = tryJS "Window.event" $ Window.prim__event a
 
-
+  
   export
   external : (obj : Window) -> JSIO External
   external a = primJS $ Window.prim__external a
 
-
+  
   export
   frameElement : (obj : Window) -> JSIO (Maybe Element)
   frameElement a = tryJS "Window.frameElement" $ Window.prim__frameElement a
 
-
+  
   export
   frames : (obj : Window) -> JSIO WindowProxy
   frames a = primJS $ Window.prim__frames a
 
-
+  
   export
   history : (obj : Window) -> JSIO History
   history a = primJS $ Window.prim__history a
 
-
+  
   export
   innerHeight : (obj : Window) -> JSIO Int32
   innerHeight a = primJS $ Window.prim__innerHeight a
 
-
+  
   export
   innerWidth : (obj : Window) -> JSIO Int32
   innerWidth a = primJS $ Window.prim__innerWidth a
 
-
+  
   export
   length : (obj : Window) -> JSIO Bits32
   length a = primJS $ Window.prim__length a
 
-
+  
   export
   location : (obj : Window) -> JSIO Location
   location a = primJS $ Window.prim__location a
 
-
+  
   export
   locationbar : (obj : Window) -> JSIO BarProp
   locationbar a = primJS $ Window.prim__locationbar a
 
-
+  
   export
   menubar : (obj : Window) -> JSIO BarProp
   menubar a = primJS $ Window.prim__menubar a
 
-
+  
   export
   name : Window -> Attribute True Prelude.id String
   name v = fromPrim "Window.getname" prim__name prim__setName v
 
-
+  
   export
   navigator : (obj : Window) -> JSIO Navigator
   navigator a = primJS $ Window.prim__navigator a
 
-
+  
   export
   opener : Window -> Attribute True Prelude.id Any
   opener v = fromPrim "Window.getopener" prim__opener prim__setOpener v
 
-
+  
   export
   originAgentCluster : (obj : Window) -> JSIO Bool
   originAgentCluster a = tryJS "Window.originAgentCluster" $
     Window.prim__originAgentCluster a
 
-
+  
   export
   outerHeight : (obj : Window) -> JSIO Int32
   outerHeight a = primJS $ Window.prim__outerHeight a
 
-
+  
   export
   outerWidth : (obj : Window) -> JSIO Int32
   outerWidth a = primJS $ Window.prim__outerWidth a
 
-
+  
   export
   pageXOffset : (obj : Window) -> JSIO Double
   pageXOffset a = primJS $ Window.prim__pageXOffset a
 
-
+  
   export
   pageYOffset : (obj : Window) -> JSIO Double
   pageYOffset a = primJS $ Window.prim__pageYOffset a
 
-
+  
   export
   parent : (obj : Window) -> JSIO (Maybe WindowProxy)
   parent a = tryJS "Window.parent" $ Window.prim__parent a
 
-
+  
   export
   personalbar : (obj : Window) -> JSIO BarProp
   personalbar a = primJS $ Window.prim__personalbar a
 
-
+  
   export
   screen : (obj : Window) -> JSIO Screen
   screen a = primJS $ Window.prim__screen a
 
-
+  
   export
   screenLeft : (obj : Window) -> JSIO Int32
   screenLeft a = primJS $ Window.prim__screenLeft a
 
-
+  
   export
   screenTop : (obj : Window) -> JSIO Int32
   screenTop a = primJS $ Window.prim__screenTop a
 
-
+  
   export
   screenX : (obj : Window) -> JSIO Int32
   screenX a = primJS $ Window.prim__screenX a
 
-
+  
   export
   screenY : (obj : Window) -> JSIO Int32
   screenY a = primJS $ Window.prim__screenY a
 
-
+  
   export
   scrollX : (obj : Window) -> JSIO Double
   scrollX a = primJS $ Window.prim__scrollX a
 
-
+  
   export
   scrollY : (obj : Window) -> JSIO Double
   scrollY a = primJS $ Window.prim__scrollY a
 
-
+  
   export
   scrollbars : (obj : Window) -> JSIO BarProp
   scrollbars a = primJS $ Window.prim__scrollbars a
 
-
+  
   export
   self : (obj : Window) -> JSIO WindowProxy
   self a = primJS $ Window.prim__self a
 
-
+  
   export
   status : Window -> Attribute True Prelude.id String
   status v = fromPrim "Window.getstatus" prim__status prim__setStatus v
 
-
+  
   export
   statusbar : (obj : Window) -> JSIO BarProp
   statusbar a = primJS $ Window.prim__statusbar a
 
-
+  
   export
   toolbar : (obj : Window) -> JSIO BarProp
   toolbar a = primJS $ Window.prim__toolbar a
 
-
+  
   export
   top : (obj : Window) -> JSIO (Maybe WindowProxy)
   top a = tryJS "Window.top" $ Window.prim__top a
 
-
+  
   export
   visualViewport : (obj : Window) -> JSIO (Maybe VisualViewport)
   visualViewport a = tryJS "Window.visualViewport" $
     Window.prim__visualViewport a
 
-
+  
   export
   window : (obj : Window) -> JSIO WindowProxy
   window a = primJS $ Window.prim__window a
 
-
+  
   export
   alert : (obj : Window) -> JSIO ()
   alert a = primJS $ Window.prim__alert a
 
-
+  
   export
   alert1 : (obj : Window) -> (message : String) -> JSIO ()
   alert1 a b = primJS $ Window.prim__alert1 a b
 
-
+  
   export
   blur : (obj : Window) -> JSIO ()
   blur a = primJS $ Window.prim__blur a
 
-
+  
   export
   captureEvents : (obj : Window) -> JSIO ()
   captureEvents a = primJS $ Window.prim__captureEvents a
 
-
+  
   export
   close : (obj : Window) -> JSIO ()
   close a = primJS $ Window.prim__close a
 
-
+  
   export
   confirm' : (obj : Window) -> (message : Optional String) -> JSIO Bool
   confirm' a b = tryJS "Window.confirm'" $ Window.prim__confirm a (toFFI b)
-
+  
   export
   confirm : (obj : Window) -> JSIO Bool
   confirm a = tryJS "Window.confirm" $ Window.prim__confirm a undef
 
-
+  
   export
   focus : (obj : Window) -> JSIO ()
   focus a = primJS $ Window.prim__focus a
 
-
+  
   export
   getComputedStyle' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t2)}
+       {auto _ : Cast t2 Element}
     -> (obj : Window)
     -> (elt : t2)
     -> (pseudoElt : Optional (Maybe String))
     -> JSIO CSSStyleDeclaration
   getComputedStyle' a b c = primJS $
-    Window.prim__getComputedStyle a (up b) (toFFI c)
-
+    Window.prim__getComputedStyle a (cast b) (toFFI c)
+  
   export
   getComputedStyle :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Element (Types t2)}
+       {auto _ : Cast t2 Element}
     -> (obj : Window)
     -> (elt : t2)
     -> JSIO CSSStyleDeclaration
-  getComputedStyle a b = primJS $ Window.prim__getComputedStyle a (up b) undef
+  getComputedStyle a b = primJS $ Window.prim__getComputedStyle a (cast b) undef
 
-
+  
   export
   matchMedia : (obj : Window) -> (query : String) -> JSIO MediaQueryList
   matchMedia a b = primJS $ Window.prim__matchMedia a b
 
-
+  
   export
   moveBy : (obj : Window) -> (x : Int32) -> (y : Int32) -> JSIO ()
   moveBy a b c = primJS $ Window.prim__moveBy a b c
 
-
+  
   export
   moveTo : (obj : Window) -> (x : Int32) -> (y : Int32) -> JSIO ()
   moveTo a b c = primJS $ Window.prim__moveTo a b c
 
-
+  
   export
   open' :
        (obj : Window)
@@ -7474,12 +7335,12 @@ namespace Window
     -> JSIO (Maybe WindowProxy)
   open' a b c d = tryJS "Window.open'" $
     Window.prim__open a (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   open_ : (obj : Window) -> JSIO (Maybe WindowProxy)
   open_ a = tryJS "Window.open_" $ Window.prim__open a undef undef undef
 
-
+  
   export
   postMessage' :
        (obj : Window)
@@ -7489,7 +7350,7 @@ namespace Window
     -> JSIO ()
   postMessage' a b c d = primJS $
     Window.prim__postMessage a (toFFI b) c (toFFI d)
-
+  
   export
   postMessage :
        (obj : Window)
@@ -7498,27 +7359,26 @@ namespace Window
     -> JSIO ()
   postMessage a b c = primJS $ Window.prim__postMessage a (toFFI b) c undef
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem WindowPostMessageOptions (Types t3)}
+       {auto _ : Cast t3 WindowPostMessageOptions}
     -> (obj : Window)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $ Window.prim__postMessage1 a (toFFI b) (optUp c)
-
+  
   export
   postMessage1 : (obj : Window) -> (message : Any) -> JSIO ()
   postMessage1 a b = primJS $ Window.prim__postMessage1 a (toFFI b) undef
 
-
+  
   export
   print : (obj : Window) -> JSIO ()
   print a = primJS $ Window.prim__print a
 
-
+  
   export
   prompt' :
        (obj : Window)
@@ -7527,84 +7387,81 @@ namespace Window
     -> JSIO (Maybe String)
   prompt' a b c = tryJS "Window.prompt'" $
     Window.prim__prompt a (toFFI b) (toFFI c)
-
+  
   export
   prompt : (obj : Window) -> JSIO (Maybe String)
   prompt a = tryJS "Window.prompt" $ Window.prim__prompt a undef undef
 
-
+  
   export
   releaseEvents : (obj : Window) -> JSIO ()
   releaseEvents a = primJS $ Window.prim__releaseEvents a
 
-
+  
   export
   resizeBy : (obj : Window) -> (x : Int32) -> (y : Int32) -> JSIO ()
   resizeBy a b c = primJS $ Window.prim__resizeBy a b c
 
-
+  
   export
   resizeTo : (obj : Window) -> (width : Int32) -> (height : Int32) -> JSIO ()
   resizeTo a b c = primJS $ Window.prim__resizeTo a b c
 
-
+  
   export
   scrollBy' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t2 ScrollToOptions}
     -> (obj : Window)
     -> (options : Optional t2)
     -> JSIO ()
   scrollBy' a b = primJS $ Window.prim__scrollBy a (optUp b)
-
+  
   export
   scrollBy : (obj : Window) -> JSIO ()
   scrollBy a = primJS $ Window.prim__scrollBy a undef
 
-
+  
   export
   scrollBy1 : (obj : Window) -> (x : Double) -> (y : Double) -> JSIO ()
   scrollBy1 a b c = primJS $ Window.prim__scrollBy1 a b c
 
-
+  
   export
   scrollTo' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t2 ScrollToOptions}
     -> (obj : Window)
     -> (options : Optional t2)
     -> JSIO ()
   scrollTo' a b = primJS $ Window.prim__scrollTo a (optUp b)
-
+  
   export
   scrollTo : (obj : Window) -> JSIO ()
   scrollTo a = primJS $ Window.prim__scrollTo a undef
 
-
+  
   export
   scrollTo1 : (obj : Window) -> (x : Double) -> (y : Double) -> JSIO ()
   scrollTo1 a b c = primJS $ Window.prim__scrollTo1 a b c
 
-
+  
   export
   scroll' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ScrollToOptions (Types t2)}
+       {auto _ : Cast t2 ScrollToOptions}
     -> (obj : Window)
     -> (options : Optional t2)
     -> JSIO ()
   scroll' a b = primJS $ Window.prim__scroll a (optUp b)
-
+  
   export
   scroll : (obj : Window) -> JSIO ()
   scroll a = primJS $ Window.prim__scroll a undef
 
-
+  
   export
   scroll1 : (obj : Window) -> (x : Double) -> (y : Double) -> JSIO ()
   scroll1 a b c = primJS $ Window.prim__scroll1 a b c
 
-
+  
   export
   stop : (obj : Window) -> JSIO ()
   stop a = primJS $ Window.prim__stop a
@@ -7612,21 +7469,20 @@ namespace Window
 
 
 namespace Worker
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem WorkerOptions (Types t2)}
+       {auto _ : Cast t2 WorkerOptions}
     -> (scriptURL : String)
     -> (options : Optional t2)
     -> JSIO Worker
   new' a b = primJS $ Worker.prim__new a (optUp b)
-
+  
   export
   new : (scriptURL : String) -> JSIO Worker
   new a = primJS $ Worker.prim__new a undef
 
-
+  
   export
   onmessage : Worker -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
@@ -7635,7 +7491,7 @@ namespace Worker
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror : Worker -> Attribute False Maybe EventHandlerNonNull
   onmessageerror v = fromNullablePrim
@@ -7644,7 +7500,7 @@ namespace Worker
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   postMessage :
        (obj : Worker)
@@ -7653,22 +7509,21 @@ namespace Worker
     -> JSIO ()
   postMessage a b c = primJS $ Worker.prim__postMessage a (toFFI b) c
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t3)}
+       {auto _ : Cast t3 PostMessageOptions}
     -> (obj : Worker)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $ Worker.prim__postMessage1 a (toFFI b) (optUp c)
-
+  
   export
   postMessage1 : (obj : Worker) -> (message : Any) -> JSIO ()
   postMessage1 a b = primJS $ Worker.prim__postMessage1 a (toFFI b) undef
 
-
+  
   export
   terminate : (obj : Worker) -> JSIO ()
   terminate a = primJS $ Worker.prim__terminate a
@@ -7676,166 +7531,156 @@ namespace Worker
 
 
 namespace WorkerGlobalScope
-
+  
   export
   location :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WorkerGlobalScope}
     -> (obj : t1)
     -> JSIO WorkerLocation
-  location a = primJS $ WorkerGlobalScope.prim__location (up a)
+  location a = primJS $ WorkerGlobalScope.prim__location (cast a)
 
-
+  
   export
   navigator :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WorkerGlobalScope}
     -> (obj : t1)
     -> JSIO WorkerNavigator
-  navigator a = primJS $ WorkerGlobalScope.prim__navigator (up a)
+  navigator a = primJS $ WorkerGlobalScope.prim__navigator (cast a)
 
-
+  
   export
   onerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe OnErrorEventHandlerNonNull
   onerror v = fromNullablePrim
                 "WorkerGlobalScope.getonerror"
                 prim__onerror
                 prim__setOnerror
-                (v :> WorkerGlobalScope)
+                (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   onlanguagechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onlanguagechange v = fromNullablePrim
                          "WorkerGlobalScope.getonlanguagechange"
                          prim__onlanguagechange
                          prim__setOnlanguagechange
-                         (v :> WorkerGlobalScope)
+                         (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   onoffline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onoffline v = fromNullablePrim
                   "WorkerGlobalScope.getonoffline"
                   prim__onoffline
                   prim__setOnoffline
-                  (v :> WorkerGlobalScope)
+                  (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   ononline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ononline v = fromNullablePrim
                  "WorkerGlobalScope.getononline"
                  prim__ononline
                  prim__setOnonline
-                 (v :> WorkerGlobalScope)
+                 (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   onrejectionhandled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onrejectionhandled v = fromNullablePrim
                            "WorkerGlobalScope.getonrejectionhandled"
                            prim__onrejectionhandled
                            prim__setOnrejectionhandled
-                           (v :> WorkerGlobalScope)
+                           (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   onunhandledrejection :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t)}
+       {auto _ : Cast t WorkerGlobalScope}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onunhandledrejection v = fromNullablePrim
                              "WorkerGlobalScope.getonunhandledrejection"
                              prim__onunhandledrejection
                              prim__setOnunhandledrejection
-                             (v :> WorkerGlobalScope)
+                             (cast {to = WorkerGlobalScope} v)
 
-
+  
   export
   self :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WorkerGlobalScope}
     -> (obj : t1)
     -> JSIO WorkerGlobalScope
-  self a = primJS $ WorkerGlobalScope.prim__self (up a)
+  self a = primJS $ WorkerGlobalScope.prim__self (cast a)
 
-
+  
   export
   importScripts :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WorkerGlobalScope}
     -> (obj : t1)
     -> (urls : List String)
     -> JSIO ()
   importScripts a b = primJS $
-    WorkerGlobalScope.prim__importScripts (up a) (toFFI b)
+    WorkerGlobalScope.prim__importScripts (cast a) (toFFI b)
 
 
 
 namespace WorkerLocation
-
+  
   export
   hash : (obj : WorkerLocation) -> JSIO String
   hash a = primJS $ WorkerLocation.prim__hash a
 
-
+  
   export
   host : (obj : WorkerLocation) -> JSIO String
   host a = primJS $ WorkerLocation.prim__host a
 
-
+  
   export
   hostname : (obj : WorkerLocation) -> JSIO String
   hostname a = primJS $ WorkerLocation.prim__hostname a
 
-
+  
   export
   href : (obj : WorkerLocation) -> JSIO String
   href a = primJS $ WorkerLocation.prim__href a
 
-
+  
   export
   origin : (obj : WorkerLocation) -> JSIO String
   origin a = primJS $ WorkerLocation.prim__origin a
 
-
+  
   export
   pathname : (obj : WorkerLocation) -> JSIO String
   pathname a = primJS $ WorkerLocation.prim__pathname a
 
-
+  
   export
   port : (obj : WorkerLocation) -> JSIO String
   port a = primJS $ WorkerLocation.prim__port a
 
-
+  
   export
   protocol : (obj : WorkerLocation) -> JSIO String
   protocol a = primJS $ WorkerLocation.prim__protocol a
 
-
+  
   export
   search : (obj : WorkerLocation) -> JSIO String
   search a = primJS $ WorkerLocation.prim__search a
@@ -7843,12 +7688,12 @@ namespace WorkerLocation
 
 
 namespace WorkerNavigator
-
+  
   export
   permissions : (obj : WorkerNavigator) -> JSIO Permissions
   permissions a = primJS $ WorkerNavigator.prim__permissions a
 
-
+  
   export
   serviceWorker : (obj : WorkerNavigator) -> JSIO ServiceWorkerContainer
   serviceWorker a = primJS $ WorkerNavigator.prim__serviceWorker a
@@ -7856,17 +7701,16 @@ namespace WorkerNavigator
 
 
 namespace Worklet
-
+  
   export
   addModule' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem WorkletOptions (Types t3)}
+       {auto _ : Cast t3 WorkletOptions}
     -> (obj : Worklet)
     -> (moduleURL : String)
     -> (options : Optional t3)
     -> JSIO (Promise Undefined)
   addModule' a b c = primJS $ Worklet.prim__addModule a b (optUp c)
-
+  
   export
   addModule :
        (obj : Worklet)
@@ -7883,592 +7727,544 @@ namespace Worklet
 --------------------------------------------------------------------------------
 
 namespace ARIAMixin
-
+  
   export
   ariaAtomic :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaAtomic v = fromPrim
                    "ARIAMixin.getariaAtomic"
                    prim__ariaAtomic
                    prim__setAriaAtomic
-                   (v :> ARIAMixin)
+                   (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaAutoComplete :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaAutoComplete v = fromPrim
                          "ARIAMixin.getariaAutoComplete"
                          prim__ariaAutoComplete
                          prim__setAriaAutoComplete
-                         (v :> ARIAMixin)
+                         (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaBusy :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaBusy v = fromPrim
                  "ARIAMixin.getariaBusy"
                  prim__ariaBusy
                  prim__setAriaBusy
-                 (v :> ARIAMixin)
+                 (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaChecked :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaChecked v = fromPrim
                     "ARIAMixin.getariaChecked"
                     prim__ariaChecked
                     prim__setAriaChecked
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaColCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaColCount v = fromPrim
                      "ARIAMixin.getariaColCount"
                      prim__ariaColCount
                      prim__setAriaColCount
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaColIndex :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaColIndex v = fromPrim
                      "ARIAMixin.getariaColIndex"
                      prim__ariaColIndex
                      prim__setAriaColIndex
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaColIndexText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaColIndexText v = fromPrim
                          "ARIAMixin.getariaColIndexText"
                          prim__ariaColIndexText
                          prim__setAriaColIndexText
-                         (v :> ARIAMixin)
+                         (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaColSpan :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaColSpan v = fromPrim
                     "ARIAMixin.getariaColSpan"
                     prim__ariaColSpan
                     prim__setAriaColSpan
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaCurrent :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaCurrent v = fromPrim
                     "ARIAMixin.getariaCurrent"
                     prim__ariaCurrent
                     prim__setAriaCurrent
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaDescription :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaDescription v = fromPrim
                         "ARIAMixin.getariaDescription"
                         prim__ariaDescription
                         prim__setAriaDescription
-                        (v :> ARIAMixin)
+                        (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaDisabled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaDisabled v = fromPrim
                      "ARIAMixin.getariaDisabled"
                      prim__ariaDisabled
                      prim__setAriaDisabled
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaExpanded :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaExpanded v = fromPrim
                      "ARIAMixin.getariaExpanded"
                      prim__ariaExpanded
                      prim__setAriaExpanded
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaHasPopup :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaHasPopup v = fromPrim
                      "ARIAMixin.getariaHasPopup"
                      prim__ariaHasPopup
                      prim__setAriaHasPopup
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaHidden :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaHidden v = fromPrim
                    "ARIAMixin.getariaHidden"
                    prim__ariaHidden
                    prim__setAriaHidden
-                   (v :> ARIAMixin)
+                   (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaInvalid :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaInvalid v = fromPrim
                     "ARIAMixin.getariaInvalid"
                     prim__ariaInvalid
                     prim__setAriaInvalid
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaKeyShortcuts :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaKeyShortcuts v = fromPrim
                          "ARIAMixin.getariaKeyShortcuts"
                          prim__ariaKeyShortcuts
                          prim__setAriaKeyShortcuts
-                         (v :> ARIAMixin)
+                         (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaLabel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaLabel v = fromPrim
                   "ARIAMixin.getariaLabel"
                   prim__ariaLabel
                   prim__setAriaLabel
-                  (v :> ARIAMixin)
+                  (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaLevel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaLevel v = fromPrim
                   "ARIAMixin.getariaLevel"
                   prim__ariaLevel
                   prim__setAriaLevel
-                  (v :> ARIAMixin)
+                  (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaLive :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaLive v = fromPrim
                  "ARIAMixin.getariaLive"
                  prim__ariaLive
                  prim__setAriaLive
-                 (v :> ARIAMixin)
+                 (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaModal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaModal v = fromPrim
                   "ARIAMixin.getariaModal"
                   prim__ariaModal
                   prim__setAriaModal
-                  (v :> ARIAMixin)
+                  (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaMultiLine :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaMultiLine v = fromPrim
                       "ARIAMixin.getariaMultiLine"
                       prim__ariaMultiLine
                       prim__setAriaMultiLine
-                      (v :> ARIAMixin)
+                      (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaMultiSelectable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaMultiSelectable v = fromPrim
                             "ARIAMixin.getariaMultiSelectable"
                             prim__ariaMultiSelectable
                             prim__setAriaMultiSelectable
-                            (v :> ARIAMixin)
+                            (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaOrientation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaOrientation v = fromPrim
                         "ARIAMixin.getariaOrientation"
                         prim__ariaOrientation
                         prim__setAriaOrientation
-                        (v :> ARIAMixin)
+                        (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaPlaceholder :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaPlaceholder v = fromPrim
                         "ARIAMixin.getariaPlaceholder"
                         prim__ariaPlaceholder
                         prim__setAriaPlaceholder
-                        (v :> ARIAMixin)
+                        (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaPosInSet :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaPosInSet v = fromPrim
                      "ARIAMixin.getariaPosInSet"
                      prim__ariaPosInSet
                      prim__setAriaPosInSet
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaPressed :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaPressed v = fromPrim
                     "ARIAMixin.getariaPressed"
                     prim__ariaPressed
                     prim__setAriaPressed
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaReadOnly :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaReadOnly v = fromPrim
                      "ARIAMixin.getariaReadOnly"
                      prim__ariaReadOnly
                      prim__setAriaReadOnly
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRequired :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRequired v = fromPrim
                      "ARIAMixin.getariaRequired"
                      prim__ariaRequired
                      prim__setAriaRequired
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRoleDescription :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRoleDescription v = fromPrim
                             "ARIAMixin.getariaRoleDescription"
                             prim__ariaRoleDescription
                             prim__setAriaRoleDescription
-                            (v :> ARIAMixin)
+                            (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRowCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRowCount v = fromPrim
                      "ARIAMixin.getariaRowCount"
                      prim__ariaRowCount
                      prim__setAriaRowCount
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRowIndex :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRowIndex v = fromPrim
                      "ARIAMixin.getariaRowIndex"
                      prim__ariaRowIndex
                      prim__setAriaRowIndex
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRowIndexText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRowIndexText v = fromPrim
                          "ARIAMixin.getariaRowIndexText"
                          prim__ariaRowIndexText
                          prim__setAriaRowIndexText
-                         (v :> ARIAMixin)
+                         (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaRowSpan :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaRowSpan v = fromPrim
                     "ARIAMixin.getariaRowSpan"
                     prim__ariaRowSpan
                     prim__setAriaRowSpan
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaSelected :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaSelected v = fromPrim
                      "ARIAMixin.getariaSelected"
                      prim__ariaSelected
                      prim__setAriaSelected
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaSetSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaSetSize v = fromPrim
                     "ARIAMixin.getariaSetSize"
                     prim__ariaSetSize
                     prim__setAriaSetSize
-                    (v :> ARIAMixin)
+                    (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaSort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaSort v = fromPrim
                  "ARIAMixin.getariaSort"
                  prim__ariaSort
                  prim__setAriaSort
-                 (v :> ARIAMixin)
+                 (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaValueMax :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaValueMax v = fromPrim
                      "ARIAMixin.getariaValueMax"
                      prim__ariaValueMax
                      prim__setAriaValueMax
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaValueMin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaValueMin v = fromPrim
                      "ARIAMixin.getariaValueMin"
                      prim__ariaValueMin
                      prim__setAriaValueMin
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaValueNow :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaValueNow v = fromPrim
                      "ARIAMixin.getariaValueNow"
                      prim__ariaValueNow
                      prim__setAriaValueNow
-                     (v :> ARIAMixin)
+                     (cast {to = ARIAMixin} v)
 
-
+  
   export
   ariaValueText :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
+       {auto _ : Cast t ARIAMixin}
     -> t
     -> Attribute True Prelude.id String
   ariaValueText v = fromPrim
                       "ARIAMixin.getariaValueText"
                       prim__ariaValueText
                       prim__setAriaValueText
-                      (v :> ARIAMixin)
+                      (cast {to = ARIAMixin} v)
 
-
+  
   export
-  role :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ARIAMixin (Types t)}
-    -> t
-    -> Attribute False Maybe String
+  role : {auto _ : Cast t ARIAMixin} -> t -> Attribute False Maybe String
   role v = fromNullablePrim
              "ARIAMixin.getrole"
              prim__role
              prim__setRole
-             (v :> ARIAMixin)
+             (cast {to = ARIAMixin} v)
 
 
 
 namespace AbstractWorker
-
+  
   export
   onerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AbstractWorker (Types t)}
+       {auto _ : Cast t AbstractWorker}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
                 "AbstractWorker.getonerror"
                 prim__onerror
                 prim__setOnerror
-                (v :> AbstractWorker)
+                (cast {to = AbstractWorker} v)
 
 
 
 namespace CanvasCompositing
-
+  
   export
   globalAlpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasCompositing (Types t)}
+       {auto _ : Cast t CanvasCompositing}
     -> t
     -> Attribute True Prelude.id Double
   globalAlpha v = fromPrim
                     "CanvasCompositing.getglobalAlpha"
                     prim__globalAlpha
                     prim__setGlobalAlpha
-                    (v :> CanvasCompositing)
+                    (cast {to = CanvasCompositing} v)
 
-
+  
   export
   globalCompositeOperation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasCompositing (Types t)}
+       {auto _ : Cast t CanvasCompositing}
     -> t
     -> Attribute True Prelude.id String
   globalCompositeOperation v = fromPrim
                                  "CanvasCompositing.getglobalCompositeOperation"
                                  prim__globalCompositeOperation
                                  prim__setGlobalCompositeOperation
-                                 (v :> CanvasCompositing)
+                                 (cast {to = CanvasCompositing} v)
 
 
 
 namespace CanvasDrawImage
-
+  
   export
   drawImage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawImage (Types t1)}
+       {auto _ : Cast t1 CanvasDrawImage}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -8482,13 +8278,12 @@ namespace CanvasDrawImage
     -> (dy : Double)
     -> JSIO ()
   drawImage a b c d = primJS $
-    CanvasDrawImage.prim__drawImage (up a) (toFFI b) c d
+    CanvasDrawImage.prim__drawImage (cast a) (toFFI b) c d
 
-
+  
   export
   drawImage1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawImage (Types t1)}
+       {auto _ : Cast t1 CanvasDrawImage}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -8504,13 +8299,12 @@ namespace CanvasDrawImage
     -> (dh : Double)
     -> JSIO ()
   drawImage1 a b c d e f = primJS $
-    CanvasDrawImage.prim__drawImage1 (up a) (toFFI b) c d e f
+    CanvasDrawImage.prim__drawImage1 (cast a) (toFFI b) c d e f
 
-
+  
   export
   drawImage2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawImage (Types t1)}
+       {auto _ : Cast t1 CanvasDrawImage}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -8530,125 +8324,104 @@ namespace CanvasDrawImage
     -> (dh : Double)
     -> JSIO ()
   drawImage2 a b c d e f g h i j = primJS $
-    CanvasDrawImage.prim__drawImage2 (up a) (toFFI b) c d e f g h i j
+    CanvasDrawImage.prim__drawImage2 (cast a) (toFFI b) c d e f g h i j
 
 
 
 namespace CanvasDrawPath
-
+  
   export
-  beginPath :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  beginPath a = primJS $ CanvasDrawPath.prim__beginPath (up a)
+  beginPath : {auto _ : Cast t1 CanvasDrawPath} -> (obj : t1) -> JSIO ()
+  beginPath a = primJS $ CanvasDrawPath.prim__beginPath (cast a)
 
-
+  
   export
   clip' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO ()
-  clip' a b = primJS $ CanvasDrawPath.prim__clip (up a) (toFFI b)
-
+  clip' a b = primJS $ CanvasDrawPath.prim__clip (cast a) (toFFI b)
+  
   export
-  clip :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  clip a = primJS $ CanvasDrawPath.prim__clip (up a) undef
+  clip : {auto _ : Cast t1 CanvasDrawPath} -> (obj : t1) -> JSIO ()
+  clip a = primJS $ CanvasDrawPath.prim__clip (cast a) undef
 
-
+  
   export
   clip1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO ()
-  clip1' a b c = primJS $ CanvasDrawPath.prim__clip1 (up a) b (toFFI c)
-
+  clip1' a b c = primJS $ CanvasDrawPath.prim__clip1 (cast a) b (toFFI c)
+  
   export
   clip1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> JSIO ()
-  clip1 a b = primJS $ CanvasDrawPath.prim__clip1 (up a) b undef
+  clip1 a b = primJS $ CanvasDrawPath.prim__clip1 (cast a) b undef
 
-
+  
   export
   fill' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO ()
-  fill' a b = primJS $ CanvasDrawPath.prim__fill (up a) (toFFI b)
-
+  fill' a b = primJS $ CanvasDrawPath.prim__fill (cast a) (toFFI b)
+  
   export
-  fill :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  fill a = primJS $ CanvasDrawPath.prim__fill (up a) undef
+  fill : {auto _ : Cast t1 CanvasDrawPath} -> (obj : t1) -> JSIO ()
+  fill a = primJS $ CanvasDrawPath.prim__fill (cast a) undef
 
-
+  
   export
   fill1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO ()
-  fill1' a b c = primJS $ CanvasDrawPath.prim__fill1 (up a) b (toFFI c)
-
+  fill1' a b c = primJS $ CanvasDrawPath.prim__fill1 (cast a) b (toFFI c)
+  
   export
   fill1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> JSIO ()
-  fill1 a b = primJS $ CanvasDrawPath.prim__fill1 (up a) b undef
+  fill1 a b = primJS $ CanvasDrawPath.prim__fill1 (cast a) b undef
 
-
+  
   export
   isPointInPath' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO Bool
   isPointInPath' a b c d = tryJS "CanvasDrawPath.isPointInPath'" $
-    CanvasDrawPath.prim__isPointInPath (up a) b c (toFFI d)
-
+    CanvasDrawPath.prim__isPointInPath (cast a) b c (toFFI d)
+  
   export
   isPointInPath :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO Bool
   isPointInPath a b c = tryJS "CanvasDrawPath.isPointInPath" $
-    CanvasDrawPath.prim__isPointInPath (up a) b c undef
+    CanvasDrawPath.prim__isPointInPath (cast a) b c undef
 
-
+  
   export
   isPointInPath1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> (x : Double)
@@ -8656,98 +8429,87 @@ namespace CanvasDrawPath
     -> (fillRule : Optional CanvasFillRule)
     -> JSIO Bool
   isPointInPath1' a b c d e = tryJS "CanvasDrawPath.isPointInPath1'" $
-    CanvasDrawPath.prim__isPointInPath1 (up a) b c d (toFFI e)
-
+    CanvasDrawPath.prim__isPointInPath1 (cast a) b c d (toFFI e)
+  
   export
   isPointInPath1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> (x : Double)
     -> (y : Double)
     -> JSIO Bool
   isPointInPath1 a b c d = tryJS "CanvasDrawPath.isPointInPath1" $
-    CanvasDrawPath.prim__isPointInPath1 (up a) b c d undef
+    CanvasDrawPath.prim__isPointInPath1 (cast a) b c d undef
 
-
+  
   export
   isPointInStroke :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO Bool
   isPointInStroke a b c = tryJS "CanvasDrawPath.isPointInStroke" $
-    CanvasDrawPath.prim__isPointInStroke (up a) b c
+    CanvasDrawPath.prim__isPointInStroke (cast a) b c
 
-
+  
   export
   isPointInStroke1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> (x : Double)
     -> (y : Double)
     -> JSIO Bool
   isPointInStroke1 a b c d = tryJS "CanvasDrawPath.isPointInStroke1" $
-    CanvasDrawPath.prim__isPointInStroke1 (up a) b c d
+    CanvasDrawPath.prim__isPointInStroke1 (cast a) b c d
 
-
+  
   export
-  stroke :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  stroke a = primJS $ CanvasDrawPath.prim__stroke (up a)
+  stroke : {auto _ : Cast t1 CanvasDrawPath} -> (obj : t1) -> JSIO ()
+  stroke a = primJS $ CanvasDrawPath.prim__stroke (cast a)
 
-
+  
   export
   stroke1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasDrawPath (Types t1)}
+       {auto _ : Cast t1 CanvasDrawPath}
     -> (obj : t1)
     -> (path : Path2D)
     -> JSIO ()
-  stroke1 a b = primJS $ CanvasDrawPath.prim__stroke1 (up a) b
+  stroke1 a b = primJS $ CanvasDrawPath.prim__stroke1 (cast a) b
 
 
 
 namespace CanvasFillStrokeStyles
-
+  
   export
   fillStyle :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasFillStrokeStyles (Types t)}
+       {auto _ : Cast t CanvasFillStrokeStyles}
     -> t
     -> Attribute True Prelude.id (HSum [String, CanvasGradient, CanvasPattern])
   fillStyle v = fromPrim
                   "CanvasFillStrokeStyles.getfillStyle"
                   prim__fillStyle
                   prim__setFillStyle
-                  (v :> CanvasFillStrokeStyles)
+                  (cast {to = CanvasFillStrokeStyles} v)
 
-
+  
   export
   strokeStyle :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasFillStrokeStyles (Types t)}
+       {auto _ : Cast t CanvasFillStrokeStyles}
     -> t
     -> Attribute True Prelude.id (HSum [String, CanvasGradient, CanvasPattern])
   strokeStyle v = fromPrim
                     "CanvasFillStrokeStyles.getstrokeStyle"
                     prim__strokeStyle
                     prim__setStrokeStyle
-                    (v :> CanvasFillStrokeStyles)
+                    (cast {to = CanvasFillStrokeStyles} v)
 
-
+  
   export
   createLinearGradient :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasFillStrokeStyles (Types t1)}
+       {auto _ : Cast t1 CanvasFillStrokeStyles}
     -> (obj : t1)
     -> (x0 : Double)
     -> (y0 : Double)
@@ -8755,13 +8517,12 @@ namespace CanvasFillStrokeStyles
     -> (y1 : Double)
     -> JSIO CanvasGradient
   createLinearGradient a b c d e = primJS $
-    CanvasFillStrokeStyles.prim__createLinearGradient (up a) b c d e
+    CanvasFillStrokeStyles.prim__createLinearGradient (cast a) b c d e
 
-
+  
   export
   createPattern :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasFillStrokeStyles (Types t1)}
+       {auto _ : Cast t1 CanvasFillStrokeStyles}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -8774,13 +8535,12 @@ namespace CanvasFillStrokeStyles
     -> (repetition : String)
     -> JSIO (Maybe CanvasPattern)
   createPattern a b c = tryJS "CanvasFillStrokeStyles.createPattern" $
-    CanvasFillStrokeStyles.prim__createPattern (up a) (toFFI b) c
+    CanvasFillStrokeStyles.prim__createPattern (cast a) (toFFI b) c
 
-
+  
   export
   createRadialGradient :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasFillStrokeStyles (Types t1)}
+       {auto _ : Cast t1 CanvasFillStrokeStyles}
     -> (obj : t1)
     -> (x0 : Double)
     -> (y0 : Double)
@@ -8790,55 +8550,51 @@ namespace CanvasFillStrokeStyles
     -> (r1 : Double)
     -> JSIO CanvasGradient
   createRadialGradient a b c d e f g = primJS $
-    CanvasFillStrokeStyles.prim__createRadialGradient (up a) b c d e f g
+    CanvasFillStrokeStyles.prim__createRadialGradient (cast a) b c d e f g
 
 
 
 namespace CanvasFilters
-
+  
   export
   filter :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasFilters (Types t)}
+       {auto _ : Cast t CanvasFilters}
     -> t
     -> Attribute True Prelude.id String
   filter v = fromPrim
                "CanvasFilters.getfilter"
                prim__filter
                prim__setFilter
-               (v :> CanvasFilters)
+               (cast {to = CanvasFilters} v)
 
 
 
 namespace CanvasImageData
-
+  
   export
   createImageData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasImageData (Types t1)}
+       {auto _ : Cast t1 CanvasImageData}
     -> (obj : t1)
     -> (sw : Int32)
     -> (sh : Int32)
     -> JSIO ImageData
   createImageData a b c = primJS $
-    CanvasImageData.prim__createImageData (up a) b c
+    CanvasImageData.prim__createImageData (cast a) b c
 
-
+  
   export
   createImageData1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasImageData (Types t1)}
+       {auto _ : Cast t1 CanvasImageData}
     -> (obj : t1)
     -> (imagedata : ImageData)
     -> JSIO ImageData
   createImageData1 a b = primJS $
-    CanvasImageData.prim__createImageData1 (up a) b
+    CanvasImageData.prim__createImageData1 (cast a) b
 
-
+  
   export
   getImageData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasImageData (Types t1)}
+       {auto _ : Cast t1 CanvasImageData}
     -> (obj : t1)
     -> (sx : Int32)
     -> (sy : Int32)
@@ -8846,26 +8602,24 @@ namespace CanvasImageData
     -> (sh : Int32)
     -> JSIO ImageData
   getImageData a b c d e = primJS $
-    CanvasImageData.prim__getImageData (up a) b c d e
+    CanvasImageData.prim__getImageData (cast a) b c d e
 
-
+  
   export
   putImageData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasImageData (Types t1)}
+       {auto _ : Cast t1 CanvasImageData}
     -> (obj : t1)
     -> (imagedata : ImageData)
     -> (dx : Int32)
     -> (dy : Int32)
     -> JSIO ()
   putImageData a b c d = primJS $
-    CanvasImageData.prim__putImageData (up a) b c d
+    CanvasImageData.prim__putImageData (cast a) b c d
 
-
+  
   export
   putImageData1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasImageData (Types t1)}
+       {auto _ : Cast t1 CanvasImageData}
     -> (obj : t1)
     -> (imagedata : ImageData)
     -> (dx : Int32)
@@ -8876,45 +8630,42 @@ namespace CanvasImageData
     -> (dirtyHeight : Int32)
     -> JSIO ()
   putImageData1 a b c d e f g h = primJS $
-    CanvasImageData.prim__putImageData1 (up a) b c d e f g h
+    CanvasImageData.prim__putImageData1 (cast a) b c d e f g h
 
 
 
 namespace CanvasImageSmoothing
-
+  
   export
   imageSmoothingEnabled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasImageSmoothing (Types t)}
+       {auto _ : Cast t CanvasImageSmoothing}
     -> t
     -> Attribute True Prelude.id Bool
   imageSmoothingEnabled v = fromPrim
                               "CanvasImageSmoothing.getimageSmoothingEnabled"
                               prim__imageSmoothingEnabled
                               prim__setImageSmoothingEnabled
-                              (v :> CanvasImageSmoothing)
+                              (cast {to = CanvasImageSmoothing} v)
 
-
+  
   export
   imageSmoothingQuality :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasImageSmoothing (Types t)}
+       {auto _ : Cast t CanvasImageSmoothing}
     -> t
     -> Attribute True Prelude.id ImageSmoothingQuality
   imageSmoothingQuality v = fromPrim
                               "CanvasImageSmoothing.getimageSmoothingQuality"
                               prim__imageSmoothingQuality
                               prim__setImageSmoothingQuality
-                              (v :> CanvasImageSmoothing)
+                              (cast {to = CanvasImageSmoothing} v)
 
 
 
 namespace CanvasPath
-
+  
   export
   arc' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
@@ -8923,12 +8674,12 @@ namespace CanvasPath
     -> (endAngle : Double)
     -> (counterclockwise : Optional Bool)
     -> JSIO ()
-  arc' a b c d e f g = primJS $ CanvasPath.prim__arc (up a) b c d e f (toFFI g)
-
+  arc' a b c d e f g = primJS $
+    CanvasPath.prim__arc (cast a) b c d e f (toFFI g)
+  
   export
   arc :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
@@ -8936,13 +8687,12 @@ namespace CanvasPath
     -> (startAngle : Double)
     -> (endAngle : Double)
     -> JSIO ()
-  arc a b c d e f = primJS $ CanvasPath.prim__arc (up a) b c d e f undef
+  arc a b c d e f = primJS $ CanvasPath.prim__arc (cast a) b c d e f undef
 
-
+  
   export
   arcTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x1 : Double)
     -> (y1 : Double)
@@ -8950,13 +8700,12 @@ namespace CanvasPath
     -> (y2 : Double)
     -> (radius : Double)
     -> JSIO ()
-  arcTo a b c d e f = primJS $ CanvasPath.prim__arcTo (up a) b c d e f
+  arcTo a b c d e f = primJS $ CanvasPath.prim__arcTo (cast a) b c d e f
 
-
+  
   export
   bezierCurveTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (cp1x : Double)
     -> (cp1y : Double)
@@ -8966,22 +8715,17 @@ namespace CanvasPath
     -> (y : Double)
     -> JSIO ()
   bezierCurveTo a b c d e f g = primJS $
-    CanvasPath.prim__bezierCurveTo (up a) b c d e f g
+    CanvasPath.prim__bezierCurveTo (cast a) b c d e f g
 
-
+  
   export
-  closePath :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  closePath a = primJS $ CanvasPath.prim__closePath (up a)
+  closePath : {auto _ : Cast t1 CanvasPath} -> (obj : t1) -> JSIO ()
+  closePath a = primJS $ CanvasPath.prim__closePath (cast a)
 
-
+  
   export
   ellipse' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
@@ -8993,12 +8737,11 @@ namespace CanvasPath
     -> (counterclockwise : Optional Bool)
     -> JSIO ()
   ellipse' a b c d e f g h i = primJS $
-    CanvasPath.prim__ellipse (up a) b c d e f g h (toFFI i)
-
+    CanvasPath.prim__ellipse (cast a) b c d e f g h (toFFI i)
+  
   export
   ellipse :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
@@ -9009,35 +8752,32 @@ namespace CanvasPath
     -> (endAngle : Double)
     -> JSIO ()
   ellipse a b c d e f g h = primJS $
-    CanvasPath.prim__ellipse (up a) b c d e f g h undef
+    CanvasPath.prim__ellipse (cast a) b c d e f g h undef
 
-
+  
   export
   lineTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  lineTo a b c = primJS $ CanvasPath.prim__lineTo (up a) b c
+  lineTo a b c = primJS $ CanvasPath.prim__lineTo (cast a) b c
 
-
+  
   export
   moveTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  moveTo a b c = primJS $ CanvasPath.prim__moveTo (up a) b c
+  moveTo a b c = primJS $ CanvasPath.prim__moveTo (cast a) b c
 
-
+  
   export
   quadraticCurveTo :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (cpx : Double)
     -> (cpy : Double)
@@ -9045,234 +8785,211 @@ namespace CanvasPath
     -> (y : Double)
     -> JSIO ()
   quadraticCurveTo a b c d e = primJS $
-    CanvasPath.prim__quadraticCurveTo (up a) b c d e
+    CanvasPath.prim__quadraticCurveTo (cast a) b c d e
 
-
+  
   export
   rect :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPath (Types t1)}
+       {auto _ : Cast t1 CanvasPath}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> (w : Double)
     -> (h : Double)
     -> JSIO ()
-  rect a b c d e = primJS $ CanvasPath.prim__rect (up a) b c d e
+  rect a b c d e = primJS $ CanvasPath.prim__rect (cast a) b c d e
 
 
 
 namespace CanvasPathDrawingStyles
-
+  
   export
   lineCap :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasPathDrawingStyles}
     -> t
     -> Attribute True Prelude.id CanvasLineCap
   lineCap v = fromPrim
                 "CanvasPathDrawingStyles.getlineCap"
                 prim__lineCap
                 prim__setLineCap
-                (v :> CanvasPathDrawingStyles)
+                (cast {to = CanvasPathDrawingStyles} v)
 
-
+  
   export
   lineDashOffset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasPathDrawingStyles}
     -> t
     -> Attribute True Prelude.id Double
   lineDashOffset v = fromPrim
                        "CanvasPathDrawingStyles.getlineDashOffset"
                        prim__lineDashOffset
                        prim__setLineDashOffset
-                       (v :> CanvasPathDrawingStyles)
+                       (cast {to = CanvasPathDrawingStyles} v)
 
-
+  
   export
   lineJoin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasPathDrawingStyles}
     -> t
     -> Attribute True Prelude.id CanvasLineJoin
   lineJoin v = fromPrim
                  "CanvasPathDrawingStyles.getlineJoin"
                  prim__lineJoin
                  prim__setLineJoin
-                 (v :> CanvasPathDrawingStyles)
+                 (cast {to = CanvasPathDrawingStyles} v)
 
-
+  
   export
   lineWidth :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasPathDrawingStyles}
     -> t
     -> Attribute True Prelude.id Double
   lineWidth v = fromPrim
                   "CanvasPathDrawingStyles.getlineWidth"
                   prim__lineWidth
                   prim__setLineWidth
-                  (v :> CanvasPathDrawingStyles)
+                  (cast {to = CanvasPathDrawingStyles} v)
 
-
+  
   export
   miterLimit :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasPathDrawingStyles}
     -> t
     -> Attribute True Prelude.id Double
   miterLimit v = fromPrim
                    "CanvasPathDrawingStyles.getmiterLimit"
                    prim__miterLimit
                    prim__setMiterLimit
-                   (v :> CanvasPathDrawingStyles)
+                   (cast {to = CanvasPathDrawingStyles} v)
 
-
+  
   export
   getLineDash :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t1)}
+       {auto _ : Cast t1 CanvasPathDrawingStyles}
     -> (obj : t1)
     -> JSIO (Array Double)
-  getLineDash a = primJS $ CanvasPathDrawingStyles.prim__getLineDash (up a)
+  getLineDash a = primJS $ CanvasPathDrawingStyles.prim__getLineDash (cast a)
 
-
+  
   export
   setLineDash :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasPathDrawingStyles (Types t1)}
+       {auto _ : Cast t1 CanvasPathDrawingStyles}
     -> (obj : t1)
     -> (segments : Array Double)
     -> JSIO ()
-  setLineDash a b = primJS $ CanvasPathDrawingStyles.prim__setLineDash (up a) b
+  setLineDash a b = primJS $
+    CanvasPathDrawingStyles.prim__setLineDash (cast a) b
 
 
 
 namespace CanvasRect
-
+  
   export
   clearRect :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasRect (Types t1)}
+       {auto _ : Cast t1 CanvasRect}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> (w : Double)
     -> (h : Double)
     -> JSIO ()
-  clearRect a b c d e = primJS $ CanvasRect.prim__clearRect (up a) b c d e
+  clearRect a b c d e = primJS $ CanvasRect.prim__clearRect (cast a) b c d e
 
-
+  
   export
   fillRect :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasRect (Types t1)}
+       {auto _ : Cast t1 CanvasRect}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> (w : Double)
     -> (h : Double)
     -> JSIO ()
-  fillRect a b c d e = primJS $ CanvasRect.prim__fillRect (up a) b c d e
+  fillRect a b c d e = primJS $ CanvasRect.prim__fillRect (cast a) b c d e
 
-
+  
   export
   strokeRect :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasRect (Types t1)}
+       {auto _ : Cast t1 CanvasRect}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> (w : Double)
     -> (h : Double)
     -> JSIO ()
-  strokeRect a b c d e = primJS $ CanvasRect.prim__strokeRect (up a) b c d e
+  strokeRect a b c d e = primJS $ CanvasRect.prim__strokeRect (cast a) b c d e
 
 
 
 namespace CanvasShadowStyles
-
+  
   export
   shadowBlur :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasShadowStyles (Types t)}
+       {auto _ : Cast t CanvasShadowStyles}
     -> t
     -> Attribute True Prelude.id Double
   shadowBlur v = fromPrim
                    "CanvasShadowStyles.getshadowBlur"
                    prim__shadowBlur
                    prim__setShadowBlur
-                   (v :> CanvasShadowStyles)
+                   (cast {to = CanvasShadowStyles} v)
 
-
+  
   export
   shadowColor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasShadowStyles (Types t)}
+       {auto _ : Cast t CanvasShadowStyles}
     -> t
     -> Attribute True Prelude.id String
   shadowColor v = fromPrim
                     "CanvasShadowStyles.getshadowColor"
                     prim__shadowColor
                     prim__setShadowColor
-                    (v :> CanvasShadowStyles)
+                    (cast {to = CanvasShadowStyles} v)
 
-
+  
   export
   shadowOffsetX :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasShadowStyles (Types t)}
+       {auto _ : Cast t CanvasShadowStyles}
     -> t
     -> Attribute True Prelude.id Double
   shadowOffsetX v = fromPrim
                       "CanvasShadowStyles.getshadowOffsetX"
                       prim__shadowOffsetX
                       prim__setShadowOffsetX
-                      (v :> CanvasShadowStyles)
+                      (cast {to = CanvasShadowStyles} v)
 
-
+  
   export
   shadowOffsetY :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasShadowStyles (Types t)}
+       {auto _ : Cast t CanvasShadowStyles}
     -> t
     -> Attribute True Prelude.id Double
   shadowOffsetY v = fromPrim
                       "CanvasShadowStyles.getshadowOffsetY"
                       prim__shadowOffsetY
                       prim__setShadowOffsetY
-                      (v :> CanvasShadowStyles)
+                      (cast {to = CanvasShadowStyles} v)
 
 
 
 namespace CanvasState
-
+  
   export
-  restore :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasState (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  restore a = primJS $ CanvasState.prim__restore (up a)
+  restore : {auto _ : Cast t1 CanvasState} -> (obj : t1) -> JSIO ()
+  restore a = primJS $ CanvasState.prim__restore (cast a)
 
-
+  
   export
-  save :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasState (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  save a = primJS $ CanvasState.prim__save (up a)
+  save : {auto _ : Cast t1 CanvasState} -> (obj : t1) -> JSIO ()
+  save a = primJS $ CanvasState.prim__save (cast a)
 
 
 
 namespace CanvasText
-
+  
   export
   fillText' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasText (Types t1)}
+       {auto _ : Cast t1 CanvasText}
     -> (obj : t1)
     -> (text : String)
     -> (x : Double)
@@ -9280,34 +8997,31 @@ namespace CanvasText
     -> (maxWidth : Optional Double)
     -> JSIO ()
   fillText' a b c d e = primJS $
-    CanvasText.prim__fillText (up a) b c d (toFFI e)
-
+    CanvasText.prim__fillText (cast a) b c d (toFFI e)
+  
   export
   fillText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasText (Types t1)}
+       {auto _ : Cast t1 CanvasText}
     -> (obj : t1)
     -> (text : String)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  fillText a b c d = primJS $ CanvasText.prim__fillText (up a) b c d undef
+  fillText a b c d = primJS $ CanvasText.prim__fillText (cast a) b c d undef
 
-
+  
   export
   measureText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasText (Types t1)}
+       {auto _ : Cast t1 CanvasText}
     -> (obj : t1)
     -> (text : String)
     -> JSIO TextMetrics
-  measureText a b = primJS $ CanvasText.prim__measureText (up a) b
+  measureText a b = primJS $ CanvasText.prim__measureText (cast a) b
 
-
+  
   export
   strokeText' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasText (Types t1)}
+       {auto _ : Cast t1 CanvasText}
     -> (obj : t1)
     -> (text : String)
     -> (x : Double)
@@ -9315,121 +9029,108 @@ namespace CanvasText
     -> (maxWidth : Optional Double)
     -> JSIO ()
   strokeText' a b c d e = primJS $
-    CanvasText.prim__strokeText (up a) b c d (toFFI e)
-
+    CanvasText.prim__strokeText (cast a) b c d (toFFI e)
+  
   export
   strokeText :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasText (Types t1)}
+       {auto _ : Cast t1 CanvasText}
     -> (obj : t1)
     -> (text : String)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  strokeText a b c d = primJS $ CanvasText.prim__strokeText (up a) b c d undef
+  strokeText a b c d = primJS $ CanvasText.prim__strokeText (cast a) b c d undef
 
 
 
 namespace CanvasTextDrawingStyles
-
+  
   export
   direction :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasTextDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasTextDrawingStyles}
     -> t
     -> Attribute True Prelude.id CanvasDirection
   direction v = fromPrim
                   "CanvasTextDrawingStyles.getdirection"
                   prim__direction
                   prim__setDirection
-                  (v :> CanvasTextDrawingStyles)
+                  (cast {to = CanvasTextDrawingStyles} v)
 
-
+  
   export
   font :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasTextDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasTextDrawingStyles}
     -> t
     -> Attribute True Prelude.id String
   font v = fromPrim
              "CanvasTextDrawingStyles.getfont"
              prim__font
              prim__setFont
-             (v :> CanvasTextDrawingStyles)
+             (cast {to = CanvasTextDrawingStyles} v)
 
-
+  
   export
   textAlign :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasTextDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasTextDrawingStyles}
     -> t
     -> Attribute True Prelude.id CanvasTextAlign
   textAlign v = fromPrim
                   "CanvasTextDrawingStyles.gettextAlign"
                   prim__textAlign
                   prim__setTextAlign
-                  (v :> CanvasTextDrawingStyles)
+                  (cast {to = CanvasTextDrawingStyles} v)
 
-
+  
   export
   textBaseline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasTextDrawingStyles (Types t)}
+       {auto _ : Cast t CanvasTextDrawingStyles}
     -> t
     -> Attribute True Prelude.id CanvasTextBaseline
   textBaseline v = fromPrim
                      "CanvasTextDrawingStyles.gettextBaseline"
                      prim__textBaseline
                      prim__setTextBaseline
-                     (v :> CanvasTextDrawingStyles)
+                     (cast {to = CanvasTextDrawingStyles} v)
 
 
 
 namespace CanvasTransform
-
+  
   export
   getTransform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> JSIO DOMMatrix
-  getTransform a = primJS $ CanvasTransform.prim__getTransform (up a)
+  getTransform a = primJS $ CanvasTransform.prim__getTransform (cast a)
 
-
+  
   export
-  resetTransform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  resetTransform a = primJS $ CanvasTransform.prim__resetTransform (up a)
+  resetTransform : {auto _ : Cast t1 CanvasTransform} -> (obj : t1) -> JSIO ()
+  resetTransform a = primJS $ CanvasTransform.prim__resetTransform (cast a)
 
-
+  
   export
   rotate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> (angle : Double)
     -> JSIO ()
-  rotate a b = primJS $ CanvasTransform.prim__rotate (up a) b
+  rotate a b = primJS $ CanvasTransform.prim__rotate (cast a) b
 
-
+  
   export
   scale :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  scale a b c = primJS $ CanvasTransform.prim__scale (up a) b c
+  scale a b c = primJS $ CanvasTransform.prim__scale (cast a) b c
 
-
+  
   export
   setTransform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> (a : Double)
     -> (b : Double)
@@ -9439,34 +9140,27 @@ namespace CanvasTransform
     -> (f : Double)
     -> JSIO ()
   setTransform a b c d e f g = primJS $
-    CanvasTransform.prim__setTransform (up a) b c d e f g
+    CanvasTransform.prim__setTransform (cast a) b c d e f g
 
-
+  
   export
   setTransform1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t2)}
+       {auto _ : Cast t1 CanvasTransform}
+    -> {auto _ : Cast t2 DOMMatrix2DInit}
     -> (obj : t1)
     -> (transform : Optional t2)
     -> JSIO ()
   setTransform1' a b = primJS $
-    CanvasTransform.prim__setTransform1 (up a) (optUp b)
-
+    CanvasTransform.prim__setTransform1 (cast a) (optUp b)
+  
   export
-  setTransform1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  setTransform1 a = primJS $ CanvasTransform.prim__setTransform1 (up a) undef
+  setTransform1 : {auto _ : Cast t1 CanvasTransform} -> (obj : t1) -> JSIO ()
+  setTransform1 a = primJS $ CanvasTransform.prim__setTransform1 (cast a) undef
 
-
+  
   export
   transform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> (a : Double)
     -> (b : Double)
@@ -9476,1798 +9170,1604 @@ namespace CanvasTransform
     -> (f : Double)
     -> JSIO ()
   transform a b c d e f g = primJS $
-    CanvasTransform.prim__transform (up a) b c d e f g
+    CanvasTransform.prim__transform (cast a) b c d e f g
 
-
+  
   export
   translate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasTransform (Types t1)}
+       {auto _ : Cast t1 CanvasTransform}
     -> (obj : t1)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
-  translate a b c = primJS $ CanvasTransform.prim__translate (up a) b c
+  translate a b c = primJS $ CanvasTransform.prim__translate (cast a) b c
 
 
 
 namespace CanvasUserInterface
-
+  
   export
   drawFocusIfNeeded :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem CanvasUserInterface (Types t1)}
-    -> {auto 0 _ : Elem Element (Types t2)}
+       {auto _ : Cast t1 CanvasUserInterface}
+    -> {auto _ : Cast t2 Element}
     -> (obj : t1)
     -> (element : t2)
     -> JSIO ()
   drawFocusIfNeeded a b = primJS $
-    CanvasUserInterface.prim__drawFocusIfNeeded (up a) (up b)
+    CanvasUserInterface.prim__drawFocusIfNeeded (cast a) (cast b)
 
-
+  
   export
   drawFocusIfNeeded1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem CanvasUserInterface (Types t1)}
-    -> {auto 0 _ : Elem Element (Types t3)}
+       {auto _ : Cast t1 CanvasUserInterface}
+    -> {auto _ : Cast t3 Element}
     -> (obj : t1)
     -> (path : Path2D)
     -> (element : t3)
     -> JSIO ()
   drawFocusIfNeeded1 a b c = primJS $
-    CanvasUserInterface.prim__drawFocusIfNeeded1 (up a) b (up c)
+    CanvasUserInterface.prim__drawFocusIfNeeded1 (cast a) b (cast c)
 
-
+  
   export
   scrollPathIntoView :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasUserInterface (Types t1)}
+       {auto _ : Cast t1 CanvasUserInterface}
     -> (obj : t1)
     -> JSIO ()
   scrollPathIntoView a = primJS $
-    CanvasUserInterface.prim__scrollPathIntoView (up a)
+    CanvasUserInterface.prim__scrollPathIntoView (cast a)
 
-
+  
   export
   scrollPathIntoView1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem CanvasUserInterface (Types t1)}
+       {auto _ : Cast t1 CanvasUserInterface}
     -> (obj : t1)
     -> (path : Path2D)
     -> JSIO ()
   scrollPathIntoView1 a b = primJS $
-    CanvasUserInterface.prim__scrollPathIntoView1 (up a) b
+    CanvasUserInterface.prim__scrollPathIntoView1 (cast a) b
 
 
 
 namespace DocumentAndElementEventHandlers
-
+  
   export
   oncopy :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DocumentAndElementEventHandlers (Types t)}
+       {auto _ : Cast t DocumentAndElementEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncopy v = fromNullablePrim
                "DocumentAndElementEventHandlers.getoncopy"
                prim__oncopy
                prim__setOncopy
-               (v :> DocumentAndElementEventHandlers)
+               (cast {to = DocumentAndElementEventHandlers} v)
 
-
+  
   export
   oncut :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DocumentAndElementEventHandlers (Types t)}
+       {auto _ : Cast t DocumentAndElementEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncut v = fromNullablePrim
               "DocumentAndElementEventHandlers.getoncut"
               prim__oncut
               prim__setOncut
-              (v :> DocumentAndElementEventHandlers)
+              (cast {to = DocumentAndElementEventHandlers} v)
 
-
+  
   export
   onpaste :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DocumentAndElementEventHandlers (Types t)}
+       {auto _ : Cast t DocumentAndElementEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onpaste v = fromNullablePrim
                 "DocumentAndElementEventHandlers.getonpaste"
                 prim__onpaste
                 prim__setOnpaste
-                (v :> DocumentAndElementEventHandlers)
+                (cast {to = DocumentAndElementEventHandlers} v)
 
 
 
 namespace ElementContentEditable
-
+  
   export
   contentEditable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ElementContentEditable (Types t)}
+       {auto _ : Cast t ElementContentEditable}
     -> t
     -> Attribute True Prelude.id String
   contentEditable v = fromPrim
                         "ElementContentEditable.getcontentEditable"
                         prim__contentEditable
                         prim__setContentEditable
-                        (v :> ElementContentEditable)
+                        (cast {to = ElementContentEditable} v)
 
-
+  
   export
   enterKeyHint :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ElementContentEditable (Types t)}
+       {auto _ : Cast t ElementContentEditable}
     -> t
     -> Attribute True Prelude.id String
   enterKeyHint v = fromPrim
                      "ElementContentEditable.getenterKeyHint"
                      prim__enterKeyHint
                      prim__setEnterKeyHint
-                     (v :> ElementContentEditable)
+                     (cast {to = ElementContentEditable} v)
 
-
+  
   export
   inputMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ElementContentEditable (Types t)}
+       {auto _ : Cast t ElementContentEditable}
     -> t
     -> Attribute True Prelude.id String
   inputMode v = fromPrim
                   "ElementContentEditable.getinputMode"
                   prim__inputMode
                   prim__setInputMode
-                  (v :> ElementContentEditable)
+                  (cast {to = ElementContentEditable} v)
 
-
+  
   export
   isContentEditable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ElementContentEditable (Types t1)}
+       {auto _ : Cast t1 ElementContentEditable}
     -> (obj : t1)
     -> JSIO Bool
   isContentEditable a = tryJS "ElementContentEditable.isContentEditable" $
-    ElementContentEditable.prim__isContentEditable (up a)
+    ElementContentEditable.prim__isContentEditable (cast a)
 
 
 
 namespace GlobalEventHandlers
-
+  
   export
   onabort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe UIEventHandler
   onabort v = fromNullablePrim
                 "GlobalEventHandlers.getonabort"
                 prim__onabort
                 prim__setOnabort
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onauxclick :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onauxclick v = fromNullablePrim
                    "GlobalEventHandlers.getonauxclick"
                    prim__onauxclick
                    prim__setOnauxclick
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onblur :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe FocusEventHandler
   onblur v = fromNullablePrim
                "GlobalEventHandlers.getonblur"
                prim__onblur
                prim__setOnblur
-               (v :> GlobalEventHandlers)
+               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oncancel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncancel v = fromNullablePrim
                  "GlobalEventHandlers.getoncancel"
                  prim__oncancel
                  prim__setOncancel
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oncanplay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncanplay v = fromNullablePrim
                   "GlobalEventHandlers.getoncanplay"
                   prim__oncanplay
                   prim__setOncanplay
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oncanplaythrough :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncanplaythrough v = fromNullablePrim
                          "GlobalEventHandlers.getoncanplaythrough"
                          prim__oncanplaythrough
                          prim__setOncanplaythrough
-                         (v :> GlobalEventHandlers)
+                         (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onchange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
                  "GlobalEventHandlers.getonchange"
                  prim__onchange
                  prim__setOnchange
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onclick :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onclick v = fromNullablePrim
                 "GlobalEventHandlers.getonclick"
                 prim__onclick
                 prim__setOnclick
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onclose :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onclose v = fromNullablePrim
                 "GlobalEventHandlers.getonclose"
                 prim__onclose
                 prim__setOnclose
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oncontextmenu :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncontextmenu v = fromNullablePrim
                       "GlobalEventHandlers.getoncontextmenu"
                       prim__oncontextmenu
                       prim__setOncontextmenu
-                      (v :> GlobalEventHandlers)
+                      (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oncuechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oncuechange v = fromNullablePrim
                     "GlobalEventHandlers.getoncuechange"
                     prim__oncuechange
                     prim__setOncuechange
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondblclick :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   ondblclick v = fromNullablePrim
                    "GlobalEventHandlers.getondblclick"
                    prim__ondblclick
                    prim__setOndblclick
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondrag :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondrag v = fromNullablePrim
                "GlobalEventHandlers.getondrag"
                prim__ondrag
                prim__setOndrag
-               (v :> GlobalEventHandlers)
+               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondragend :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondragend v = fromNullablePrim
                   "GlobalEventHandlers.getondragend"
                   prim__ondragend
                   prim__setOndragend
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondragenter :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondragenter v = fromNullablePrim
                     "GlobalEventHandlers.getondragenter"
                     prim__ondragenter
                     prim__setOndragenter
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondragleave :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondragleave v = fromNullablePrim
                     "GlobalEventHandlers.getondragleave"
                     prim__ondragleave
                     prim__setOndragleave
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondragover :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondragover v = fromNullablePrim
                    "GlobalEventHandlers.getondragover"
                    prim__ondragover
                    prim__setOndragover
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondragstart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondragstart v = fromNullablePrim
                     "GlobalEventHandlers.getondragstart"
                     prim__ondragstart
                     prim__setOndragstart
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondrop :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondrop v = fromNullablePrim
                "GlobalEventHandlers.getondrop"
                prim__ondrop
                prim__setOndrop
-               (v :> GlobalEventHandlers)
+               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ondurationchange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ondurationchange v = fromNullablePrim
                          "GlobalEventHandlers.getondurationchange"
                          prim__ondurationchange
                          prim__setOndurationchange
-                         (v :> GlobalEventHandlers)
+                         (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onemptied :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onemptied v = fromNullablePrim
                   "GlobalEventHandlers.getonemptied"
                   prim__onemptied
                   prim__setOnemptied
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onended :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onended v = fromNullablePrim
                 "GlobalEventHandlers.getonended"
                 prim__onended
                 prim__setOnended
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe OnErrorEventHandlerNonNull
   onerror v = fromNullablePrim
                 "GlobalEventHandlers.getonerror"
                 prim__onerror
                 prim__setOnerror
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onfocus :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe FocusEventHandler
   onfocus v = fromNullablePrim
                 "GlobalEventHandlers.getonfocus"
                 prim__onfocus
                 prim__setOnfocus
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onformdata :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onformdata v = fromNullablePrim
                    "GlobalEventHandlers.getonformdata"
                    prim__onformdata
                    prim__setOnformdata
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oninput :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe InputEventHandler
   oninput v = fromNullablePrim
                 "GlobalEventHandlers.getoninput"
                 prim__oninput
                 prim__setOninput
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   oninvalid :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   oninvalid v = fromNullablePrim
                   "GlobalEventHandlers.getoninvalid"
                   prim__oninvalid
                   prim__setOninvalid
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onkeydown :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe KeyboardEventHandler
   onkeydown v = fromNullablePrim
                   "GlobalEventHandlers.getonkeydown"
                   prim__onkeydown
                   prim__setOnkeydown
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onkeypress :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onkeypress v = fromNullablePrim
                    "GlobalEventHandlers.getonkeypress"
                    prim__onkeypress
                    prim__setOnkeypress
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onkeyup :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe KeyboardEventHandler
   onkeyup v = fromNullablePrim
                 "GlobalEventHandlers.getonkeyup"
                 prim__onkeyup
                 prim__setOnkeyup
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onload :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe UIEventHandler
   onload v = fromNullablePrim
                "GlobalEventHandlers.getonload"
                prim__onload
                prim__setOnload
-               (v :> GlobalEventHandlers)
+               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onloadeddata :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onloadeddata v = fromNullablePrim
                      "GlobalEventHandlers.getonloadeddata"
                      prim__onloadeddata
                      prim__setOnloadeddata
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onloadedmetadata :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onloadedmetadata v = fromNullablePrim
                          "GlobalEventHandlers.getonloadedmetadata"
                          prim__onloadedmetadata
                          prim__setOnloadedmetadata
-                         (v :> GlobalEventHandlers)
+                         (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onloadstart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onloadstart v = fromNullablePrim
                     "GlobalEventHandlers.getonloadstart"
                     prim__onloadstart
                     prim__setOnloadstart
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmousedown :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmousedown v = fromNullablePrim
                     "GlobalEventHandlers.getonmousedown"
                     prim__onmousedown
                     prim__setOnmousedown
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmouseenter :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmouseenter v = fromNullablePrim
                      "GlobalEventHandlers.getonmouseenter"
                      prim__onmouseenter
                      prim__setOnmouseenter
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmouseleave :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmouseleave v = fromNullablePrim
                      "GlobalEventHandlers.getonmouseleave"
                      prim__onmouseleave
                      prim__setOnmouseleave
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmousemove :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmousemove v = fromNullablePrim
                     "GlobalEventHandlers.getonmousemove"
                     prim__onmousemove
                     prim__setOnmousemove
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmouseout :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmouseout v = fromNullablePrim
                    "GlobalEventHandlers.getonmouseout"
                    prim__onmouseout
                    prim__setOnmouseout
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmouseover :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmouseover v = fromNullablePrim
                     "GlobalEventHandlers.getonmouseover"
                     prim__onmouseover
                     prim__setOnmouseover
-                    (v :> GlobalEventHandlers)
+                    (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onmouseup :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe MouseEventHandler
   onmouseup v = fromNullablePrim
                   "GlobalEventHandlers.getonmouseup"
                   prim__onmouseup
                   prim__setOnmouseup
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onpause :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onpause v = fromNullablePrim
                 "GlobalEventHandlers.getonpause"
                 prim__onpause
                 prim__setOnpause
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onplay :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onplay v = fromNullablePrim
                "GlobalEventHandlers.getonplay"
                prim__onplay
                prim__setOnplay
-               (v :> GlobalEventHandlers)
+               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onplaying :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onplaying v = fromNullablePrim
                   "GlobalEventHandlers.getonplaying"
                   prim__onplaying
                   prim__setOnplaying
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onprogress :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onprogress v = fromNullablePrim
                    "GlobalEventHandlers.getonprogress"
                    prim__onprogress
                    prim__setOnprogress
-                   (v :> GlobalEventHandlers)
+                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onratechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onratechange v = fromNullablePrim
                      "GlobalEventHandlers.getonratechange"
                      prim__onratechange
                      prim__setOnratechange
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onreset :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onreset v = fromNullablePrim
                 "GlobalEventHandlers.getonreset"
                 prim__onreset
                 prim__setOnreset
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onresize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onresize v = fromNullablePrim
                  "GlobalEventHandlers.getonresize"
                  prim__onresize
                  prim__setOnresize
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onscroll :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onscroll v = fromNullablePrim
                  "GlobalEventHandlers.getonscroll"
                  prim__onscroll
                  prim__setOnscroll
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onsecuritypolicyviolation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onsecuritypolicyviolation v = fromNullablePrim
                                   "GlobalEventHandlers.getonsecuritypolicyviolation"
                                   prim__onsecuritypolicyviolation
                                   prim__setOnsecuritypolicyviolation
-                                  (v :> GlobalEventHandlers)
+                                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onseeked :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onseeked v = fromNullablePrim
                  "GlobalEventHandlers.getonseeked"
                  prim__onseeked
                  prim__setOnseeked
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onseeking :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onseeking v = fromNullablePrim
                   "GlobalEventHandlers.getonseeking"
                   prim__onseeking
                   prim__setOnseeking
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onselect :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe UIEventHandler
   onselect v = fromNullablePrim
                  "GlobalEventHandlers.getonselect"
                  prim__onselect
                  prim__setOnselect
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onslotchange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onslotchange v = fromNullablePrim
                      "GlobalEventHandlers.getonslotchange"
                      prim__onslotchange
                      prim__setOnslotchange
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onstalled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onstalled v = fromNullablePrim
                   "GlobalEventHandlers.getonstalled"
                   prim__onstalled
                   prim__setOnstalled
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onsubmit :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onsubmit v = fromNullablePrim
                  "GlobalEventHandlers.getonsubmit"
                  prim__onsubmit
                  prim__setOnsubmit
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onsuspend :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onsuspend v = fromNullablePrim
                   "GlobalEventHandlers.getonsuspend"
                   prim__onsuspend
                   prim__setOnsuspend
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ontimeupdate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ontimeupdate v = fromNullablePrim
                      "GlobalEventHandlers.getontimeupdate"
                      prim__ontimeupdate
                      prim__setOntimeupdate
-                     (v :> GlobalEventHandlers)
+                     (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   ontoggle :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ontoggle v = fromNullablePrim
                  "GlobalEventHandlers.getontoggle"
                  prim__ontoggle
                  prim__setOntoggle
-                 (v :> GlobalEventHandlers)
+                 (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onvolumechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onvolumechange v = fromNullablePrim
                        "GlobalEventHandlers.getonvolumechange"
                        prim__onvolumechange
                        prim__setOnvolumechange
-                       (v :> GlobalEventHandlers)
+                       (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwaiting :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onwaiting v = fromNullablePrim
                   "GlobalEventHandlers.getonwaiting"
                   prim__onwaiting
                   prim__setOnwaiting
-                  (v :> GlobalEventHandlers)
+                  (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwebkitanimationend :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onwebkitanimationend v = fromNullablePrim
                              "GlobalEventHandlers.getonwebkitanimationend"
                              prim__onwebkitanimationend
                              prim__setOnwebkitanimationend
-                             (v :> GlobalEventHandlers)
+                             (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwebkitanimationiteration :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onwebkitanimationiteration v = fromNullablePrim
                                    "GlobalEventHandlers.getonwebkitanimationiteration"
                                    prim__onwebkitanimationiteration
                                    prim__setOnwebkitanimationiteration
-                                   (v :> GlobalEventHandlers)
+                                   (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwebkitanimationstart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onwebkitanimationstart v = fromNullablePrim
                                "GlobalEventHandlers.getonwebkitanimationstart"
                                prim__onwebkitanimationstart
                                prim__setOnwebkitanimationstart
-                               (v :> GlobalEventHandlers)
+                               (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwebkittransitionend :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onwebkittransitionend v = fromNullablePrim
                               "GlobalEventHandlers.getonwebkittransitionend"
                               prim__onwebkittransitionend
                               prim__setOnwebkittransitionend
-                              (v :> GlobalEventHandlers)
+                              (cast {to = GlobalEventHandlers} v)
 
-
+  
   export
   onwheel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem GlobalEventHandlers (Types t)}
+       {auto _ : Cast t GlobalEventHandlers}
     -> t
     -> Attribute False Maybe WheelEventHandler
   onwheel v = fromNullablePrim
                 "GlobalEventHandlers.getonwheel"
                 prim__onwheel
                 prim__setOnwheel
-                (v :> GlobalEventHandlers)
+                (cast {to = GlobalEventHandlers} v)
 
 
 
 namespace HTMLHyperlinkElementUtils
-
+  
   export
   hash :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   hash v = fromPrim
              "HTMLHyperlinkElementUtils.gethash"
              prim__hash
              prim__setHash
-             (v :> HTMLHyperlinkElementUtils)
+             (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   host :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   host v = fromPrim
              "HTMLHyperlinkElementUtils.gethost"
              prim__host
              prim__setHost
-             (v :> HTMLHyperlinkElementUtils)
+             (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   hostname :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   hostname v = fromPrim
                  "HTMLHyperlinkElementUtils.gethostname"
                  prim__hostname
                  prim__setHostname
-                 (v :> HTMLHyperlinkElementUtils)
+                 (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   href :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   href v = fromPrim
              "HTMLHyperlinkElementUtils.gethref"
              prim__href
              prim__setHref
-             (v :> HTMLHyperlinkElementUtils)
+             (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   origin :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t1)}
+       {auto _ : Cast t1 HTMLHyperlinkElementUtils}
     -> (obj : t1)
     -> JSIO String
-  origin a = primJS $ HTMLHyperlinkElementUtils.prim__origin (up a)
+  origin a = primJS $ HTMLHyperlinkElementUtils.prim__origin (cast a)
 
-
+  
   export
   password :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   password v = fromPrim
                  "HTMLHyperlinkElementUtils.getpassword"
                  prim__password
                  prim__setPassword
-                 (v :> HTMLHyperlinkElementUtils)
+                 (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   pathname :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   pathname v = fromPrim
                  "HTMLHyperlinkElementUtils.getpathname"
                  prim__pathname
                  prim__setPathname
-                 (v :> HTMLHyperlinkElementUtils)
+                 (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   port :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   port v = fromPrim
              "HTMLHyperlinkElementUtils.getport"
              prim__port
              prim__setPort
-             (v :> HTMLHyperlinkElementUtils)
+             (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   protocol :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   protocol v = fromPrim
                  "HTMLHyperlinkElementUtils.getprotocol"
                  prim__protocol
                  prim__setProtocol
-                 (v :> HTMLHyperlinkElementUtils)
+                 (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   search :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   search v = fromPrim
                "HTMLHyperlinkElementUtils.getsearch"
                prim__search
                prim__setSearch
-               (v :> HTMLHyperlinkElementUtils)
+               (cast {to = HTMLHyperlinkElementUtils} v)
 
-
+  
   export
   username :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLHyperlinkElementUtils (Types t)}
+       {auto _ : Cast t HTMLHyperlinkElementUtils}
     -> t
     -> Attribute True Prelude.id String
   username v = fromPrim
                  "HTMLHyperlinkElementUtils.getusername"
                  prim__username
                  prim__setUsername
-                 (v :> HTMLHyperlinkElementUtils)
+                 (cast {to = HTMLHyperlinkElementUtils} v)
 
 
 
 namespace HTMLOrSVGElement
-
+  
   export
   autofocus :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t)}
+       {auto _ : Cast t HTMLOrSVGElement}
     -> t
     -> Attribute True Prelude.id Bool
   autofocus v = fromPrim
                   "HTMLOrSVGElement.getautofocus"
                   prim__autofocus
                   prim__setAutofocus
-                  (v :> HTMLOrSVGElement)
+                  (cast {to = HTMLOrSVGElement} v)
 
-
+  
   export
   dataset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t1)}
+       {auto _ : Cast t1 HTMLOrSVGElement}
     -> (obj : t1)
     -> JSIO DOMStringMap
-  dataset a = primJS $ HTMLOrSVGElement.prim__dataset (up a)
+  dataset a = primJS $ HTMLOrSVGElement.prim__dataset (cast a)
 
-
+  
   export
   nonce :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t)}
+       {auto _ : Cast t HTMLOrSVGElement}
     -> t
     -> Attribute True Prelude.id String
   nonce v = fromPrim
               "HTMLOrSVGElement.getnonce"
               prim__nonce
               prim__setNonce
-              (v :> HTMLOrSVGElement)
+              (cast {to = HTMLOrSVGElement} v)
 
-
+  
   export
   tabIndex :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t)}
+       {auto _ : Cast t HTMLOrSVGElement}
     -> t
     -> Attribute True Prelude.id Int32
   tabIndex v = fromPrim
                  "HTMLOrSVGElement.gettabIndex"
                  prim__tabIndex
                  prim__setTabIndex
-                 (v :> HTMLOrSVGElement)
+                 (cast {to = HTMLOrSVGElement} v)
 
-
+  
   export
-  blur :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  blur a = primJS $ HTMLOrSVGElement.prim__blur (up a)
+  blur : {auto _ : Cast t1 HTMLOrSVGElement} -> (obj : t1) -> JSIO ()
+  blur a = primJS $ HTMLOrSVGElement.prim__blur (cast a)
 
-
+  
   export
   focus' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t1)}
-    -> {auto 0 _ : Elem FocusOptions (Types t2)}
+       {auto _ : Cast t1 HTMLOrSVGElement}
+    -> {auto _ : Cast t2 FocusOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO ()
-  focus' a b = primJS $ HTMLOrSVGElement.prim__focus (up a) (optUp b)
-
+  focus' a b = primJS $ HTMLOrSVGElement.prim__focus (cast a) (optUp b)
+  
   export
-  focus :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLOrSVGElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  focus a = primJS $ HTMLOrSVGElement.prim__focus (up a) undef
+  focus : {auto _ : Cast t1 HTMLOrSVGElement} -> (obj : t1) -> JSIO ()
+  focus a = primJS $ HTMLOrSVGElement.prim__focus (cast a) undef
 
 
 
 namespace NavigatorConcurrentHardware
-
+  
   export
   hardwareConcurrency :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorConcurrentHardware (Types t1)}
+       {auto _ : Cast t1 NavigatorConcurrentHardware}
     -> (obj : t1)
     -> JSIO JSBits64
   hardwareConcurrency a = primJS $
-    NavigatorConcurrentHardware.prim__hardwareConcurrency (up a)
+    NavigatorConcurrentHardware.prim__hardwareConcurrency (cast a)
 
 
 
 namespace NavigatorContentUtils
-
+  
   export
   registerProtocolHandler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorContentUtils (Types t1)}
+       {auto _ : Cast t1 NavigatorContentUtils}
     -> (obj : t1)
     -> (scheme : String)
     -> (url : String)
     -> JSIO ()
   registerProtocolHandler a b c = primJS $
-    NavigatorContentUtils.prim__registerProtocolHandler (up a) b c
+    NavigatorContentUtils.prim__registerProtocolHandler (cast a) b c
 
-
+  
   export
   unregisterProtocolHandler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorContentUtils (Types t1)}
+       {auto _ : Cast t1 NavigatorContentUtils}
     -> (obj : t1)
     -> (scheme : String)
     -> (url : String)
     -> JSIO ()
   unregisterProtocolHandler a b c = primJS $
-    NavigatorContentUtils.prim__unregisterProtocolHandler (up a) b c
+    NavigatorContentUtils.prim__unregisterProtocolHandler (cast a) b c
 
 
 
 namespace NavigatorCookies
-
+  
   export
-  cookieEnabled :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorCookies (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  cookieEnabled : {auto _ : Cast t1 NavigatorCookies} -> (obj : t1) -> JSIO Bool
   cookieEnabled a = tryJS "NavigatorCookies.cookieEnabled" $
-    NavigatorCookies.prim__cookieEnabled (up a)
+    NavigatorCookies.prim__cookieEnabled (cast a)
 
 
 
 namespace NavigatorID
-
+  
   export
-  appCodeName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  appCodeName a = primJS $ NavigatorID.prim__appCodeName (up a)
+  appCodeName : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  appCodeName a = primJS $ NavigatorID.prim__appCodeName (cast a)
 
-
+  
   export
-  appName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  appName a = primJS $ NavigatorID.prim__appName (up a)
+  appName : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  appName a = primJS $ NavigatorID.prim__appName (cast a)
 
-
+  
   export
-  appVersion :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  appVersion a = primJS $ NavigatorID.prim__appVersion (up a)
+  appVersion : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  appVersion a = primJS $ NavigatorID.prim__appVersion (cast a)
 
-
+  
   export
-  platform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  platform a = primJS $ NavigatorID.prim__platform (up a)
+  platform : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  platform a = primJS $ NavigatorID.prim__platform (cast a)
 
-
+  
   export
-  product :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  product a = primJS $ NavigatorID.prim__product (up a)
+  product : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  product a = primJS $ NavigatorID.prim__product (cast a)
 
-
+  
   export
-  productSub :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  productSub a = primJS $ NavigatorID.prim__productSub (up a)
+  productSub : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  productSub a = primJS $ NavigatorID.prim__productSub (cast a)
 
-
+  
   export
-  userAgent :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  userAgent a = primJS $ NavigatorID.prim__userAgent (up a)
+  userAgent : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  userAgent a = primJS $ NavigatorID.prim__userAgent (cast a)
 
-
+  
   export
-  vendor :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  vendor a = primJS $ NavigatorID.prim__vendor (up a)
+  vendor : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  vendor a = primJS $ NavigatorID.prim__vendor (cast a)
 
-
+  
   export
-  vendorSub :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorID (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  vendorSub a = primJS $ NavigatorID.prim__vendorSub (up a)
+  vendorSub : {auto _ : Cast t1 NavigatorID} -> (obj : t1) -> JSIO String
+  vendorSub a = primJS $ NavigatorID.prim__vendorSub (cast a)
 
 
 
 namespace NavigatorLanguage
-
+  
   export
-  language :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorLanguage (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  language a = primJS $ NavigatorLanguage.prim__language (up a)
+  language : {auto _ : Cast t1 NavigatorLanguage} -> (obj : t1) -> JSIO String
+  language a = primJS $ NavigatorLanguage.prim__language (cast a)
 
-
+  
   export
   languages :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorLanguage (Types t1)}
+       {auto _ : Cast t1 NavigatorLanguage}
     -> (obj : t1)
     -> JSIO (Array String)
-  languages a = primJS $ NavigatorLanguage.prim__languages (up a)
+  languages a = primJS $ NavigatorLanguage.prim__languages (cast a)
 
 
 
 namespace NavigatorOnLine
-
+  
   export
-  onLine :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorOnLine (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  onLine : {auto _ : Cast t1 NavigatorOnLine} -> (obj : t1) -> JSIO Bool
   onLine a = tryJS "NavigatorOnLine.onLine" $
-    NavigatorOnLine.prim__onLine (up a)
+    NavigatorOnLine.prim__onLine (cast a)
 
 
 
 namespace NavigatorPlugins
-
+  
   export
   mimeTypes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorPlugins (Types t1)}
+       {auto _ : Cast t1 NavigatorPlugins}
     -> (obj : t1)
     -> JSIO MimeTypeArray
-  mimeTypes a = primJS $ NavigatorPlugins.prim__mimeTypes (up a)
+  mimeTypes a = primJS $ NavigatorPlugins.prim__mimeTypes (cast a)
 
-
+  
   export
   plugins :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorPlugins (Types t1)}
+       {auto _ : Cast t1 NavigatorPlugins}
     -> (obj : t1)
     -> JSIO PluginArray
-  plugins a = primJS $ NavigatorPlugins.prim__plugins (up a)
+  plugins a = primJS $ NavigatorPlugins.prim__plugins (cast a)
 
-
+  
   export
-  javaEnabled :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem NavigatorPlugins (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
+  javaEnabled : {auto _ : Cast t1 NavigatorPlugins} -> (obj : t1) -> JSIO Bool
   javaEnabled a = tryJS "NavigatorPlugins.javaEnabled" $
-    NavigatorPlugins.prim__javaEnabled (up a)
+    NavigatorPlugins.prim__javaEnabled (cast a)
 
 
 
 namespace WindowEventHandlers
-
+  
   export
   onafterprint :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onafterprint v = fromNullablePrim
                      "WindowEventHandlers.getonafterprint"
                      prim__onafterprint
                      prim__setOnafterprint
-                     (v :> WindowEventHandlers)
+                     (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onbeforeprint :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onbeforeprint v = fromNullablePrim
                       "WindowEventHandlers.getonbeforeprint"
                       prim__onbeforeprint
                       prim__setOnbeforeprint
-                      (v :> WindowEventHandlers)
+                      (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onbeforeunload :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe OnBeforeUnloadEventHandlerNonNull
   onbeforeunload v = fromNullablePrim
                        "WindowEventHandlers.getonbeforeunload"
                        prim__onbeforeunload
                        prim__setOnbeforeunload
-                       (v :> WindowEventHandlers)
+                       (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onhashchange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onhashchange v = fromNullablePrim
                      "WindowEventHandlers.getonhashchange"
                      prim__onhashchange
                      prim__setOnhashchange
-                     (v :> WindowEventHandlers)
+                     (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onlanguagechange :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onlanguagechange v = fromNullablePrim
                          "WindowEventHandlers.getonlanguagechange"
                          prim__onlanguagechange
                          prim__setOnlanguagechange
-                         (v :> WindowEventHandlers)
+                         (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onmessage :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onmessage v = fromNullablePrim
                   "WindowEventHandlers.getonmessage"
                   prim__onmessage
                   prim__setOnmessage
-                  (v :> WindowEventHandlers)
+                  (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onmessageerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onmessageerror v = fromNullablePrim
                        "WindowEventHandlers.getonmessageerror"
                        prim__onmessageerror
                        prim__setOnmessageerror
-                       (v :> WindowEventHandlers)
+                       (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onoffline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onoffline v = fromNullablePrim
                   "WindowEventHandlers.getonoffline"
                   prim__onoffline
                   prim__setOnoffline
-                  (v :> WindowEventHandlers)
+                  (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   ononline :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ononline v = fromNullablePrim
                  "WindowEventHandlers.getononline"
                  prim__ononline
                  prim__setOnonline
-                 (v :> WindowEventHandlers)
+                 (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onpagehide :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onpagehide v = fromNullablePrim
                    "WindowEventHandlers.getonpagehide"
                    prim__onpagehide
                    prim__setOnpagehide
-                   (v :> WindowEventHandlers)
+                   (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onpageshow :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onpageshow v = fromNullablePrim
                    "WindowEventHandlers.getonpageshow"
                    prim__onpageshow
                    prim__setOnpageshow
-                   (v :> WindowEventHandlers)
+                   (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onpopstate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onpopstate v = fromNullablePrim
                    "WindowEventHandlers.getonpopstate"
                    prim__onpopstate
                    prim__setOnpopstate
-                   (v :> WindowEventHandlers)
+                   (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onrejectionhandled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onrejectionhandled v = fromNullablePrim
                            "WindowEventHandlers.getonrejectionhandled"
                            prim__onrejectionhandled
                            prim__setOnrejectionhandled
-                           (v :> WindowEventHandlers)
+                           (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onstorage :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onstorage v = fromNullablePrim
                   "WindowEventHandlers.getonstorage"
                   prim__onstorage
                   prim__setOnstorage
-                  (v :> WindowEventHandlers)
+                  (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onunhandledrejection :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onunhandledrejection v = fromNullablePrim
                              "WindowEventHandlers.getonunhandledrejection"
                              prim__onunhandledrejection
                              prim__setOnunhandledrejection
-                             (v :> WindowEventHandlers)
+                             (cast {to = WindowEventHandlers} v)
 
-
+  
   export
   onunload :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowEventHandlers (Types t)}
+       {auto _ : Cast t WindowEventHandlers}
     -> t
     -> Attribute False Maybe UIEventHandler
   onunload v = fromNullablePrim
                  "WindowEventHandlers.getonunload"
                  prim__onunload
                  prim__setOnunload
-                 (v :> WindowEventHandlers)
+                 (cast {to = WindowEventHandlers} v)
 
 
 
 namespace WindowLocalStorage
-
+  
   export
   localStorage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowLocalStorage (Types t1)}
+       {auto _ : Cast t1 WindowLocalStorage}
     -> (obj : t1)
     -> JSIO Storage
-  localStorage a = primJS $ WindowLocalStorage.prim__localStorage (up a)
+  localStorage a = primJS $ WindowLocalStorage.prim__localStorage (cast a)
 
 
 
 namespace WindowOrWorkerGlobalScope
-
+  
   export
   caches :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO CacheStorage
-  caches a = primJS $ WindowOrWorkerGlobalScope.prim__caches (up a)
+  caches a = primJS $ WindowOrWorkerGlobalScope.prim__caches (cast a)
 
-
+  
   export
   crossOriginIsolated :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO Bool
   crossOriginIsolated a = tryJS "WindowOrWorkerGlobalScope.crossOriginIsolated" $
-    WindowOrWorkerGlobalScope.prim__crossOriginIsolated (up a)
+    WindowOrWorkerGlobalScope.prim__crossOriginIsolated (cast a)
 
-
+  
   export
   indexedDB :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO IDBFactory
-  indexedDB a = primJS $ WindowOrWorkerGlobalScope.prim__indexedDB (up a)
+  indexedDB a = primJS $ WindowOrWorkerGlobalScope.prim__indexedDB (cast a)
 
-
+  
   export
   isSecureContext :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO Bool
   isSecureContext a = tryJS "WindowOrWorkerGlobalScope.isSecureContext" $
-    WindowOrWorkerGlobalScope.prim__isSecureContext (up a)
+    WindowOrWorkerGlobalScope.prim__isSecureContext (cast a)
 
-
+  
   export
   origin :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO String
-  origin a = primJS $ WindowOrWorkerGlobalScope.prim__origin (up a)
+  origin a = primJS $ WindowOrWorkerGlobalScope.prim__origin (cast a)
 
-
+  
   export
   performance :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO Performance
-  performance a = primJS $ WindowOrWorkerGlobalScope.prim__performance (up a)
+  performance a = primJS $ WindowOrWorkerGlobalScope.prim__performance (cast a)
 
-
+  
   export
   atob :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO ByteString
-  atob a b = primJS $ WindowOrWorkerGlobalScope.prim__atob (up a) b
+  atob a b = primJS $ WindowOrWorkerGlobalScope.prim__atob (cast a) b
 
-
+  
   export
   btoa :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (data_ : String)
     -> JSIO String
-  btoa a b = primJS $ WindowOrWorkerGlobalScope.prim__btoa (up a) b
+  btoa a b = primJS $ WindowOrWorkerGlobalScope.prim__btoa (cast a) b
 
-
+  
   export
   clearInterval' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (id : Optional Int32)
     -> JSIO ()
   clearInterval' a b = primJS $
-    WindowOrWorkerGlobalScope.prim__clearInterval (up a) (toFFI b)
-
+    WindowOrWorkerGlobalScope.prim__clearInterval (cast a) (toFFI b)
+  
   export
   clearInterval :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO ()
   clearInterval a = primJS $
-    WindowOrWorkerGlobalScope.prim__clearInterval (up a) undef
+    WindowOrWorkerGlobalScope.prim__clearInterval (cast a) undef
 
-
+  
   export
   clearTimeout' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (id : Optional Int32)
     -> JSIO ()
   clearTimeout' a b = primJS $
-    WindowOrWorkerGlobalScope.prim__clearTimeout (up a) (toFFI b)
-
+    WindowOrWorkerGlobalScope.prim__clearTimeout (cast a) (toFFI b)
+  
   export
   clearTimeout :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> JSIO ()
   clearTimeout a = primJS $
-    WindowOrWorkerGlobalScope.prim__clearTimeout (up a) undef
+    WindowOrWorkerGlobalScope.prim__clearTimeout (cast a) undef
 
-
+  
   export
   createImageBitmap' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t3)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
+    -> {auto _ : Cast t3 ImageBitmapOptions}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -11282,12 +10782,14 @@ namespace WindowOrWorkerGlobalScope
     -> (options : Optional t3)
     -> JSIO (Promise ImageBitmap)
   createImageBitmap' a b c = primJS $
-    WindowOrWorkerGlobalScope.prim__createImageBitmap (up a) (toFFI b) (optUp c)
-
+    WindowOrWorkerGlobalScope.prim__createImageBitmap
+      (cast a)
+      (toFFI b)
+      (optUp c)
+  
   export
   createImageBitmap :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -11301,15 +10803,13 @@ namespace WindowOrWorkerGlobalScope
                   ])
     -> JSIO (Promise ImageBitmap)
   createImageBitmap a b = primJS $
-    WindowOrWorkerGlobalScope.prim__createImageBitmap (up a) (toFFI b) undef
+    WindowOrWorkerGlobalScope.prim__createImageBitmap (cast a) (toFFI b) undef
 
-
+  
   export
   createImageBitmap1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t7}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t7)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
+    -> {auto _ : Cast t7 ImageBitmapOptions}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -11329,18 +10829,17 @@ namespace WindowOrWorkerGlobalScope
     -> JSIO (Promise ImageBitmap)
   createImageBitmap1' a b c d e f g = primJS $
     WindowOrWorkerGlobalScope.prim__createImageBitmap1
-      (up a)
+      (cast a)
       (toFFI b)
       c
       d
       e
       f
       (optUp g)
-
+  
   export
   createImageBitmap1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (image : HSum
                   [ HTMLImageElement
@@ -11359,7 +10858,7 @@ namespace WindowOrWorkerGlobalScope
     -> JSIO (Promise ImageBitmap)
   createImageBitmap1 a b c d e f = primJS $
     WindowOrWorkerGlobalScope.prim__createImageBitmap1
-      (up a)
+      (cast a)
       (toFFI b)
       c
       d
@@ -11367,75 +10866,67 @@ namespace WindowOrWorkerGlobalScope
       f
       undef
 
-
+  
   export
   fetch' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
-    -> {auto 0 _ : Elem RequestInit (Types t3)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
+    -> {auto _ : Cast t3 RequestInit}
     -> (obj : t1)
     -> (input : HSum [Request, String])
     -> (init : Optional t3)
     -> JSIO (Promise Response)
   fetch' a b c = primJS $
-    WindowOrWorkerGlobalScope.prim__fetch (up a) (toFFI b) (optUp c)
-
+    WindowOrWorkerGlobalScope.prim__fetch (cast a) (toFFI b) (optUp c)
+  
   export
   fetch :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (input : HSum [Request, String])
     -> JSIO (Promise Response)
   fetch a b = primJS $
-    WindowOrWorkerGlobalScope.prim__fetch (up a) (toFFI b) undef
+    WindowOrWorkerGlobalScope.prim__fetch (cast a) (toFFI b) undef
 
-
+  
   export
   queueMicrotask :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (callback : VoidFunction)
     -> JSIO ()
   queueMicrotask a b = primJS $
-    WindowOrWorkerGlobalScope.prim__queueMicrotask (up a) b
+    WindowOrWorkerGlobalScope.prim__queueMicrotask (cast a) b
 
-
+  
   export
   reportError :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (e : Any)
     -> JSIO ()
   reportError a b = primJS $
-    WindowOrWorkerGlobalScope.prim__reportError (up a) (toFFI b)
+    WindowOrWorkerGlobalScope.prim__reportError (cast a) (toFFI b)
 
-
+  
   export
   structuredClone' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
-    -> {auto 0 _ : Elem StructuredSerializeOptions (Types t3)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
+    -> {auto _ : Cast t3 StructuredSerializeOptions}
     -> (obj : t1)
     -> (value : Any)
     -> (options : Optional t3)
     -> JSIO Any
   structuredClone' a b c = tryJS "WindowOrWorkerGlobalScope.structuredClone'" $
-    WindowOrWorkerGlobalScope.prim__structuredClone (up a) (toFFI b) (optUp c)
-
+    WindowOrWorkerGlobalScope.prim__structuredClone (cast a) (toFFI b) (optUp c)
+  
   export
   structuredClone :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WindowOrWorkerGlobalScope (Types t1)}
+       {auto _ : Cast t1 WindowOrWorkerGlobalScope}
     -> (obj : t1)
     -> (value : Any)
     -> JSIO Any
   structuredClone a b = tryJS "WindowOrWorkerGlobalScope.structuredClone" $
-    WindowOrWorkerGlobalScope.prim__structuredClone (up a) (toFFI b) undef
+    WindowOrWorkerGlobalScope.prim__structuredClone (cast a) (toFFI b) undef
 
 
 
@@ -11445,20 +10936,19 @@ namespace WindowOrWorkerGlobalScope
 --------------------------------------------------------------------------------
 
 namespace AssignedNodesOptions
-
+  
   export
   new' : (flatten : Optional Bool) -> JSIO AssignedNodesOptions
   new' a = primJS $ AssignedNodesOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO AssignedNodesOptions
   new = primJS $ AssignedNodesOptions.prim__new undef
 
-
+  
   export
   flatten :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem AssignedNodesOptions (Types t)}
+       {auto _ : Cast t AssignedNodesOptions}
     -> t
     -> Attribute True Optional Bool
   flatten v = fromUndefOrPrim
@@ -11466,12 +10956,12 @@ namespace AssignedNodesOptions
                 prim__flatten
                 prim__setFlatten
                 False
-                (v :> AssignedNodesOptions)
+                (cast {to = AssignedNodesOptions} v)
 
 
 
 namespace CanvasRenderingContext2DSettings
-
+  
   export
   new' :
        (alpha : Optional Bool)
@@ -11479,16 +10969,15 @@ namespace CanvasRenderingContext2DSettings
     -> JSIO CanvasRenderingContext2DSettings
   new' a b = primJS $
     CanvasRenderingContext2DSettings.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO CanvasRenderingContext2DSettings
   new = primJS $ CanvasRenderingContext2DSettings.prim__new undef undef
 
-
+  
   export
   alpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasRenderingContext2DSettings (Types t)}
+       {auto _ : Cast t CanvasRenderingContext2DSettings}
     -> t
     -> Attribute True Optional Bool
   alpha v = fromUndefOrPrim
@@ -11496,13 +10985,12 @@ namespace CanvasRenderingContext2DSettings
               prim__alpha
               prim__setAlpha
               True
-              (v :> CanvasRenderingContext2DSettings)
+              (cast {to = CanvasRenderingContext2DSettings} v)
 
-
+  
   export
   desynchronized :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CanvasRenderingContext2DSettings (Types t)}
+       {auto _ : Cast t CanvasRenderingContext2DSettings}
     -> t
     -> Attribute True Optional Bool
   desynchronized v = fromUndefOrPrim
@@ -11510,12 +10998,12 @@ namespace CanvasRenderingContext2DSettings
                        prim__desynchronized
                        prim__setDesynchronized
                        False
-                       (v :> CanvasRenderingContext2DSettings)
+                       (cast {to = CanvasRenderingContext2DSettings} v)
 
 
 
 namespace CloseEventInit
-
+  
   export
   new' :
        (wasClean : Optional Bool)
@@ -11523,30 +11011,25 @@ namespace CloseEventInit
     -> (reason : Optional String)
     -> JSIO CloseEventInit
   new' a b c = primJS $ CloseEventInit.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO CloseEventInit
   new = primJS $ CloseEventInit.prim__new undef undef undef
 
-
+  
   export
-  code :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CloseEventInit (Types t)}
-    -> t
-    -> Attribute True Optional Bits16
+  code : {auto _ : Cast t CloseEventInit} -> t -> Attribute True Optional Bits16
   code v = fromUndefOrPrim
              "CloseEventInit.getcode"
              prim__code
              prim__setCode
              0
-             (v :> CloseEventInit)
+             (cast {to = CloseEventInit} v)
 
-
+  
   export
   reason :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CloseEventInit (Types t)}
+       {auto _ : Cast t CloseEventInit}
     -> t
     -> Attribute True Optional String
   reason v = fromUndefOrPrim
@@ -11554,13 +11037,12 @@ namespace CloseEventInit
                prim__reason
                prim__setReason
                ""
-               (v :> CloseEventInit)
+               (cast {to = CloseEventInit} v)
 
-
+  
   export
   wasClean :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CloseEventInit (Types t)}
+       {auto _ : Cast t CloseEventInit}
     -> t
     -> Attribute True Optional Bool
   wasClean v = fromUndefOrPrim
@@ -11568,25 +11050,24 @@ namespace CloseEventInit
                  prim__wasClean
                  prim__setWasClean
                  False
-                 (v :> CloseEventInit)
+                 (cast {to = CloseEventInit} v)
 
 
 
 namespace DragEventInit
-
+  
   export
   new' : (dataTransfer : Optional (Maybe DataTransfer)) -> JSIO DragEventInit
   new' a = primJS $ DragEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO DragEventInit
   new = primJS $ DragEventInit.prim__new undef
 
-
+  
   export
   dataTransfer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DragEventInit (Types t)}
+       {auto _ : Cast t DragEventInit}
     -> t
     -> Attribute True Optional (Maybe DataTransfer)
   dataTransfer v = fromUndefOrPrim
@@ -11594,37 +11075,36 @@ namespace DragEventInit
                      prim__dataTransfer
                      prim__setDataTransfer
                      Nothing
-                     (v :> DragEventInit)
+                     (cast {to = DragEventInit} v)
 
 
 
 namespace ElementDefinitionOptions
-
+  
   export
   new' : (extends : Optional String) -> JSIO ElementDefinitionOptions
   new' a = primJS $ ElementDefinitionOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ElementDefinitionOptions
   new = primJS $ ElementDefinitionOptions.prim__new undef
 
-
+  
   export
   extends :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ElementDefinitionOptions (Types t)}
+       {auto _ : Cast t ElementDefinitionOptions}
     -> t
     -> Attribute False Optional String
   extends v = fromUndefOrPrimNoDefault
                 "ElementDefinitionOptions.getextends"
                 prim__extends
                 prim__setExtends
-                (v :> ElementDefinitionOptions)
+                (cast {to = ElementDefinitionOptions} v)
 
 
 
 namespace ErrorEventInit
-
+  
   export
   new' :
        (message : Optional String)
@@ -11635,16 +11115,15 @@ namespace ErrorEventInit
     -> JSIO ErrorEventInit
   new' a b c d e = primJS $
     ErrorEventInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO ErrorEventInit
   new = primJS $ ErrorEventInit.prim__new undef undef undef undef undef
 
-
+  
   export
   colno :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t)}
+       {auto _ : Cast t ErrorEventInit}
     -> t
     -> Attribute True Optional Bits32
   colno v = fromUndefOrPrim
@@ -11652,27 +11131,22 @@ namespace ErrorEventInit
               prim__colno
               prim__setColno
               0
-              (v :> ErrorEventInit)
+              (cast {to = ErrorEventInit} v)
 
-
+  
   export
-  error :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t)}
-    -> t
-    -> Attribute True Optional Any
+  error : {auto _ : Cast t ErrorEventInit} -> t -> Attribute True Optional Any
   error v = fromUndefOrPrim
               "ErrorEventInit.geterror"
               prim__error
               prim__setError
               (MkAny $ null {a = ()})
-              (v :> ErrorEventInit)
+              (cast {to = ErrorEventInit} v)
 
-
+  
   export
   filename :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t)}
+       {auto _ : Cast t ErrorEventInit}
     -> t
     -> Attribute True Optional String
   filename v = fromUndefOrPrim
@@ -11680,13 +11154,12 @@ namespace ErrorEventInit
                  prim__filename
                  prim__setFilename
                  ""
-                 (v :> ErrorEventInit)
+                 (cast {to = ErrorEventInit} v)
 
-
+  
   export
   lineno :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t)}
+       {auto _ : Cast t ErrorEventInit}
     -> t
     -> Attribute True Optional Bits32
   lineno v = fromUndefOrPrim
@@ -11694,13 +11167,12 @@ namespace ErrorEventInit
                prim__lineno
                prim__setLineno
                0
-               (v :> ErrorEventInit)
+               (cast {to = ErrorEventInit} v)
 
-
+  
   export
   message :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ErrorEventInit (Types t)}
+       {auto _ : Cast t ErrorEventInit}
     -> t
     -> Attribute True Optional String
   message v = fromUndefOrPrim
@@ -11708,25 +11180,24 @@ namespace ErrorEventInit
                 prim__message
                 prim__setMessage
                 ""
-                (v :> ErrorEventInit)
+                (cast {to = ErrorEventInit} v)
 
 
 
 namespace EventSourceInit
-
+  
   export
   new' : (withCredentials : Optional Bool) -> JSIO EventSourceInit
   new' a = primJS $ EventSourceInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO EventSourceInit
   new = primJS $ EventSourceInit.prim__new undef
 
-
+  
   export
   withCredentials :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventSourceInit (Types t)}
+       {auto _ : Cast t EventSourceInit}
     -> t
     -> Attribute True Optional Bool
   withCredentials v = fromUndefOrPrim
@@ -11734,25 +11205,24 @@ namespace EventSourceInit
                         prim__withCredentials
                         prim__setWithCredentials
                         False
-                        (v :> EventSourceInit)
+                        (cast {to = EventSourceInit} v)
 
 
 
 namespace FocusOptions
-
+  
   export
   new' : (preventScroll : Optional Bool) -> JSIO FocusOptions
   new' a = primJS $ FocusOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO FocusOptions
   new = primJS $ FocusOptions.prim__new undef
 
-
+  
   export
   preventScroll :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FocusOptions (Types t)}
+       {auto _ : Cast t FocusOptions}
     -> t
     -> Attribute True Optional Bool
   preventScroll v = fromUndefOrPrim
@@ -11760,49 +11230,47 @@ namespace FocusOptions
                       prim__preventScroll
                       prim__setPreventScroll
                       False
-                      (v :> FocusOptions)
+                      (cast {to = FocusOptions} v)
 
 
 
 namespace FormDataEventInit
-
+  
   export
   new : (formData : FormData) -> JSIO FormDataEventInit
   new a = primJS $ FormDataEventInit.prim__new a
 
-
+  
   export
   formData :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FormDataEventInit (Types t)}
+       {auto _ : Cast t FormDataEventInit}
     -> t
     -> Attribute True Prelude.id FormData
   formData v = fromPrim
                  "FormDataEventInit.getformData"
                  prim__formData
                  prim__setFormData
-                 (v :> FormDataEventInit)
+                 (cast {to = FormDataEventInit} v)
 
 
 
 namespace HashChangeEventInit
-
+  
   export
   new' :
        (oldURL : Optional String)
     -> (newURL : Optional String)
     -> JSIO HashChangeEventInit
   new' a b = primJS $ HashChangeEventInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO HashChangeEventInit
   new = primJS $ HashChangeEventInit.prim__new undef undef
 
-
+  
   export
   newURL :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HashChangeEventInit (Types t)}
+       {auto _ : Cast t HashChangeEventInit}
     -> t
     -> Attribute True Optional String
   newURL v = fromUndefOrPrim
@@ -11810,13 +11278,12 @@ namespace HashChangeEventInit
                prim__newURL
                prim__setNewURL
                ""
-               (v :> HashChangeEventInit)
+               (cast {to = HashChangeEventInit} v)
 
-
+  
   export
   oldURL :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem HashChangeEventInit (Types t)}
+       {auto _ : Cast t HashChangeEventInit}
     -> t
     -> Attribute True Optional String
   oldURL v = fromUndefOrPrim
@@ -11824,12 +11291,12 @@ namespace HashChangeEventInit
                prim__oldURL
                prim__setOldURL
                ""
-               (v :> HashChangeEventInit)
+               (cast {to = HashChangeEventInit} v)
 
 
 
 namespace ImageBitmapOptions
-
+  
   export
   new' :
        (imageOrientation : Optional ImageOrientation)
@@ -11847,107 +11314,100 @@ namespace ImageBitmapOptions
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   new : JSIO ImageBitmapOptions
   new = primJS $
     ImageBitmapOptions.prim__new undef undef undef undef undef undef
 
-
+  
   export
   colorSpaceConversion :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional ColorSpaceConversion
   colorSpaceConversion v = fromUndefOrPrimNoDefault
                              "ImageBitmapOptions.getcolorSpaceConversion"
                              prim__colorSpaceConversion
                              prim__setColorSpaceConversion
-                             (v :> ImageBitmapOptions)
+                             (cast {to = ImageBitmapOptions} v)
 
-
+  
   export
   imageOrientation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional ImageOrientation
   imageOrientation v = fromUndefOrPrimNoDefault
                          "ImageBitmapOptions.getimageOrientation"
                          prim__imageOrientation
                          prim__setImageOrientation
-                         (v :> ImageBitmapOptions)
+                         (cast {to = ImageBitmapOptions} v)
 
-
+  
   export
   premultiplyAlpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional PremultiplyAlpha
   premultiplyAlpha v = fromUndefOrPrimNoDefault
                          "ImageBitmapOptions.getpremultiplyAlpha"
                          prim__premultiplyAlpha
                          prim__setPremultiplyAlpha
-                         (v :> ImageBitmapOptions)
+                         (cast {to = ImageBitmapOptions} v)
 
-
+  
   export
   resizeHeight :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional Bits32
   resizeHeight v = fromUndefOrPrimNoDefault
                      "ImageBitmapOptions.getresizeHeight"
                      prim__resizeHeight
                      prim__setResizeHeight
-                     (v :> ImageBitmapOptions)
+                     (cast {to = ImageBitmapOptions} v)
 
-
+  
   export
   resizeQuality :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional ResizeQuality
   resizeQuality v = fromUndefOrPrimNoDefault
                       "ImageBitmapOptions.getresizeQuality"
                       prim__resizeQuality
                       prim__setResizeQuality
-                      (v :> ImageBitmapOptions)
+                      (cast {to = ImageBitmapOptions} v)
 
-
+  
   export
   resizeWidth :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapOptions (Types t)}
+       {auto _ : Cast t ImageBitmapOptions}
     -> t
     -> Attribute False Optional Bits32
   resizeWidth v = fromUndefOrPrimNoDefault
                     "ImageBitmapOptions.getresizeWidth"
                     prim__resizeWidth
                     prim__setResizeWidth
-                    (v :> ImageBitmapOptions)
+                    (cast {to = ImageBitmapOptions} v)
 
 
 
 namespace ImageBitmapRenderingContextSettings
-
+  
   export
   new' : (alpha : Optional Bool) -> JSIO ImageBitmapRenderingContextSettings
   new' a = primJS $ ImageBitmapRenderingContextSettings.prim__new (toFFI a)
-
+  
   export
   new : JSIO ImageBitmapRenderingContextSettings
   new = primJS $ ImageBitmapRenderingContextSettings.prim__new undef
 
-
+  
   export
   alpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageBitmapRenderingContextSettings (Types t)}
+       {auto _ : Cast t ImageBitmapRenderingContextSettings}
     -> t
     -> Attribute True Optional Bool
   alpha v = fromUndefOrPrim
@@ -11955,41 +11415,39 @@ namespace ImageBitmapRenderingContextSettings
               prim__alpha
               prim__setAlpha
               True
-              (v :> ImageBitmapRenderingContextSettings)
+              (cast {to = ImageBitmapRenderingContextSettings} v)
 
 
 
 namespace ImageEncodeOptions
-
+  
   export
   new' :
        (type : Optional String)
     -> (quality : Optional Double)
     -> JSIO ImageEncodeOptions
   new' a b = primJS $ ImageEncodeOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ImageEncodeOptions
   new = primJS $ ImageEncodeOptions.prim__new undef undef
 
-
+  
   export
   quality :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageEncodeOptions (Types t)}
+       {auto _ : Cast t ImageEncodeOptions}
     -> t
     -> Attribute False Optional Double
   quality v = fromUndefOrPrimNoDefault
                 "ImageEncodeOptions.getquality"
                 prim__quality
                 prim__setQuality
-                (v :> ImageEncodeOptions)
+                (cast {to = ImageEncodeOptions} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ImageEncodeOptions (Types t)}
+       {auto _ : Cast t ImageEncodeOptions}
     -> t
     -> Attribute True Optional String
   type v = fromUndefOrPrim
@@ -11997,12 +11455,12 @@ namespace ImageEncodeOptions
              prim__type
              prim__setType
              "image/png"
-             (v :> ImageEncodeOptions)
+             (cast {to = ImageEncodeOptions} v)
 
 
 
 namespace MessageEventInit
-
+  
   export
   new' :
        (data_ : Optional Any)
@@ -12014,30 +11472,25 @@ namespace MessageEventInit
     -> JSIO MessageEventInit
   new' a b c d e = primJS $
     MessageEventInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO MessageEventInit
   new = primJS $ MessageEventInit.prim__new undef undef undef undef undef
 
-
+  
   export
-  data_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MessageEventInit (Types t)}
-    -> t
-    -> Attribute True Optional Any
+  data_ : {auto _ : Cast t MessageEventInit} -> t -> Attribute True Optional Any
   data_ v = fromUndefOrPrim
               "MessageEventInit.getdata"
               prim__data
               prim__setData
               (MkAny $ null {a = ()})
-              (v :> MessageEventInit)
+              (cast {to = MessageEventInit} v)
 
-
+  
   export
   lastEventId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MessageEventInit (Types t)}
+       {auto _ : Cast t MessageEventInit}
     -> t
     -> Attribute True Optional String
   lastEventId v = fromUndefOrPrim
@@ -12045,13 +11498,12 @@ namespace MessageEventInit
                     prim__lastEventId
                     prim__setLastEventId
                     ""
-                    (v :> MessageEventInit)
+                    (cast {to = MessageEventInit} v)
 
-
+  
   export
   origin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MessageEventInit (Types t)}
+       {auto _ : Cast t MessageEventInit}
     -> t
     -> Attribute True Optional String
   origin v = fromUndefOrPrim
@@ -12059,26 +11511,24 @@ namespace MessageEventInit
                prim__origin
                prim__setOrigin
                ""
-               (v :> MessageEventInit)
+               (cast {to = MessageEventInit} v)
 
-
+  
   export
   ports :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MessageEventInit (Types t)}
+       {auto _ : Cast t MessageEventInit}
     -> t
     -> Attribute False Optional (Array MessagePort)
   ports v = fromUndefOrPrimNoDefault
               "MessageEventInit.getports"
               prim__ports
               prim__setPorts
-              (v :> MessageEventInit)
+              (cast {to = MessageEventInit} v)
 
-
+  
   export
   source :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MessageEventInit (Types t)}
+       {auto _ : Cast t MessageEventInit}
     -> t
     -> Attribute True Optional (Maybe
                                   (Union3
@@ -12090,25 +11540,24 @@ namespace MessageEventInit
                prim__source
                prim__setSource
                Nothing
-               (v :> MessageEventInit)
+               (cast {to = MessageEventInit} v)
 
 
 
 namespace PageTransitionEventInit
-
+  
   export
   new' : (persisted : Optional Bool) -> JSIO PageTransitionEventInit
   new' a = primJS $ PageTransitionEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO PageTransitionEventInit
   new = primJS $ PageTransitionEventInit.prim__new undef
 
-
+  
   export
   persisted :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PageTransitionEventInit (Types t)}
+       {auto _ : Cast t PageTransitionEventInit}
     -> t
     -> Attribute True Optional Bool
   persisted v = fromUndefOrPrim
@@ -12116,25 +11565,24 @@ namespace PageTransitionEventInit
                   prim__persisted
                   prim__setPersisted
                   False
-                  (v :> PageTransitionEventInit)
+                  (cast {to = PageTransitionEventInit} v)
 
 
 
 namespace PopStateEventInit
-
+  
   export
   new' : (state : Optional Any) -> JSIO PopStateEventInit
   new' a = primJS $ PopStateEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO PopStateEventInit
   new = primJS $ PopStateEventInit.prim__new undef
 
-
+  
   export
   state :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PopStateEventInit (Types t)}
+       {auto _ : Cast t PopStateEventInit}
     -> t
     -> Attribute True Optional Any
   state v = fromUndefOrPrim
@@ -12142,78 +11590,75 @@ namespace PopStateEventInit
               prim__state
               prim__setState
               (MkAny $ null {a = ()})
-              (v :> PopStateEventInit)
+              (cast {to = PopStateEventInit} v)
 
 
 
 namespace PostMessageOptions
-
+  
   export
   new' : (transfer : Optional (Array Object)) -> JSIO PostMessageOptions
   new' a = primJS $ PostMessageOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO PostMessageOptions
   new = primJS $ PostMessageOptions.prim__new undef
 
-
+  
   export
   transfer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t)}
+       {auto _ : Cast t PostMessageOptions}
     -> t
     -> Attribute False Optional (Array Object)
   transfer v = fromUndefOrPrimNoDefault
                  "PostMessageOptions.gettransfer"
                  prim__transfer
                  prim__setTransfer
-                 (v :> PostMessageOptions)
+                 (cast {to = PostMessageOptions} v)
 
 
 
 namespace PromiseRejectionEventInit
-
+  
   export
   new' :
        (promise : Promise AnyPtr)
     -> (reason : Optional Any)
     -> JSIO PromiseRejectionEventInit
   new' a b = primJS $ PromiseRejectionEventInit.prim__new a (toFFI b)
-
+  
   export
   new : (promise : Promise AnyPtr) -> JSIO PromiseRejectionEventInit
   new a = primJS $ PromiseRejectionEventInit.prim__new a undef
 
-
+  
   export
   promise :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PromiseRejectionEventInit (Types t)}
+       {auto _ : Cast t PromiseRejectionEventInit}
     -> t
     -> Attribute True Prelude.id (Promise AnyPtr)
   promise v = fromPrim
                 "PromiseRejectionEventInit.getpromise"
                 prim__promise
                 prim__setPromise
-                (v :> PromiseRejectionEventInit)
+                (cast {to = PromiseRejectionEventInit} v)
 
-
+  
   export
   reason :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PromiseRejectionEventInit (Types t)}
+       {auto _ : Cast t PromiseRejectionEventInit}
     -> t
     -> Attribute False Optional Any
   reason v = fromUndefOrPrimNoDefault
                "PromiseRejectionEventInit.getreason"
                prim__reason
                prim__setReason
-               (v :> PromiseRejectionEventInit)
+               (cast {to = PromiseRejectionEventInit} v)
 
 
 
 namespace StorageEventInit
-
+  
   export
   new' :
        (key : Optional (Maybe String))
@@ -12224,16 +11669,15 @@ namespace StorageEventInit
     -> JSIO StorageEventInit
   new' a b c d e = primJS $
     StorageEventInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO StorageEventInit
   new = primJS $ StorageEventInit.prim__new undef undef undef undef undef
 
-
+  
   export
   key :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StorageEventInit (Types t)}
+       {auto _ : Cast t StorageEventInit}
     -> t
     -> Attribute True Optional (Maybe String)
   key v = fromUndefOrPrim
@@ -12241,13 +11685,12 @@ namespace StorageEventInit
             prim__key
             prim__setKey
             Nothing
-            (v :> StorageEventInit)
+            (cast {to = StorageEventInit} v)
 
-
+  
   export
   newValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StorageEventInit (Types t)}
+       {auto _ : Cast t StorageEventInit}
     -> t
     -> Attribute True Optional (Maybe String)
   newValue v = fromUndefOrPrim
@@ -12255,13 +11698,12 @@ namespace StorageEventInit
                  prim__newValue
                  prim__setNewValue
                  Nothing
-                 (v :> StorageEventInit)
+                 (cast {to = StorageEventInit} v)
 
-
+  
   export
   oldValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StorageEventInit (Types t)}
+       {auto _ : Cast t StorageEventInit}
     -> t
     -> Attribute True Optional (Maybe String)
   oldValue v = fromUndefOrPrim
@@ -12269,13 +11711,12 @@ namespace StorageEventInit
                  prim__oldValue
                  prim__setOldValue
                  Nothing
-                 (v :> StorageEventInit)
+                 (cast {to = StorageEventInit} v)
 
-
+  
   export
   storageArea :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StorageEventInit (Types t)}
+       {auto _ : Cast t StorageEventInit}
     -> t
     -> Attribute True Optional (Maybe Storage)
   storageArea v = fromUndefOrPrim
@@ -12283,13 +11724,12 @@ namespace StorageEventInit
                     prim__storageArea
                     prim__setStorageArea
                     Nothing
-                    (v :> StorageEventInit)
+                    (cast {to = StorageEventInit} v)
 
-
+  
   export
   url :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StorageEventInit (Types t)}
+       {auto _ : Cast t StorageEventInit}
     -> t
     -> Attribute True Optional String
   url v = fromUndefOrPrim
@@ -12297,54 +11737,51 @@ namespace StorageEventInit
             prim__url
             prim__setUrl
             ""
-            (v :> StorageEventInit)
+            (cast {to = StorageEventInit} v)
 
 
 
 namespace StructuredSerializeOptions
-
+  
   export
   new' : (transfer : Optional (Array Object)) -> JSIO StructuredSerializeOptions
   new' a = primJS $ StructuredSerializeOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO StructuredSerializeOptions
   new = primJS $ StructuredSerializeOptions.prim__new undef
 
-
+  
   export
   transfer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StructuredSerializeOptions (Types t)}
+       {auto _ : Cast t StructuredSerializeOptions}
     -> t
     -> Attribute False Optional (Array Object)
   transfer v = fromUndefOrPrimNoDefault
                  "StructuredSerializeOptions.gettransfer"
                  prim__transfer
                  prim__setTransfer
-                 (v :> StructuredSerializeOptions)
+                 (cast {to = StructuredSerializeOptions} v)
 
 
 
 namespace SubmitEventInit
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem HTMLElement (Types t1)}
+       {auto _ : Cast t1 HTMLElement}
     -> (submitter : Optional (Maybe t1))
     -> JSIO SubmitEventInit
   new' a = primJS $ SubmitEventInit.prim__new (omyUp a)
-
+  
   export
   new : JSIO SubmitEventInit
   new = primJS $ SubmitEventInit.prim__new undef
 
-
+  
   export
   submitter :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem SubmitEventInit (Types t)}
+       {auto _ : Cast t SubmitEventInit}
     -> t
     -> Attribute True Optional (Maybe HTMLElement)
   submitter v = fromUndefOrPrim
@@ -12352,27 +11789,26 @@ namespace SubmitEventInit
                   prim__submitter
                   prim__setSubmitter
                   Nothing
-                  (v :> SubmitEventInit)
+                  (cast {to = SubmitEventInit} v)
 
 
 
 namespace TrackEventInit
-
+  
   export
   new' :
        (track : Optional (Maybe (HSum [VideoTrack, AudioTrack, TextTrack])))
     -> JSIO TrackEventInit
   new' a = primJS $ TrackEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO TrackEventInit
   new = primJS $ TrackEventInit.prim__new undef
 
-
+  
   export
   track :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem TrackEventInit (Types t)}
+       {auto _ : Cast t TrackEventInit}
     -> t
     -> Attribute True Optional (Maybe
                                   (HSum [VideoTrack, AudioTrack, TextTrack]))
@@ -12381,12 +11817,12 @@ namespace TrackEventInit
               prim__track
               prim__setTrack
               Nothing
-              (v :> TrackEventInit)
+              (cast {to = TrackEventInit} v)
 
 
 
 namespace ValidityStateFlags
-
+  
   export
   new' :
        (valueMissing : Optional Bool)
@@ -12412,7 +11848,7 @@ namespace ValidityStateFlags
       (toFFI h)
       (toFFI i)
       (toFFI j)
-
+  
   export
   new : JSIO ValidityStateFlags
   new = primJS $
@@ -12428,11 +11864,10 @@ namespace ValidityStateFlags
       undef
       undef
 
-
+  
   export
   badInput :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   badInput v = fromUndefOrPrim
@@ -12440,13 +11875,12 @@ namespace ValidityStateFlags
                  prim__badInput
                  prim__setBadInput
                  False
-                 (v :> ValidityStateFlags)
+                 (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   customError :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   customError v = fromUndefOrPrim
@@ -12454,13 +11888,12 @@ namespace ValidityStateFlags
                     prim__customError
                     prim__setCustomError
                     False
-                    (v :> ValidityStateFlags)
+                    (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   patternMismatch :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   patternMismatch v = fromUndefOrPrim
@@ -12468,13 +11901,12 @@ namespace ValidityStateFlags
                         prim__patternMismatch
                         prim__setPatternMismatch
                         False
-                        (v :> ValidityStateFlags)
+                        (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   rangeOverflow :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   rangeOverflow v = fromUndefOrPrim
@@ -12482,13 +11914,12 @@ namespace ValidityStateFlags
                       prim__rangeOverflow
                       prim__setRangeOverflow
                       False
-                      (v :> ValidityStateFlags)
+                      (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   rangeUnderflow :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   rangeUnderflow v = fromUndefOrPrim
@@ -12496,13 +11927,12 @@ namespace ValidityStateFlags
                        prim__rangeUnderflow
                        prim__setRangeUnderflow
                        False
-                       (v :> ValidityStateFlags)
+                       (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   stepMismatch :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   stepMismatch v = fromUndefOrPrim
@@ -12510,13 +11940,12 @@ namespace ValidityStateFlags
                      prim__stepMismatch
                      prim__setStepMismatch
                      False
-                     (v :> ValidityStateFlags)
+                     (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   tooLong :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   tooLong v = fromUndefOrPrim
@@ -12524,13 +11953,12 @@ namespace ValidityStateFlags
                 prim__tooLong
                 prim__setTooLong
                 False
-                (v :> ValidityStateFlags)
+                (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   tooShort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   tooShort v = fromUndefOrPrim
@@ -12538,13 +11966,12 @@ namespace ValidityStateFlags
                  prim__tooShort
                  prim__setTooShort
                  False
-                 (v :> ValidityStateFlags)
+                 (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   typeMismatch :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   typeMismatch v = fromUndefOrPrim
@@ -12552,13 +11979,12 @@ namespace ValidityStateFlags
                      prim__typeMismatch
                      prim__setTypeMismatch
                      False
-                     (v :> ValidityStateFlags)
+                     (cast {to = ValidityStateFlags} v)
 
-
+  
   export
   valueMissing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ValidityStateFlags (Types t)}
+       {auto _ : Cast t ValidityStateFlags}
     -> t
     -> Attribute True Optional Bool
   valueMissing v = fromUndefOrPrim
@@ -12566,25 +11992,24 @@ namespace ValidityStateFlags
                      prim__valueMissing
                      prim__setValueMissing
                      False
-                     (v :> ValidityStateFlags)
+                     (cast {to = ValidityStateFlags} v)
 
 
 
 namespace WindowPostMessageOptions
-
+  
   export
   new' : (targetOrigin : Optional String) -> JSIO WindowPostMessageOptions
   new' a = primJS $ WindowPostMessageOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO WindowPostMessageOptions
   new = primJS $ WindowPostMessageOptions.prim__new undef
 
-
+  
   export
   targetOrigin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WindowPostMessageOptions (Types t)}
+       {auto _ : Cast t WindowPostMessageOptions}
     -> t
     -> Attribute True Optional String
   targetOrigin v = fromUndefOrPrim
@@ -12592,12 +12017,12 @@ namespace WindowPostMessageOptions
                      prim__targetOrigin
                      prim__setTargetOrigin
                      "/"
-                     (v :> WindowPostMessageOptions)
+                     (cast {to = WindowPostMessageOptions} v)
 
 
 
 namespace WorkerOptions
-
+  
   export
   new' :
        (type : Optional WorkerType)
@@ -12605,75 +12030,68 @@ namespace WorkerOptions
     -> (name : Optional String)
     -> JSIO WorkerOptions
   new' a b c = primJS $ WorkerOptions.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO WorkerOptions
   new = primJS $ WorkerOptions.prim__new undef undef undef
 
-
+  
   export
   credentials :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerOptions (Types t)}
+       {auto _ : Cast t WorkerOptions}
     -> t
     -> Attribute False Optional RequestCredentials
   credentials v = fromUndefOrPrimNoDefault
                     "WorkerOptions.getcredentials"
                     prim__credentials
                     prim__setCredentials
-                    (v :> WorkerOptions)
+                    (cast {to = WorkerOptions} v)
 
-
+  
   export
-  name :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerOptions (Types t)}
-    -> t
-    -> Attribute True Optional String
+  name : {auto _ : Cast t WorkerOptions} -> t -> Attribute True Optional String
   name v = fromUndefOrPrim
              "WorkerOptions.getname"
              prim__name
              prim__setName
              ""
-             (v :> WorkerOptions)
+             (cast {to = WorkerOptions} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkerOptions (Types t)}
+       {auto _ : Cast t WorkerOptions}
     -> t
     -> Attribute False Optional WorkerType
   type v = fromUndefOrPrimNoDefault
              "WorkerOptions.gettype"
              prim__type
              prim__setType
-             (v :> WorkerOptions)
+             (cast {to = WorkerOptions} v)
 
 
 
 namespace WorkletOptions
-
+  
   export
   new' : (credentials : Optional RequestCredentials) -> JSIO WorkletOptions
   new' a = primJS $ WorkletOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO WorkletOptions
   new = primJS $ WorkletOptions.prim__new undef
 
-
+  
   export
   credentials :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WorkletOptions (Types t)}
+       {auto _ : Cast t WorkletOptions}
     -> t
     -> Attribute False Optional RequestCredentials
   credentials v = fromUndefOrPrimNoDefault
                     "WorkletOptions.getcredentials"
                     prim__credentials
                     prim__setCredentials
-                    (v :> WorkletOptions)
+                    (cast {to = WorkletOptions} v)
 
 
 
@@ -12683,7 +12101,7 @@ namespace WorkletOptions
 --------------------------------------------------------------------------------
 
 namespace BlobCallback
-
+  
   export
   toBlobCallback : (Nullable Blob -> IO ()) -> JSIO BlobCallback
   toBlobCallback cb = primJS $ prim__toBlobCallback cb
@@ -12691,7 +12109,7 @@ namespace BlobCallback
 
 
 namespace CompositionEventHandler
-
+  
   export
   toCompositionEventHandler :
        (CompositionEvent -> IO ())
@@ -12701,7 +12119,7 @@ namespace CompositionEventHandler
 
 
 namespace CustomElementConstructor
-
+  
   export
   toCustomElementConstructor :
        (() -> IO HTMLElement)
@@ -12711,7 +12129,7 @@ namespace CustomElementConstructor
 
 
 namespace EventHandlerNonNull
-
+  
   export
   toEventHandlerNonNull : (Event -> IO AnyPtr) -> JSIO EventHandlerNonNull
   toEventHandlerNonNull cb = primJS $ prim__toEventHandlerNonNull cb
@@ -12719,7 +12137,7 @@ namespace EventHandlerNonNull
 
 
 namespace FocusEventHandler
-
+  
   export
   toFocusEventHandler : (FocusEvent -> IO ()) -> JSIO FocusEventHandler
   toFocusEventHandler cb = primJS $ prim__toFocusEventHandler cb
@@ -12727,7 +12145,7 @@ namespace FocusEventHandler
 
 
 namespace FunctionStringCallback
-
+  
   export
   toFunctionStringCallback : (String -> IO ()) -> JSIO FunctionStringCallback
   toFunctionStringCallback cb = primJS $ prim__toFunctionStringCallback cb
@@ -12735,7 +12153,7 @@ namespace FunctionStringCallback
 
 
 namespace InputEventHandler
-
+  
   export
   toInputEventHandler : (InputEvent -> IO ()) -> JSIO InputEventHandler
   toInputEventHandler cb = primJS $ prim__toInputEventHandler cb
@@ -12743,7 +12161,7 @@ namespace InputEventHandler
 
 
 namespace KeyboardEventHandler
-
+  
   export
   toKeyboardEventHandler : (KeyboardEvent -> IO ()) -> JSIO KeyboardEventHandler
   toKeyboardEventHandler cb = primJS $ prim__toKeyboardEventHandler cb
@@ -12751,7 +12169,7 @@ namespace KeyboardEventHandler
 
 
 namespace MouseEventHandler
-
+  
   export
   toMouseEventHandler : (MouseEvent -> IO ()) -> JSIO MouseEventHandler
   toMouseEventHandler cb = primJS $ prim__toMouseEventHandler cb
@@ -12759,7 +12177,7 @@ namespace MouseEventHandler
 
 
 namespace OnBeforeUnloadEventHandlerNonNull
-
+  
   export
   toOnBeforeUnloadEventHandlerNonNull :
        (Event -> IO (Nullable String))
@@ -12769,7 +12187,7 @@ namespace OnBeforeUnloadEventHandlerNonNull
 
 
 namespace OnErrorEventHandlerNonNull
-
+  
   export
   toOnErrorEventHandlerNonNull :
        (  Union2 Event String
@@ -12785,7 +12203,7 @@ namespace OnErrorEventHandlerNonNull
 
 
 namespace UIEventHandler
-
+  
   export
   toUIEventHandler : (UIEvent -> IO ()) -> JSIO UIEventHandler
   toUIEventHandler cb = primJS $ prim__toUIEventHandler cb
@@ -12793,7 +12211,9 @@ namespace UIEventHandler
 
 
 namespace WheelEventHandler
-
+  
   export
   toWheelEventHandler : (WheelEvent -> IO ()) -> JSIO WheelEventHandler
   toWheelEventHandler cb = primJS $ prim__toWheelEventHandler cb
+
+

--- a/src/Web/Raw/IndexedDB.idr
+++ b/src/Web/Raw/IndexedDB.idr
@@ -12,115 +12,89 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace IDBCursor
-
+  
   export
   direction :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> JSIO IDBCursorDirection
-  direction a = tryJS "IDBCursor.direction" $ IDBCursor.prim__direction (up a)
+  direction a = tryJS "IDBCursor.direction" $ IDBCursor.prim__direction (cast a)
 
-
+  
   export
-  key :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
-    -> (obj : t1)
-    -> JSIO Any
-  key a = tryJS "IDBCursor.key" $ IDBCursor.prim__key (up a)
+  key : {auto _ : Cast t1 IDBCursor} -> (obj : t1) -> JSIO Any
+  key a = tryJS "IDBCursor.key" $ IDBCursor.prim__key (cast a)
 
-
+  
   export
-  primaryKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
-    -> (obj : t1)
-    -> JSIO Any
+  primaryKey : {auto _ : Cast t1 IDBCursor} -> (obj : t1) -> JSIO Any
   primaryKey a = tryJS "IDBCursor.primaryKey" $
-    IDBCursor.prim__primaryKey (up a)
+    IDBCursor.prim__primaryKey (cast a)
 
-
+  
   export
-  request :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
-    -> (obj : t1)
-    -> JSIO IDBRequest
-  request a = primJS $ IDBCursor.prim__request (up a)
+  request : {auto _ : Cast t1 IDBCursor} -> (obj : t1) -> JSIO IDBRequest
+  request a = primJS $ IDBCursor.prim__request (cast a)
 
-
+  
   export
   source :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> JSIO (HSum [IDBObjectStore, IDBIndex])
-  source a = tryJS "IDBCursor.source" $ IDBCursor.prim__source (up a)
+  source a = tryJS "IDBCursor.source" $ IDBCursor.prim__source (cast a)
 
-
+  
   export
   advance :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> (count : Bits32)
     -> JSIO ()
-  advance a b = primJS $ IDBCursor.prim__advance (up a) b
+  advance a b = primJS $ IDBCursor.prim__advance (cast a) b
 
-
+  
   export
   continue' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> (key : Optional Any)
     -> JSIO ()
-  continue' a b = primJS $ IDBCursor.prim__continue (up a) (toFFI b)
-
+  continue' a b = primJS $ IDBCursor.prim__continue (cast a) (toFFI b)
+  
   export
-  continue :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  continue a = primJS $ IDBCursor.prim__continue (up a) undef
+  continue : {auto _ : Cast t1 IDBCursor} -> (obj : t1) -> JSIO ()
+  continue a = primJS $ IDBCursor.prim__continue (cast a) undef
 
-
+  
   export
   continuePrimaryKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> (key : Any)
     -> (primaryKey : Any)
     -> JSIO ()
   continuePrimaryKey a b c = primJS $
-    IDBCursor.prim__continuePrimaryKey (up a) (toFFI b) (toFFI c)
+    IDBCursor.prim__continuePrimaryKey (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
-  delete :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
-    -> (obj : t1)
-    -> JSIO IDBRequest
-  delete a = primJS $ IDBCursor.prim__delete (up a)
+  delete : {auto _ : Cast t1 IDBCursor} -> (obj : t1) -> JSIO IDBRequest
+  delete a = primJS $ IDBCursor.prim__delete (cast a)
 
-
+  
   export
   update :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBCursor (Types t1)}
+       {auto _ : Cast t1 IDBCursor}
     -> (obj : t1)
     -> (value : Any)
     -> JSIO IDBRequest
-  update a b = primJS $ IDBCursor.prim__update (up a) (toFFI b)
+  update a b = primJS $ IDBCursor.prim__update (cast a) (toFFI b)
 
 
 
 namespace IDBCursorWithValue
-
+  
   export
   value : (obj : IDBCursorWithValue) -> JSIO Any
   value a = tryJS "IDBCursorWithValue.value" $ IDBCursorWithValue.prim__value a
@@ -128,17 +102,17 @@ namespace IDBCursorWithValue
 
 
 namespace IDBDatabase
-
+  
   export
   name : (obj : IDBDatabase) -> JSIO String
   name a = primJS $ IDBDatabase.prim__name a
 
-
+  
   export
   objectStoreNames : (obj : IDBDatabase) -> JSIO DOMStringList
   objectStoreNames a = primJS $ IDBDatabase.prim__objectStoreNames a
 
-
+  
   export
   onabort : IDBDatabase -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
@@ -147,7 +121,7 @@ namespace IDBDatabase
                 prim__setOnabort
                 v
 
-
+  
   export
   onclose : IDBDatabase -> Attribute False Maybe EventHandlerNonNull
   onclose v = fromNullablePrim
@@ -156,7 +130,7 @@ namespace IDBDatabase
                 prim__setOnclose
                 v
 
-
+  
   export
   onerror : IDBDatabase -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -165,7 +139,7 @@ namespace IDBDatabase
                 prim__setOnerror
                 v
 
-
+  
   export
   onversionchange : IDBDatabase -> Attribute False Maybe EventHandlerNonNull
   onversionchange v = fromNullablePrim
@@ -174,28 +148,27 @@ namespace IDBDatabase
                         prim__setOnversionchange
                         v
 
-
+  
   export
   version : (obj : IDBDatabase) -> JSIO JSBits64
   version a = primJS $ IDBDatabase.prim__version a
 
-
+  
   export
   close : (obj : IDBDatabase) -> JSIO ()
   close a = primJS $ IDBDatabase.prim__close a
 
-
+  
   export
   createObjectStore' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem IDBObjectStoreParameters (Types t3)}
+       {auto _ : Cast t3 IDBObjectStoreParameters}
     -> (obj : IDBDatabase)
     -> (name : String)
     -> (options : Optional t3)
     -> JSIO IDBObjectStore
   createObjectStore' a b c = primJS $
     IDBDatabase.prim__createObjectStore a b (optUp c)
-
+  
   export
   createObjectStore :
        (obj : IDBDatabase)
@@ -203,16 +176,15 @@ namespace IDBDatabase
     -> JSIO IDBObjectStore
   createObjectStore a b = primJS $ IDBDatabase.prim__createObjectStore a b undef
 
-
+  
   export
   deleteObjectStore : (obj : IDBDatabase) -> (name : String) -> JSIO ()
   deleteObjectStore a b = primJS $ IDBDatabase.prim__deleteObjectStore a b
 
-
+  
   export
   transaction' :
-       {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem IDBTransactionOptions (Types t4)}
+       {auto _ : Cast t4 IDBTransactionOptions}
     -> (obj : IDBDatabase)
     -> (storeNames : HSum [String, Array String])
     -> (mode : Optional IDBTransactionMode)
@@ -220,7 +192,7 @@ namespace IDBDatabase
     -> JSIO IDBTransaction
   transaction' a b c d = primJS $
     IDBDatabase.prim__transaction a (toFFI b) (toFFI c) (optUp d)
-
+  
   export
   transaction :
        (obj : IDBDatabase)
@@ -232,17 +204,17 @@ namespace IDBDatabase
 
 
 namespace IDBFactory
-
+  
   export
   cmp : (obj : IDBFactory) -> (first : Any) -> (second : Any) -> JSIO Int16
   cmp a b c = primJS $ IDBFactory.prim__cmp a (toFFI b) (toFFI c)
 
-
+  
   export
   databases : (obj : IDBFactory) -> JSIO (Promise (Array IDBDatabaseInfo))
   databases a = primJS $ IDBFactory.prim__databases a
 
-
+  
   export
   deleteDatabase :
        (obj : IDBFactory)
@@ -250,7 +222,7 @@ namespace IDBFactory
     -> JSIO IDBOpenDBRequest
   deleteDatabase a b = primJS $ IDBFactory.prim__deleteDatabase a b
 
-
+  
   export
   open' :
        (obj : IDBFactory)
@@ -258,7 +230,7 @@ namespace IDBFactory
     -> (version : Optional JSBits64)
     -> JSIO IDBOpenDBRequest
   open' a b c = primJS $ IDBFactory.prim__open a b (toFFI c)
-
+  
   export
   open_ : (obj : IDBFactory) -> (name : String) -> JSIO IDBOpenDBRequest
   open_ a b = primJS $ IDBFactory.prim__open a b undef
@@ -266,41 +238,41 @@ namespace IDBFactory
 
 
 namespace IDBIndex
-
+  
   export
   keyPath : (obj : IDBIndex) -> JSIO Any
   keyPath a = tryJS "IDBIndex.keyPath" $ IDBIndex.prim__keyPath a
 
-
+  
   export
   multiEntry : (obj : IDBIndex) -> JSIO Bool
   multiEntry a = tryJS "IDBIndex.multiEntry" $ IDBIndex.prim__multiEntry a
 
-
+  
   export
   name : IDBIndex -> Attribute True Prelude.id String
   name v = fromPrim "IDBIndex.getname" prim__name prim__setName v
 
-
+  
   export
   objectStore : (obj : IDBIndex) -> JSIO IDBObjectStore
   objectStore a = primJS $ IDBIndex.prim__objectStore a
 
-
+  
   export
   unique : (obj : IDBIndex) -> JSIO Bool
   unique a = tryJS "IDBIndex.unique" $ IDBIndex.prim__unique a
 
-
+  
   export
   count' : (obj : IDBIndex) -> (query : Optional Any) -> JSIO IDBRequest
   count' a b = primJS $ IDBIndex.prim__count a (toFFI b)
-
+  
   export
   count : (obj : IDBIndex) -> JSIO IDBRequest
   count a = primJS $ IDBIndex.prim__count a undef
 
-
+  
   export
   getAll' :
        (obj : IDBIndex)
@@ -308,12 +280,12 @@ namespace IDBIndex
     -> (count : Optional Bits32)
     -> JSIO IDBRequest
   getAll' a b c = primJS $ IDBIndex.prim__getAll a (toFFI b) (toFFI c)
-
+  
   export
   getAll : (obj : IDBIndex) -> JSIO IDBRequest
   getAll a = primJS $ IDBIndex.prim__getAll a undef undef
 
-
+  
   export
   getAllKeys' :
        (obj : IDBIndex)
@@ -321,22 +293,22 @@ namespace IDBIndex
     -> (count : Optional Bits32)
     -> JSIO IDBRequest
   getAllKeys' a b c = primJS $ IDBIndex.prim__getAllKeys a (toFFI b) (toFFI c)
-
+  
   export
   getAllKeys : (obj : IDBIndex) -> JSIO IDBRequest
   getAllKeys a = primJS $ IDBIndex.prim__getAllKeys a undef undef
 
-
+  
   export
   get : (obj : IDBIndex) -> (query : Any) -> JSIO IDBRequest
   get a b = primJS $ IDBIndex.prim__get a (toFFI b)
 
-
+  
   export
   getKey : (obj : IDBIndex) -> (query : Any) -> JSIO IDBRequest
   getKey a b = primJS $ IDBIndex.prim__getKey a (toFFI b)
 
-
+  
   export
   openCursor' :
        (obj : IDBIndex)
@@ -344,12 +316,12 @@ namespace IDBIndex
     -> (direction : Optional IDBCursorDirection)
     -> JSIO IDBRequest
   openCursor' a b c = primJS $ IDBIndex.prim__openCursor a (toFFI b) (toFFI c)
-
+  
   export
   openCursor : (obj : IDBIndex) -> JSIO IDBRequest
   openCursor a = primJS $ IDBIndex.prim__openCursor a undef undef
 
-
+  
   export
   openKeyCursor' :
        (obj : IDBIndex)
@@ -358,7 +330,7 @@ namespace IDBIndex
     -> JSIO IDBRequest
   openKeyCursor' a b c = primJS $
     IDBIndex.prim__openKeyCursor a (toFFI b) (toFFI c)
-
+  
   export
   openKeyCursor : (obj : IDBIndex) -> JSIO IDBRequest
   openKeyCursor a = primJS $ IDBIndex.prim__openKeyCursor a undef undef
@@ -366,7 +338,7 @@ namespace IDBIndex
 
 
 namespace IDBKeyRange
-
+  
   export
   bound' :
        (lower : Any)
@@ -376,55 +348,55 @@ namespace IDBKeyRange
     -> JSIO IDBKeyRange
   bound' a b c d = primJS $
     IDBKeyRange.prim__bound (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   bound : (lower : Any) -> (upper : Any) -> JSIO IDBKeyRange
   bound a b = primJS $ IDBKeyRange.prim__bound (toFFI a) (toFFI b) undef undef
 
-
+  
   export
   lowerBound' : (lower : Any) -> (open_ : Optional Bool) -> JSIO IDBKeyRange
   lowerBound' a b = primJS $ IDBKeyRange.prim__lowerBound (toFFI a) (toFFI b)
-
+  
   export
   lowerBound : (lower : Any) -> JSIO IDBKeyRange
   lowerBound a = primJS $ IDBKeyRange.prim__lowerBound (toFFI a) undef
 
-
+  
   export
   only : (value : Any) -> JSIO IDBKeyRange
   only a = primJS $ IDBKeyRange.prim__only (toFFI a)
 
-
+  
   export
   upperBound' : (upper : Any) -> (open_ : Optional Bool) -> JSIO IDBKeyRange
   upperBound' a b = primJS $ IDBKeyRange.prim__upperBound (toFFI a) (toFFI b)
-
+  
   export
   upperBound : (upper : Any) -> JSIO IDBKeyRange
   upperBound a = primJS $ IDBKeyRange.prim__upperBound (toFFI a) undef
 
-
+  
   export
   lower : (obj : IDBKeyRange) -> JSIO Any
   lower a = tryJS "IDBKeyRange.lower" $ IDBKeyRange.prim__lower a
 
-
+  
   export
   lowerOpen : (obj : IDBKeyRange) -> JSIO Bool
   lowerOpen a = tryJS "IDBKeyRange.lowerOpen" $ IDBKeyRange.prim__lowerOpen a
 
-
+  
   export
   upper : (obj : IDBKeyRange) -> JSIO Any
   upper a = tryJS "IDBKeyRange.upper" $ IDBKeyRange.prim__upper a
 
-
+  
   export
   upperOpen : (obj : IDBKeyRange) -> JSIO Bool
   upperOpen a = tryJS "IDBKeyRange.upperOpen" $ IDBKeyRange.prim__upperOpen a
 
-
+  
   export
   includes : (obj : IDBKeyRange) -> (key : Any) -> JSIO Bool
   includes a b = tryJS "IDBKeyRange.includes" $
@@ -433,33 +405,33 @@ namespace IDBKeyRange
 
 
 namespace IDBObjectStore
-
+  
   export
   autoIncrement : (obj : IDBObjectStore) -> JSIO Bool
   autoIncrement a = tryJS "IDBObjectStore.autoIncrement" $
     IDBObjectStore.prim__autoIncrement a
 
-
+  
   export
   indexNames : (obj : IDBObjectStore) -> JSIO DOMStringList
   indexNames a = primJS $ IDBObjectStore.prim__indexNames a
 
-
+  
   export
   keyPath : (obj : IDBObjectStore) -> JSIO Any
   keyPath a = tryJS "IDBObjectStore.keyPath" $ IDBObjectStore.prim__keyPath a
 
-
+  
   export
   name : IDBObjectStore -> Attribute True Prelude.id String
   name v = fromPrim "IDBObjectStore.getname" prim__name prim__setName v
 
-
+  
   export
   transaction : (obj : IDBObjectStore) -> JSIO IDBTransaction
   transaction a = primJS $ IDBObjectStore.prim__transaction a
 
-
+  
   export
   add' :
        (obj : IDBObjectStore)
@@ -467,30 +439,29 @@ namespace IDBObjectStore
     -> (key : Optional Any)
     -> JSIO IDBRequest
   add' a b c = primJS $ IDBObjectStore.prim__add a (toFFI b) (toFFI c)
-
+  
   export
   add : (obj : IDBObjectStore) -> (value : Any) -> JSIO IDBRequest
   add a b = primJS $ IDBObjectStore.prim__add a (toFFI b) undef
 
-
+  
   export
   clear : (obj : IDBObjectStore) -> JSIO IDBRequest
   clear a = primJS $ IDBObjectStore.prim__clear a
 
-
+  
   export
   count' : (obj : IDBObjectStore) -> (query : Optional Any) -> JSIO IDBRequest
   count' a b = primJS $ IDBObjectStore.prim__count a (toFFI b)
-
+  
   export
   count : (obj : IDBObjectStore) -> JSIO IDBRequest
   count a = primJS $ IDBObjectStore.prim__count a undef
 
-
+  
   export
   createIndex' :
-       {auto 0 _ : JSType t4}
-    -> {auto 0 _ : Elem IDBIndexParameters (Types t4)}
+       {auto _ : Cast t4 IDBIndexParameters}
     -> (obj : IDBObjectStore)
     -> (name : String)
     -> (keyPath : HSum [String, Array String])
@@ -498,7 +469,7 @@ namespace IDBObjectStore
     -> JSIO IDBIndex
   createIndex' a b c d = primJS $
     IDBObjectStore.prim__createIndex a b (toFFI c) (optUp d)
-
+  
   export
   createIndex :
        (obj : IDBObjectStore)
@@ -508,17 +479,17 @@ namespace IDBObjectStore
   createIndex a b c = primJS $
     IDBObjectStore.prim__createIndex a b (toFFI c) undef
 
-
+  
   export
   delete : (obj : IDBObjectStore) -> (query : Any) -> JSIO IDBRequest
   delete a b = primJS $ IDBObjectStore.prim__delete a (toFFI b)
 
-
+  
   export
   deleteIndex : (obj : IDBObjectStore) -> (name : String) -> JSIO ()
   deleteIndex a b = primJS $ IDBObjectStore.prim__deleteIndex a b
 
-
+  
   export
   getAll' :
        (obj : IDBObjectStore)
@@ -526,12 +497,12 @@ namespace IDBObjectStore
     -> (count : Optional Bits32)
     -> JSIO IDBRequest
   getAll' a b c = primJS $ IDBObjectStore.prim__getAll a (toFFI b) (toFFI c)
-
+  
   export
   getAll : (obj : IDBObjectStore) -> JSIO IDBRequest
   getAll a = primJS $ IDBObjectStore.prim__getAll a undef undef
 
-
+  
   export
   getAllKeys' :
        (obj : IDBObjectStore)
@@ -540,27 +511,27 @@ namespace IDBObjectStore
     -> JSIO IDBRequest
   getAllKeys' a b c = primJS $
     IDBObjectStore.prim__getAllKeys a (toFFI b) (toFFI c)
-
+  
   export
   getAllKeys : (obj : IDBObjectStore) -> JSIO IDBRequest
   getAllKeys a = primJS $ IDBObjectStore.prim__getAllKeys a undef undef
 
-
+  
   export
   get : (obj : IDBObjectStore) -> (query : Any) -> JSIO IDBRequest
   get a b = primJS $ IDBObjectStore.prim__get a (toFFI b)
 
-
+  
   export
   getKey : (obj : IDBObjectStore) -> (query : Any) -> JSIO IDBRequest
   getKey a b = primJS $ IDBObjectStore.prim__getKey a (toFFI b)
 
-
+  
   export
   index : (obj : IDBObjectStore) -> (name : String) -> JSIO IDBIndex
   index a b = primJS $ IDBObjectStore.prim__index a b
 
-
+  
   export
   openCursor' :
        (obj : IDBObjectStore)
@@ -569,12 +540,12 @@ namespace IDBObjectStore
     -> JSIO IDBRequest
   openCursor' a b c = primJS $
     IDBObjectStore.prim__openCursor a (toFFI b) (toFFI c)
-
+  
   export
   openCursor : (obj : IDBObjectStore) -> JSIO IDBRequest
   openCursor a = primJS $ IDBObjectStore.prim__openCursor a undef undef
 
-
+  
   export
   openKeyCursor' :
        (obj : IDBObjectStore)
@@ -583,12 +554,12 @@ namespace IDBObjectStore
     -> JSIO IDBRequest
   openKeyCursor' a b c = primJS $
     IDBObjectStore.prim__openKeyCursor a (toFFI b) (toFFI c)
-
+  
   export
   openKeyCursor : (obj : IDBObjectStore) -> JSIO IDBRequest
   openKeyCursor a = primJS $ IDBObjectStore.prim__openKeyCursor a undef undef
 
-
+  
   export
   put' :
        (obj : IDBObjectStore)
@@ -596,7 +567,7 @@ namespace IDBObjectStore
     -> (key : Optional Any)
     -> JSIO IDBRequest
   put' a b c = primJS $ IDBObjectStore.prim__put a (toFFI b) (toFFI c)
-
+  
   export
   put : (obj : IDBObjectStore) -> (value : Any) -> JSIO IDBRequest
   put a b = primJS $ IDBObjectStore.prim__put a (toFFI b) undef
@@ -604,7 +575,7 @@ namespace IDBObjectStore
 
 
 namespace IDBOpenDBRequest
-
+  
   export
   onblocked : IDBOpenDBRequest -> Attribute False Maybe EventHandlerNonNull
   onblocked v = fromNullablePrim
@@ -613,7 +584,7 @@ namespace IDBOpenDBRequest
                   prim__setOnblocked
                   v
 
-
+  
   export
   onupgradeneeded :
        IDBOpenDBRequest
@@ -627,109 +598,99 @@ namespace IDBOpenDBRequest
 
 
 namespace IDBRequest
-
+  
   export
   error :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBRequest (Types t1)}
+       {auto _ : Cast t1 IDBRequest}
     -> (obj : t1)
     -> JSIO (Maybe DOMException)
-  error a = tryJS "IDBRequest.error" $ IDBRequest.prim__error (up a)
+  error a = tryJS "IDBRequest.error" $ IDBRequest.prim__error (cast a)
 
-
+  
   export
   onerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBRequest (Types t)}
+       {auto _ : Cast t IDBRequest}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
                 "IDBRequest.getonerror"
                 prim__onerror
                 prim__setOnerror
-                (v :> IDBRequest)
+                (cast {to = IDBRequest} v)
 
-
+  
   export
   onsuccess :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBRequest (Types t)}
+       {auto _ : Cast t IDBRequest}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onsuccess v = fromNullablePrim
                   "IDBRequest.getonsuccess"
                   prim__onsuccess
                   prim__setOnsuccess
-                  (v :> IDBRequest)
+                  (cast {to = IDBRequest} v)
 
-
+  
   export
   readyState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBRequest (Types t1)}
+       {auto _ : Cast t1 IDBRequest}
     -> (obj : t1)
     -> JSIO IDBRequestReadyState
   readyState a = tryJS "IDBRequest.readyState" $
-    IDBRequest.prim__readyState (up a)
+    IDBRequest.prim__readyState (cast a)
 
-
+  
   export
-  result :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBRequest (Types t1)}
-    -> (obj : t1)
-    -> JSIO Any
-  result a = tryJS "IDBRequest.result" $ IDBRequest.prim__result (up a)
+  result : {auto _ : Cast t1 IDBRequest} -> (obj : t1) -> JSIO Any
+  result a = tryJS "IDBRequest.result" $ IDBRequest.prim__result (cast a)
 
-
+  
   export
   source :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBRequest (Types t1)}
+       {auto _ : Cast t1 IDBRequest}
     -> (obj : t1)
     -> JSIO (Maybe (HSum [IDBObjectStore, IDBIndex, IDBCursor]))
-  source a = tryJS "IDBRequest.source" $ IDBRequest.prim__source (up a)
+  source a = tryJS "IDBRequest.source" $ IDBRequest.prim__source (cast a)
 
-
+  
   export
   transaction :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem IDBRequest (Types t1)}
+       {auto _ : Cast t1 IDBRequest}
     -> (obj : t1)
     -> JSIO (Maybe IDBTransaction)
   transaction a = tryJS "IDBRequest.transaction" $
-    IDBRequest.prim__transaction (up a)
+    IDBRequest.prim__transaction (cast a)
 
 
 
 namespace IDBTransaction
-
+  
   export
   db : (obj : IDBTransaction) -> JSIO IDBDatabase
   db a = primJS $ IDBTransaction.prim__db a
 
-
+  
   export
   durability : (obj : IDBTransaction) -> JSIO IDBTransactionDurability
   durability a = tryJS "IDBTransaction.durability" $
     IDBTransaction.prim__durability a
 
-
+  
   export
   error : (obj : IDBTransaction) -> JSIO (Maybe DOMException)
   error a = tryJS "IDBTransaction.error" $ IDBTransaction.prim__error a
 
-
+  
   export
   mode : (obj : IDBTransaction) -> JSIO IDBTransactionMode
   mode a = tryJS "IDBTransaction.mode" $ IDBTransaction.prim__mode a
 
-
+  
   export
   objectStoreNames : (obj : IDBTransaction) -> JSIO DOMStringList
   objectStoreNames a = primJS $ IDBTransaction.prim__objectStoreNames a
 
-
+  
   export
   onabort : IDBTransaction -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
@@ -738,7 +699,7 @@ namespace IDBTransaction
                 prim__setOnabort
                 v
 
-
+  
   export
   oncomplete : IDBTransaction -> Attribute False Maybe EventHandlerNonNull
   oncomplete v = fromNullablePrim
@@ -747,7 +708,7 @@ namespace IDBTransaction
                    prim__setOncomplete
                    v
 
-
+  
   export
   onerror : IDBTransaction -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -756,17 +717,17 @@ namespace IDBTransaction
                 prim__setOnerror
                 v
 
-
+  
   export
   abort : (obj : IDBTransaction) -> JSIO ()
   abort a = primJS $ IDBTransaction.prim__abort a
 
-
+  
   export
   commit : (obj : IDBTransaction) -> JSIO ()
   commit a = primJS $ IDBTransaction.prim__commit a
 
-
+  
   export
   objectStore : (obj : IDBTransaction) -> (name : String) -> JSIO IDBObjectStore
   objectStore a b = primJS $ IDBTransaction.prim__objectStore a b
@@ -774,27 +735,26 @@ namespace IDBTransaction
 
 
 namespace IDBVersionChangeEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem IDBVersionChangeEventInit (Types t2)}
+       {auto _ : Cast t2 IDBVersionChangeEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO IDBVersionChangeEvent
   new' a b = primJS $ IDBVersionChangeEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO IDBVersionChangeEvent
   new a = primJS $ IDBVersionChangeEvent.prim__new a undef
 
-
+  
   export
   newVersion : (obj : IDBVersionChangeEvent) -> JSIO (Maybe JSBits64)
   newVersion a = tryJS "IDBVersionChangeEvent.newVersion" $
     IDBVersionChangeEvent.prim__newVersion a
 
-
+  
   export
   oldVersion : (obj : IDBVersionChangeEvent) -> JSIO JSBits64
   oldVersion a = primJS $ IDBVersionChangeEvent.prim__oldVersion a
@@ -808,64 +768,61 @@ namespace IDBVersionChangeEvent
 --------------------------------------------------------------------------------
 
 namespace IDBDatabaseInfo
-
+  
   export
   new' :
        (name : Optional String)
     -> (version : Optional JSBits64)
     -> JSIO IDBDatabaseInfo
   new' a b = primJS $ IDBDatabaseInfo.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO IDBDatabaseInfo
   new = primJS $ IDBDatabaseInfo.prim__new undef undef
 
-
+  
   export
   name :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBDatabaseInfo (Types t)}
+       {auto _ : Cast t IDBDatabaseInfo}
     -> t
     -> Attribute False Optional String
   name v = fromUndefOrPrimNoDefault
              "IDBDatabaseInfo.getname"
              prim__name
              prim__setName
-             (v :> IDBDatabaseInfo)
+             (cast {to = IDBDatabaseInfo} v)
 
-
+  
   export
   version :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBDatabaseInfo (Types t)}
+       {auto _ : Cast t IDBDatabaseInfo}
     -> t
     -> Attribute False Optional JSBits64
   version v = fromUndefOrPrimNoDefault
                 "IDBDatabaseInfo.getversion"
                 prim__version
                 prim__setVersion
-                (v :> IDBDatabaseInfo)
+                (cast {to = IDBDatabaseInfo} v)
 
 
 
 namespace IDBIndexParameters
-
+  
   export
   new' :
        (unique : Optional Bool)
     -> (multiEntry : Optional Bool)
     -> JSIO IDBIndexParameters
   new' a b = primJS $ IDBIndexParameters.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO IDBIndexParameters
   new = primJS $ IDBIndexParameters.prim__new undef undef
 
-
+  
   export
   multiEntry :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBIndexParameters (Types t)}
+       {auto _ : Cast t IDBIndexParameters}
     -> t
     -> Attribute True Optional Bool
   multiEntry v = fromUndefOrPrim
@@ -873,13 +830,12 @@ namespace IDBIndexParameters
                    prim__multiEntry
                    prim__setMultiEntry
                    False
-                   (v :> IDBIndexParameters)
+                   (cast {to = IDBIndexParameters} v)
 
-
+  
   export
   unique :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBIndexParameters (Types t)}
+       {auto _ : Cast t IDBIndexParameters}
     -> t
     -> Attribute True Optional Bool
   unique v = fromUndefOrPrim
@@ -887,28 +843,27 @@ namespace IDBIndexParameters
                prim__unique
                prim__setUnique
                False
-               (v :> IDBIndexParameters)
+               (cast {to = IDBIndexParameters} v)
 
 
 
 namespace IDBObjectStoreParameters
-
+  
   export
   new' :
        (keyPath : Optional (Maybe (HSum [String, Array String])))
     -> (autoIncrement : Optional Bool)
     -> JSIO IDBObjectStoreParameters
   new' a b = primJS $ IDBObjectStoreParameters.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO IDBObjectStoreParameters
   new = primJS $ IDBObjectStoreParameters.prim__new undef undef
 
-
+  
   export
   autoIncrement :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBObjectStoreParameters (Types t)}
+       {auto _ : Cast t IDBObjectStoreParameters}
     -> t
     -> Attribute True Optional Bool
   autoIncrement v = fromUndefOrPrim
@@ -916,13 +871,12 @@ namespace IDBObjectStoreParameters
                       prim__autoIncrement
                       prim__setAutoIncrement
                       False
-                      (v :> IDBObjectStoreParameters)
+                      (cast {to = IDBObjectStoreParameters} v)
 
-
+  
   export
   keyPath :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBObjectStoreParameters (Types t)}
+       {auto _ : Cast t IDBObjectStoreParameters}
     -> t
     -> Attribute True Optional (Maybe (Union2 String (Array String)))
   keyPath v = fromUndefOrPrim
@@ -930,55 +884,53 @@ namespace IDBObjectStoreParameters
                 prim__keyPath
                 prim__setKeyPath
                 Nothing
-                (v :> IDBObjectStoreParameters)
+                (cast {to = IDBObjectStoreParameters} v)
 
 
 
 namespace IDBTransactionOptions
-
+  
   export
   new' :
        (durability : Optional IDBTransactionDurability)
     -> JSIO IDBTransactionOptions
   new' a = primJS $ IDBTransactionOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO IDBTransactionOptions
   new = primJS $ IDBTransactionOptions.prim__new undef
 
-
+  
   export
   durability :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBTransactionOptions (Types t)}
+       {auto _ : Cast t IDBTransactionOptions}
     -> t
     -> Attribute False Optional IDBTransactionDurability
   durability v = fromUndefOrPrimNoDefault
                    "IDBTransactionOptions.getdurability"
                    prim__durability
                    prim__setDurability
-                   (v :> IDBTransactionOptions)
+                   (cast {to = IDBTransactionOptions} v)
 
 
 
 namespace IDBVersionChangeEventInit
-
+  
   export
   new' :
        (oldVersion : Optional JSBits64)
     -> (newVersion : Optional (Maybe JSBits64))
     -> JSIO IDBVersionChangeEventInit
   new' a b = primJS $ IDBVersionChangeEventInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO IDBVersionChangeEventInit
   new = primJS $ IDBVersionChangeEventInit.prim__new undef undef
 
-
+  
   export
   newVersion :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBVersionChangeEventInit (Types t)}
+       {auto _ : Cast t IDBVersionChangeEventInit}
     -> t
     -> Attribute True Optional (Maybe JSBits64)
   newVersion v = fromUndefOrPrim
@@ -986,13 +938,12 @@ namespace IDBVersionChangeEventInit
                    prim__newVersion
                    prim__setNewVersion
                    Nothing
-                   (v :> IDBVersionChangeEventInit)
+                   (cast {to = IDBVersionChangeEventInit} v)
 
-
+  
   export
   oldVersion :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem IDBVersionChangeEventInit (Types t)}
+       {auto _ : Cast t IDBVersionChangeEventInit}
     -> t
     -> Attribute True Optional JSBits64
   oldVersion v = fromUndefOrPrim
@@ -1000,4 +951,7 @@ namespace IDBVersionChangeEventInit
                    prim__oldVersion
                    prim__setOldVersion
                    0
-                   (v :> IDBVersionChangeEventInit)
+                   (cast {to = IDBVersionChangeEventInit} v)
+
+
+

--- a/src/Web/Raw/Mediasource.idr
+++ b/src/Web/Raw/Mediasource.idr
@@ -12,23 +12,23 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace MediaSource
-
+  
   export
   new : JSIO MediaSource
   new = primJS $ MediaSource.prim__new
 
-
+  
   export
   isTypeSupported : (type : String) -> JSIO Bool
   isTypeSupported a = tryJS "MediaSource.isTypeSupported" $
     MediaSource.prim__isTypeSupported a
 
-
+  
   export
   activeSourceBuffers : (obj : MediaSource) -> JSIO SourceBufferList
   activeSourceBuffers a = primJS $ MediaSource.prim__activeSourceBuffers a
 
-
+  
   export
   duration : MediaSource -> Attribute True Prelude.id Double
   duration v = fromPrim
@@ -37,7 +37,7 @@ namespace MediaSource
                  prim__setDuration
                  v
 
-
+  
   export
   onsourceclose : MediaSource -> Attribute False Maybe EventHandlerNonNull
   onsourceclose v = fromNullablePrim
@@ -46,7 +46,7 @@ namespace MediaSource
                       prim__setOnsourceclose
                       v
 
-
+  
   export
   onsourceended : MediaSource -> Attribute False Maybe EventHandlerNonNull
   onsourceended v = fromNullablePrim
@@ -55,7 +55,7 @@ namespace MediaSource
                       prim__setOnsourceended
                       v
 
-
+  
   export
   onsourceopen : MediaSource -> Attribute False Maybe EventHandlerNonNull
   onsourceopen v = fromNullablePrim
@@ -64,39 +64,39 @@ namespace MediaSource
                      prim__setOnsourceopen
                      v
 
-
+  
   export
   readyState : (obj : MediaSource) -> JSIO ReadyState
   readyState a = tryJS "MediaSource.readyState" $ MediaSource.prim__readyState a
 
-
+  
   export
   sourceBuffers : (obj : MediaSource) -> JSIO SourceBufferList
   sourceBuffers a = primJS $ MediaSource.prim__sourceBuffers a
 
-
+  
   export
   addSourceBuffer : (obj : MediaSource) -> (type : String) -> JSIO SourceBuffer
   addSourceBuffer a b = primJS $ MediaSource.prim__addSourceBuffer a b
 
-
+  
   export
   clearLiveSeekableRange : (obj : MediaSource) -> JSIO ()
   clearLiveSeekableRange a = primJS $ MediaSource.prim__clearLiveSeekableRange a
 
-
+  
   export
   endOfStream' :
        (obj : MediaSource)
     -> (error : Optional EndOfStreamError)
     -> JSIO ()
   endOfStream' a b = primJS $ MediaSource.prim__endOfStream a (toFFI b)
-
+  
   export
   endOfStream : (obj : MediaSource) -> JSIO ()
   endOfStream a = primJS $ MediaSource.prim__endOfStream a undef
 
-
+  
   export
   removeSourceBuffer :
        (obj : MediaSource)
@@ -104,7 +104,7 @@ namespace MediaSource
     -> JSIO ()
   removeSourceBuffer a b = primJS $ MediaSource.prim__removeSourceBuffer a b
 
-
+  
   export
   setLiveSeekableRange :
        (obj : MediaSource)
@@ -117,7 +117,7 @@ namespace MediaSource
 
 
 namespace SourceBuffer
-
+  
   export
   appendWindowEnd : SourceBuffer -> Attribute True Prelude.id Double
   appendWindowEnd v = fromPrim
@@ -126,7 +126,7 @@ namespace SourceBuffer
                         prim__setAppendWindowEnd
                         v
 
-
+  
   export
   appendWindowStart : SourceBuffer -> Attribute True Prelude.id Double
   appendWindowStart v = fromPrim
@@ -135,22 +135,22 @@ namespace SourceBuffer
                           prim__setAppendWindowStart
                           v
 
-
+  
   export
   audioTracks : (obj : SourceBuffer) -> JSIO AudioTrackList
   audioTracks a = primJS $ SourceBuffer.prim__audioTracks a
 
-
+  
   export
   buffered : (obj : SourceBuffer) -> JSIO TimeRanges
   buffered a = primJS $ SourceBuffer.prim__buffered a
 
-
+  
   export
   mode : SourceBuffer -> Attribute True Prelude.id AppendMode
   mode v = fromPrim "SourceBuffer.getmode" prim__mode prim__setMode v
 
-
+  
   export
   onabort : SourceBuffer -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
@@ -159,7 +159,7 @@ namespace SourceBuffer
                 prim__setOnabort
                 v
 
-
+  
   export
   onerror : SourceBuffer -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
@@ -168,7 +168,7 @@ namespace SourceBuffer
                 prim__setOnerror
                 v
 
-
+  
   export
   onupdate : SourceBuffer -> Attribute False Maybe EventHandlerNonNull
   onupdate v = fromNullablePrim
@@ -177,7 +177,7 @@ namespace SourceBuffer
                  prim__setOnupdate
                  v
 
-
+  
   export
   onupdateend : SourceBuffer -> Attribute False Maybe EventHandlerNonNull
   onupdateend v = fromNullablePrim
@@ -186,7 +186,7 @@ namespace SourceBuffer
                     prim__setOnupdateend
                     v
 
-
+  
   export
   onupdatestart : SourceBuffer -> Attribute False Maybe EventHandlerNonNull
   onupdatestart v = fromNullablePrim
@@ -195,12 +195,12 @@ namespace SourceBuffer
                       prim__setOnupdatestart
                       v
 
-
+  
   export
   textTracks : (obj : SourceBuffer) -> JSIO TextTrackList
   textTracks a = primJS $ SourceBuffer.prim__textTracks a
 
-
+  
   export
   timestampOffset : SourceBuffer -> Attribute True Prelude.id Double
   timestampOffset v = fromPrim
@@ -209,22 +209,22 @@ namespace SourceBuffer
                         prim__setTimestampOffset
                         v
 
-
+  
   export
   updating : (obj : SourceBuffer) -> JSIO Bool
   updating a = tryJS "SourceBuffer.updating" $ SourceBuffer.prim__updating a
 
-
+  
   export
   videoTracks : (obj : SourceBuffer) -> JSIO VideoTrackList
   videoTracks a = primJS $ SourceBuffer.prim__videoTracks a
 
-
+  
   export
   abort : (obj : SourceBuffer) -> JSIO ()
   abort a = primJS $ SourceBuffer.prim__abort a
 
-
+  
   export
   appendBuffer :
        (obj : SourceBuffer)
@@ -244,7 +244,7 @@ namespace SourceBuffer
     -> JSIO ()
   appendBuffer a b = primJS $ SourceBuffer.prim__appendBuffer a (toFFI b)
 
-
+  
   export
   remove : (obj : SourceBuffer) -> (start : Double) -> (end : Double) -> JSIO ()
   remove a b c = primJS $ SourceBuffer.prim__remove a b c
@@ -252,17 +252,17 @@ namespace SourceBuffer
 
 
 namespace SourceBufferList
-
+  
   export
   get : (obj : SourceBufferList) -> (index : Bits32) -> JSIO SourceBuffer
   get a b = primJS $ SourceBufferList.prim__get a b
 
-
+  
   export
   length : (obj : SourceBufferList) -> JSIO Bits32
   length a = primJS $ SourceBufferList.prim__length a
 
-
+  
   export
   onaddsourcebuffer :
        SourceBufferList
@@ -273,7 +273,7 @@ namespace SourceBufferList
                           prim__setOnaddsourcebuffer
                           v
 
-
+  
   export
   onremovesourcebuffer :
        SourceBufferList
@@ -283,3 +283,8 @@ namespace SourceBufferList
                              prim__onremovesourcebuffer
                              prim__setOnremovesourcebuffer
                              v
+
+
+
+
+

--- a/src/Web/Raw/Mediastream.idr
+++ b/src/Web/Raw/Mediastream.idr
@@ -12,33 +12,32 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace ConstrainablePattern
-
+  
   export
   applyConstraints' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Constraints (Types t2)}
+       {auto _ : Cast t2 Constraints}
     -> (obj : ConstrainablePattern)
     -> (constraints : Optional t2)
     -> JSIO (Promise Undefined)
   applyConstraints' a b = primJS $
     ConstrainablePattern.prim__applyConstraints a (optUp b)
-
+  
   export
   applyConstraints : (obj : ConstrainablePattern) -> JSIO (Promise Undefined)
   applyConstraints a = primJS $
     ConstrainablePattern.prim__applyConstraints a undef
 
-
+  
   export
   getCapabilities : (obj : ConstrainablePattern) -> JSIO Capabilities
   getCapabilities a = primJS $ ConstrainablePattern.prim__getCapabilities a
 
-
+  
   export
   getConstraints : (obj : ConstrainablePattern) -> JSIO Constraints
   getConstraints a = primJS $ ConstrainablePattern.prim__getConstraints a
 
-
+  
   export
   getSettings : (obj : ConstrainablePattern) -> JSIO Settings
   getSettings a = primJS $ ConstrainablePattern.prim__getSettings a
@@ -46,7 +45,7 @@ namespace ConstrainablePattern
 
 
 namespace InputDeviceInfo
-
+  
   export
   getCapabilities : (obj : InputDeviceInfo) -> JSIO MediaTrackCapabilities
   getCapabilities a = primJS $ InputDeviceInfo.prim__getCapabilities a
@@ -54,55 +53,38 @@ namespace InputDeviceInfo
 
 
 namespace MediaDeviceInfo
-
+  
   export
-  deviceId :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MediaDeviceInfo (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  deviceId a = primJS $ MediaDeviceInfo.prim__deviceId (up a)
+  deviceId : {auto _ : Cast t1 MediaDeviceInfo} -> (obj : t1) -> JSIO String
+  deviceId a = primJS $ MediaDeviceInfo.prim__deviceId (cast a)
 
-
+  
   export
-  groupId :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MediaDeviceInfo (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  groupId a = primJS $ MediaDeviceInfo.prim__groupId (up a)
+  groupId : {auto _ : Cast t1 MediaDeviceInfo} -> (obj : t1) -> JSIO String
+  groupId a = primJS $ MediaDeviceInfo.prim__groupId (cast a)
 
-
+  
   export
   kind :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MediaDeviceInfo (Types t1)}
+       {auto _ : Cast t1 MediaDeviceInfo}
     -> (obj : t1)
     -> JSIO MediaDeviceKind
-  kind a = tryJS "MediaDeviceInfo.kind" $ MediaDeviceInfo.prim__kind (up a)
+  kind a = tryJS "MediaDeviceInfo.kind" $ MediaDeviceInfo.prim__kind (cast a)
 
-
+  
   export
-  label :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MediaDeviceInfo (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  label a = primJS $ MediaDeviceInfo.prim__label (up a)
+  label : {auto _ : Cast t1 MediaDeviceInfo} -> (obj : t1) -> JSIO String
+  label a = primJS $ MediaDeviceInfo.prim__label (cast a)
 
-
+  
   export
-  toJSON :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MediaDeviceInfo (Types t1)}
-    -> (obj : t1)
-    -> JSIO Object
-  toJSON a = primJS $ MediaDeviceInfo.prim__toJSON (up a)
+  toJSON : {auto _ : Cast t1 MediaDeviceInfo} -> (obj : t1) -> JSIO Object
+  toJSON a = primJS $ MediaDeviceInfo.prim__toJSON (cast a)
 
 
 
 namespace MediaDevices
-
+  
   export
   ondevicechange : MediaDevices -> Attribute False Maybe EventHandlerNonNull
   ondevicechange v = fromNullablePrim
@@ -111,14 +93,14 @@ namespace MediaDevices
                        prim__setOndevicechange
                        v
 
-
+  
   export
   enumerateDevices :
        (obj : MediaDevices)
     -> JSIO (Promise (Array MediaDeviceInfo))
   enumerateDevices a = primJS $ MediaDevices.prim__enumerateDevices a
 
-
+  
   export
   getSupportedConstraints :
        (obj : MediaDevices)
@@ -126,16 +108,15 @@ namespace MediaDevices
   getSupportedConstraints a = primJS $
     MediaDevices.prim__getSupportedConstraints a
 
-
+  
   export
   getUserMedia' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MediaStreamConstraints (Types t2)}
+       {auto _ : Cast t2 MediaStreamConstraints}
     -> (obj : MediaDevices)
     -> (constraints : Optional t2)
     -> JSIO (Promise MediaStream)
   getUserMedia' a b = primJS $ MediaDevices.prim__getUserMedia a (optUp b)
-
+  
   export
   getUserMedia : (obj : MediaDevices) -> JSIO (Promise MediaStream)
   getUserMedia a = primJS $ MediaDevices.prim__getUserMedia a undef
@@ -143,32 +124,32 @@ namespace MediaDevices
 
 
 namespace MediaStream
-
+  
   export
   new : JSIO MediaStream
   new = primJS $ MediaStream.prim__new
 
-
+  
   export
   new1 : (stream : MediaStream) -> JSIO MediaStream
   new1 a = primJS $ MediaStream.prim__new1 a
 
-
+  
   export
   new2 : (tracks : Array MediaStreamTrack) -> JSIO MediaStream
   new2 a = primJS $ MediaStream.prim__new2 a
 
-
+  
   export
   active : (obj : MediaStream) -> JSIO Bool
   active a = tryJS "MediaStream.active" $ MediaStream.prim__active a
 
-
+  
   export
   id : (obj : MediaStream) -> JSIO String
   id a = primJS $ MediaStream.prim__id a
 
-
+  
   export
   onaddtrack : MediaStream -> Attribute False Maybe EventHandlerNonNull
   onaddtrack v = fromNullablePrim
@@ -177,7 +158,7 @@ namespace MediaStream
                    prim__setOnaddtrack
                    v
 
-
+  
   export
   onremovetrack : MediaStream -> Attribute False Maybe EventHandlerNonNull
   onremovetrack v = fromNullablePrim
@@ -186,22 +167,22 @@ namespace MediaStream
                       prim__setOnremovetrack
                       v
 
-
+  
   export
   addTrack : (obj : MediaStream) -> (track : MediaStreamTrack) -> JSIO ()
   addTrack a b = primJS $ MediaStream.prim__addTrack a b
 
-
+  
   export
   clone : (obj : MediaStream) -> JSIO MediaStream
   clone a = primJS $ MediaStream.prim__clone a
 
-
+  
   export
   getAudioTracks : (obj : MediaStream) -> JSIO (Array MediaStreamTrack)
   getAudioTracks a = primJS $ MediaStream.prim__getAudioTracks a
 
-
+  
   export
   getTrackById :
        (obj : MediaStream)
@@ -210,17 +191,17 @@ namespace MediaStream
   getTrackById a b = tryJS "MediaStream.getTrackById" $
     MediaStream.prim__getTrackById a b
 
-
+  
   export
   getTracks : (obj : MediaStream) -> JSIO (Array MediaStreamTrack)
   getTracks a = primJS $ MediaStream.prim__getTracks a
 
-
+  
   export
   getVideoTracks : (obj : MediaStream) -> JSIO (Array MediaStreamTrack)
   getVideoTracks a = primJS $ MediaStream.prim__getVideoTracks a
 
-
+  
   export
   removeTrack : (obj : MediaStream) -> (track : MediaStreamTrack) -> JSIO ()
   removeTrack a b = primJS $ MediaStream.prim__removeTrack a b
@@ -228,7 +209,7 @@ namespace MediaStream
 
 
 namespace MediaStreamTrack
-
+  
   export
   enabled : MediaStreamTrack -> Attribute True Prelude.id Bool
   enabled v = fromPrim
@@ -237,27 +218,27 @@ namespace MediaStreamTrack
                 prim__setEnabled
                 v
 
-
+  
   export
   id : (obj : MediaStreamTrack) -> JSIO String
   id a = primJS $ MediaStreamTrack.prim__id a
 
-
+  
   export
   kind : (obj : MediaStreamTrack) -> JSIO String
   kind a = primJS $ MediaStreamTrack.prim__kind a
 
-
+  
   export
   label : (obj : MediaStreamTrack) -> JSIO String
   label a = primJS $ MediaStreamTrack.prim__label a
 
-
+  
   export
   muted : (obj : MediaStreamTrack) -> JSIO Bool
   muted a = tryJS "MediaStreamTrack.muted" $ MediaStreamTrack.prim__muted a
 
-
+  
   export
   onended : MediaStreamTrack -> Attribute False Maybe EventHandlerNonNull
   onended v = fromNullablePrim
@@ -266,7 +247,7 @@ namespace MediaStreamTrack
                 prim__setOnended
                 v
 
-
+  
   export
   onmute : MediaStreamTrack -> Attribute False Maybe EventHandlerNonNull
   onmute v = fromNullablePrim
@@ -275,7 +256,7 @@ namespace MediaStreamTrack
                prim__setOnmute
                v
 
-
+  
   export
   onunmute : MediaStreamTrack -> Attribute False Maybe EventHandlerNonNull
   onunmute v = fromNullablePrim
@@ -284,48 +265,47 @@ namespace MediaStreamTrack
                  prim__setOnunmute
                  v
 
-
+  
   export
   readyState : (obj : MediaStreamTrack) -> JSIO MediaStreamTrackState
   readyState a = tryJS "MediaStreamTrack.readyState" $
     MediaStreamTrack.prim__readyState a
 
-
+  
   export
   applyConstraints' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MediaTrackConstraints (Types t2)}
+       {auto _ : Cast t2 MediaTrackConstraints}
     -> (obj : MediaStreamTrack)
     -> (constraints : Optional t2)
     -> JSIO (Promise Undefined)
   applyConstraints' a b = primJS $
     MediaStreamTrack.prim__applyConstraints a (optUp b)
-
+  
   export
   applyConstraints : (obj : MediaStreamTrack) -> JSIO (Promise Undefined)
   applyConstraints a = primJS $ MediaStreamTrack.prim__applyConstraints a undef
 
-
+  
   export
   clone : (obj : MediaStreamTrack) -> JSIO MediaStreamTrack
   clone a = primJS $ MediaStreamTrack.prim__clone a
 
-
+  
   export
   getCapabilities : (obj : MediaStreamTrack) -> JSIO MediaTrackCapabilities
   getCapabilities a = primJS $ MediaStreamTrack.prim__getCapabilities a
 
-
+  
   export
   getConstraints : (obj : MediaStreamTrack) -> JSIO MediaTrackConstraints
   getConstraints a = primJS $ MediaStreamTrack.prim__getConstraints a
 
-
+  
   export
   getSettings : (obj : MediaStreamTrack) -> JSIO MediaTrackSettings
   getSettings a = primJS $ MediaStreamTrack.prim__getSettings a
 
-
+  
   export
   stop : (obj : MediaStreamTrack) -> JSIO ()
   stop a = primJS $ MediaStreamTrack.prim__stop a
@@ -333,17 +313,16 @@ namespace MediaStreamTrack
 
 
 namespace MediaStreamTrackEvent
-
+  
   export
   new :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem MediaStreamTrackEventInit (Types t2)}
+       {auto _ : Cast t2 MediaStreamTrackEventInit}
     -> (type : String)
     -> (eventInitDict : t2)
     -> JSIO MediaStreamTrackEvent
-  new a b = primJS $ MediaStreamTrackEvent.prim__new a (up b)
+  new a b = primJS $ MediaStreamTrackEvent.prim__new a (cast b)
 
-
+  
   export
   track : (obj : MediaStreamTrackEvent) -> JSIO MediaStreamTrack
   track a = primJS $ MediaStreamTrackEvent.prim__track a
@@ -351,19 +330,19 @@ namespace MediaStreamTrackEvent
 
 
 namespace OverconstrainedError
-
+  
   export
   new' :
        (constraint : String)
     -> (message : Optional String)
     -> JSIO OverconstrainedError
   new' a b = primJS $ OverconstrainedError.prim__new a (toFFI b)
-
+  
   export
   new : (constraint : String) -> JSIO OverconstrainedError
   new a = primJS $ OverconstrainedError.prim__new a undef
 
-
+  
   export
   constraint : (obj : OverconstrainedError) -> JSIO String
   constraint a = primJS $ OverconstrainedError.prim__constraint a
@@ -377,7 +356,7 @@ namespace OverconstrainedError
 --------------------------------------------------------------------------------
 
 namespace Capabilities
-
+  
   export
   new : JSIO Capabilities
   new = primJS $ Capabilities.prim__new
@@ -385,171 +364,163 @@ namespace Capabilities
 
 
 namespace ConstrainBooleanParameters
-
+  
   export
   new' :
        (exact : Optional Bool)
     -> (ideal : Optional Bool)
     -> JSIO ConstrainBooleanParameters
   new' a b = primJS $ ConstrainBooleanParameters.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ConstrainBooleanParameters
   new = primJS $ ConstrainBooleanParameters.prim__new undef undef
 
-
+  
   export
   exact :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainBooleanParameters (Types t)}
+       {auto _ : Cast t ConstrainBooleanParameters}
     -> t
     -> Attribute False Optional Bool
   exact v = fromUndefOrPrimNoDefault
               "ConstrainBooleanParameters.getexact"
               prim__exact
               prim__setExact
-              (v :> ConstrainBooleanParameters)
+              (cast {to = ConstrainBooleanParameters} v)
 
-
+  
   export
   ideal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainBooleanParameters (Types t)}
+       {auto _ : Cast t ConstrainBooleanParameters}
     -> t
     -> Attribute False Optional Bool
   ideal v = fromUndefOrPrimNoDefault
               "ConstrainBooleanParameters.getideal"
               prim__ideal
               prim__setIdeal
-              (v :> ConstrainBooleanParameters)
+              (cast {to = ConstrainBooleanParameters} v)
 
 
 
 namespace ConstrainDOMStringParameters
-
+  
   export
   new' :
        (exact : Optional (HSum [String, Array String]))
     -> (ideal : Optional (HSum [String, Array String]))
     -> JSIO ConstrainDOMStringParameters
   new' a b = primJS $ ConstrainDOMStringParameters.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ConstrainDOMStringParameters
   new = primJS $ ConstrainDOMStringParameters.prim__new undef undef
 
-
+  
   export
   exact :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainDOMStringParameters (Types t)}
+       {auto _ : Cast t ConstrainDOMStringParameters}
     -> t
     -> Attribute False Optional (Union2 String (Array String))
   exact v = fromUndefOrPrimNoDefault
               "ConstrainDOMStringParameters.getexact"
               prim__exact
               prim__setExact
-              (v :> ConstrainDOMStringParameters)
+              (cast {to = ConstrainDOMStringParameters} v)
 
-
+  
   export
   ideal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainDOMStringParameters (Types t)}
+       {auto _ : Cast t ConstrainDOMStringParameters}
     -> t
     -> Attribute False Optional (Union2 String (Array String))
   ideal v = fromUndefOrPrimNoDefault
               "ConstrainDOMStringParameters.getideal"
               prim__ideal
               prim__setIdeal
-              (v :> ConstrainDOMStringParameters)
+              (cast {to = ConstrainDOMStringParameters} v)
 
 
 
 namespace ConstrainDoubleRange
-
+  
   export
   new' :
        (exact : Optional Double)
     -> (ideal : Optional Double)
     -> JSIO ConstrainDoubleRange
   new' a b = primJS $ ConstrainDoubleRange.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ConstrainDoubleRange
   new = primJS $ ConstrainDoubleRange.prim__new undef undef
 
-
+  
   export
   exact :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainDoubleRange (Types t)}
+       {auto _ : Cast t ConstrainDoubleRange}
     -> t
     -> Attribute False Optional Double
   exact v = fromUndefOrPrimNoDefault
               "ConstrainDoubleRange.getexact"
               prim__exact
               prim__setExact
-              (v :> ConstrainDoubleRange)
+              (cast {to = ConstrainDoubleRange} v)
 
-
+  
   export
   ideal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainDoubleRange (Types t)}
+       {auto _ : Cast t ConstrainDoubleRange}
     -> t
     -> Attribute False Optional Double
   ideal v = fromUndefOrPrimNoDefault
               "ConstrainDoubleRange.getideal"
               prim__ideal
               prim__setIdeal
-              (v :> ConstrainDoubleRange)
+              (cast {to = ConstrainDoubleRange} v)
 
 
 
 namespace ConstrainULongRange
-
+  
   export
   new' :
        (exact : Optional Bits32)
     -> (ideal : Optional Bits32)
     -> JSIO ConstrainULongRange
   new' a b = primJS $ ConstrainULongRange.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ConstrainULongRange
   new = primJS $ ConstrainULongRange.prim__new undef undef
 
-
+  
   export
   exact :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainULongRange (Types t)}
+       {auto _ : Cast t ConstrainULongRange}
     -> t
     -> Attribute False Optional Bits32
   exact v = fromUndefOrPrimNoDefault
               "ConstrainULongRange.getexact"
               prim__exact
               prim__setExact
-              (v :> ConstrainULongRange)
+              (cast {to = ConstrainULongRange} v)
 
-
+  
   export
   ideal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ConstrainULongRange (Types t)}
+       {auto _ : Cast t ConstrainULongRange}
     -> t
     -> Attribute False Optional Bits32
   ideal v = fromUndefOrPrimNoDefault
               "ConstrainULongRange.getideal"
               prim__ideal
               prim__setIdeal
-              (v :> ConstrainULongRange)
+              (cast {to = ConstrainULongRange} v)
 
 
 
 namespace ConstraintSet
-
+  
   export
   new : JSIO ConstraintSet
   new = primJS $ ConstraintSet.prim__new
@@ -557,150 +528,130 @@ namespace ConstraintSet
 
 
 namespace Constraints
-
+  
   export
   new' : (advanced : Optional (Array ConstraintSet)) -> JSIO Constraints
   new' a = primJS $ Constraints.prim__new (toFFI a)
-
+  
   export
   new : JSIO Constraints
   new = primJS $ Constraints.prim__new undef
 
-
+  
   export
   advanced :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Constraints (Types t)}
+       {auto _ : Cast t Constraints}
     -> t
     -> Attribute False Optional (Array ConstraintSet)
   advanced v = fromUndefOrPrimNoDefault
                  "Constraints.getadvanced"
                  prim__advanced
                  prim__setAdvanced
-                 (v :> Constraints)
+                 (cast {to = Constraints} v)
 
 
 
 namespace DoubleRange
-
+  
   export
   new' : (max : Optional Double) -> (min : Optional Double) -> JSIO DoubleRange
   new' a b = primJS $ DoubleRange.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO DoubleRange
   new = primJS $ DoubleRange.prim__new undef undef
 
-
+  
   export
-  max :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DoubleRange (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  max : {auto _ : Cast t DoubleRange} -> t -> Attribute False Optional Double
   max v = fromUndefOrPrimNoDefault
             "DoubleRange.getmax"
             prim__max
             prim__setMax
-            (v :> DoubleRange)
+            (cast {to = DoubleRange} v)
 
-
+  
   export
-  min :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DoubleRange (Types t)}
-    -> t
-    -> Attribute False Optional Double
+  min : {auto _ : Cast t DoubleRange} -> t -> Attribute False Optional Double
   min v = fromUndefOrPrimNoDefault
             "DoubleRange.getmin"
             prim__min
             prim__setMin
-            (v :> DoubleRange)
+            (cast {to = DoubleRange} v)
 
 
 
 namespace MediaStreamConstraints
-
+  
   export
   new' :
        (video : Optional (HSum [Bool, MediaTrackConstraints]))
     -> (audio : Optional (HSum [Bool, MediaTrackConstraints]))
     -> JSIO MediaStreamConstraints
   new' a b = primJS $ MediaStreamConstraints.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO MediaStreamConstraints
   new = primJS $ MediaStreamConstraints.prim__new undef undef
 
-
+  
   export
   audio :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaStreamConstraints (Types t)}
+       {auto _ : Cast t MediaStreamConstraints}
     -> t
     -> Attribute False Optional (Union2 Boolean MediaTrackConstraints)
   audio v = fromUndefOrPrimNoDefault
               "MediaStreamConstraints.getaudio"
               prim__audio
               prim__setAudio
-              (v :> MediaStreamConstraints)
+              (cast {to = MediaStreamConstraints} v)
 
-
+  
   export
   video :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaStreamConstraints (Types t)}
+       {auto _ : Cast t MediaStreamConstraints}
     -> t
     -> Attribute False Optional (Union2 Boolean MediaTrackConstraints)
   video v = fromUndefOrPrimNoDefault
               "MediaStreamConstraints.getvideo"
               prim__video
               prim__setVideo
-              (v :> MediaStreamConstraints)
+              (cast {to = MediaStreamConstraints} v)
 
 
 
 namespace MediaStreamTrackEventInit
-
+  
   export
   new : (track : MediaStreamTrack) -> JSIO MediaStreamTrackEventInit
   new a = primJS $ MediaStreamTrackEventInit.prim__new a
 
-
+  
   export
   track :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaStreamTrackEventInit (Types t)}
+       {auto _ : Cast t MediaStreamTrackEventInit}
     -> t
     -> Attribute True Prelude.id MediaStreamTrack
   track v = fromPrim
               "MediaStreamTrackEventInit.gettrack"
               prim__track
               prim__setTrack
-              (v :> MediaStreamTrackEventInit)
+              (cast {to = MediaStreamTrackEventInit} v)
 
 
 
 namespace MediaTrackCapabilities
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : JSType t4}
-    -> {auto 0 _ : JSType t7}
-    -> {auto 0 _ : JSType t8}
-    -> {auto 0 _ : JSType t12}
-    -> {auto 0 _ : JSType t13}
-    -> {auto 0 _ : Elem ULongRange (Types t1)}
-    -> {auto 0 _ : Elem ULongRange (Types t2)}
-    -> {auto 0 _ : Elem DoubleRange (Types t3)}
-    -> {auto 0 _ : Elem DoubleRange (Types t4)}
-    -> {auto 0 _ : Elem ULongRange (Types t7)}
-    -> {auto 0 _ : Elem ULongRange (Types t8)}
-    -> {auto 0 _ : Elem DoubleRange (Types t12)}
-    -> {auto 0 _ : Elem ULongRange (Types t13)}
+       {auto _ : Cast t1 ULongRange}
+    -> {auto _ : Cast t2 ULongRange}
+    -> {auto _ : Cast t3 DoubleRange}
+    -> {auto _ : Cast t4 DoubleRange}
+    -> {auto _ : Cast t7 ULongRange}
+    -> {auto _ : Cast t8 ULongRange}
+    -> {auto _ : Cast t12 DoubleRange}
+    -> {auto _ : Cast t13 ULongRange}
     -> (width : Optional t1)
     -> (height : Optional t2)
     -> (aspectRatio : Optional t3)
@@ -734,7 +685,7 @@ namespace MediaTrackCapabilities
       (optUp m)
       (toFFI n)
       (toFFI o)
-
+  
   export
   new : JSIO MediaTrackCapabilities
   new = primJS $
@@ -755,205 +706,190 @@ namespace MediaTrackCapabilities
       undef
       undef
 
-
+  
   export
   aspectRatio :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional DoubleRange
   aspectRatio v = fromUndefOrPrimNoDefault
                     "MediaTrackCapabilities.getaspectRatio"
                     prim__aspectRatio
                     prim__setAspectRatio
-                    (v :> MediaTrackCapabilities)
+                    (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   autoGainControl :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional (Array Boolean)
   autoGainControl v = fromUndefOrPrimNoDefault
                         "MediaTrackCapabilities.getautoGainControl"
                         prim__autoGainControl
                         prim__setAutoGainControl
-                        (v :> MediaTrackCapabilities)
+                        (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   channelCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional ULongRange
   channelCount v = fromUndefOrPrimNoDefault
                      "MediaTrackCapabilities.getchannelCount"
                      prim__channelCount
                      prim__setChannelCount
-                     (v :> MediaTrackCapabilities)
+                     (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   deviceId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional String
   deviceId v = fromUndefOrPrimNoDefault
                  "MediaTrackCapabilities.getdeviceId"
                  prim__deviceId
                  prim__setDeviceId
-                 (v :> MediaTrackCapabilities)
+                 (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   echoCancellation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional (Array Boolean)
   echoCancellation v = fromUndefOrPrimNoDefault
                          "MediaTrackCapabilities.getechoCancellation"
                          prim__echoCancellation
                          prim__setEchoCancellation
-                         (v :> MediaTrackCapabilities)
+                         (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   facingMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional (Array String)
   facingMode v = fromUndefOrPrimNoDefault
                    "MediaTrackCapabilities.getfacingMode"
                    prim__facingMode
                    prim__setFacingMode
-                   (v :> MediaTrackCapabilities)
+                   (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   frameRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional DoubleRange
   frameRate v = fromUndefOrPrimNoDefault
                   "MediaTrackCapabilities.getframeRate"
                   prim__frameRate
                   prim__setFrameRate
-                  (v :> MediaTrackCapabilities)
+                  (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   groupId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional String
   groupId v = fromUndefOrPrimNoDefault
                 "MediaTrackCapabilities.getgroupId"
                 prim__groupId
                 prim__setGroupId
-                (v :> MediaTrackCapabilities)
+                (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   height :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional ULongRange
   height v = fromUndefOrPrimNoDefault
                "MediaTrackCapabilities.getheight"
                prim__height
                prim__setHeight
-               (v :> MediaTrackCapabilities)
+               (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   latency :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional DoubleRange
   latency v = fromUndefOrPrimNoDefault
                 "MediaTrackCapabilities.getlatency"
                 prim__latency
                 prim__setLatency
-                (v :> MediaTrackCapabilities)
+                (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   noiseSuppression :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional (Array Boolean)
   noiseSuppression v = fromUndefOrPrimNoDefault
                          "MediaTrackCapabilities.getnoiseSuppression"
                          prim__noiseSuppression
                          prim__setNoiseSuppression
-                         (v :> MediaTrackCapabilities)
+                         (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   resizeMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional (Array String)
   resizeMode v = fromUndefOrPrimNoDefault
                    "MediaTrackCapabilities.getresizeMode"
                    prim__resizeMode
                    prim__setResizeMode
-                   (v :> MediaTrackCapabilities)
+                   (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   sampleRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional ULongRange
   sampleRate v = fromUndefOrPrimNoDefault
                    "MediaTrackCapabilities.getsampleRate"
                    prim__sampleRate
                    prim__setSampleRate
-                   (v :> MediaTrackCapabilities)
+                   (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   sampleSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional ULongRange
   sampleSize v = fromUndefOrPrimNoDefault
                    "MediaTrackCapabilities.getsampleSize"
                    prim__sampleSize
                    prim__setSampleSize
-                   (v :> MediaTrackCapabilities)
+                   (cast {to = MediaTrackCapabilities} v)
 
-
+  
   export
   width :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackCapabilities (Types t)}
+       {auto _ : Cast t MediaTrackCapabilities}
     -> t
     -> Attribute False Optional ULongRange
   width v = fromUndefOrPrimNoDefault
               "MediaTrackCapabilities.getwidth"
               prim__width
               prim__setWidth
-              (v :> MediaTrackCapabilities)
+              (cast {to = MediaTrackCapabilities} v)
 
 
 
 namespace MediaTrackConstraintSet
-
+  
   export
   new' :
        (width : Optional (HSum [Bits32, ConstrainULongRange]))
@@ -996,7 +932,7 @@ namespace MediaTrackConstraintSet
       (toFFI m)
       (toFFI n)
       (toFFI o)
-
+  
   export
   new : JSIO MediaTrackConstraintSet
   new = primJS $
@@ -1017,50 +953,46 @@ namespace MediaTrackConstraintSet
       undef
       undef
 
-
+  
   export
   aspectRatio :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Double ConstrainDoubleRange)
   aspectRatio v = fromUndefOrPrimNoDefault
                     "MediaTrackConstraintSet.getaspectRatio"
                     prim__aspectRatio
                     prim__setAspectRatio
-                    (v :> MediaTrackConstraintSet)
+                    (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   autoGainControl :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Boolean ConstrainBooleanParameters)
   autoGainControl v = fromUndefOrPrimNoDefault
                         "MediaTrackConstraintSet.getautoGainControl"
                         prim__autoGainControl
                         prim__setAutoGainControl
-                        (v :> MediaTrackConstraintSet)
+                        (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   channelCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Bits32 ConstrainULongRange)
   channelCount v = fromUndefOrPrimNoDefault
                      "MediaTrackConstraintSet.getchannelCount"
                      prim__channelCount
                      prim__setChannelCount
-                     (v :> MediaTrackConstraintSet)
+                     (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   deviceId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union3
                                    String
@@ -1070,26 +1002,24 @@ namespace MediaTrackConstraintSet
                  "MediaTrackConstraintSet.getdeviceId"
                  prim__deviceId
                  prim__setDeviceId
-                 (v :> MediaTrackConstraintSet)
+                 (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   echoCancellation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Boolean ConstrainBooleanParameters)
   echoCancellation v = fromUndefOrPrimNoDefault
                          "MediaTrackConstraintSet.getechoCancellation"
                          prim__echoCancellation
                          prim__setEchoCancellation
-                         (v :> MediaTrackConstraintSet)
+                         (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   facingMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union3
                                    String
@@ -1099,26 +1029,24 @@ namespace MediaTrackConstraintSet
                    "MediaTrackConstraintSet.getfacingMode"
                    prim__facingMode
                    prim__setFacingMode
-                   (v :> MediaTrackConstraintSet)
+                   (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   frameRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Double ConstrainDoubleRange)
   frameRate v = fromUndefOrPrimNoDefault
                   "MediaTrackConstraintSet.getframeRate"
                   prim__frameRate
                   prim__setFrameRate
-                  (v :> MediaTrackConstraintSet)
+                  (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   groupId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union3
                                    String
@@ -1128,52 +1056,48 @@ namespace MediaTrackConstraintSet
                 "MediaTrackConstraintSet.getgroupId"
                 prim__groupId
                 prim__setGroupId
-                (v :> MediaTrackConstraintSet)
+                (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   height :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Bits32 ConstrainULongRange)
   height v = fromUndefOrPrimNoDefault
                "MediaTrackConstraintSet.getheight"
                prim__height
                prim__setHeight
-               (v :> MediaTrackConstraintSet)
+               (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   latency :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Double ConstrainDoubleRange)
   latency v = fromUndefOrPrimNoDefault
                 "MediaTrackConstraintSet.getlatency"
                 prim__latency
                 prim__setLatency
-                (v :> MediaTrackConstraintSet)
+                (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   noiseSuppression :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Boolean ConstrainBooleanParameters)
   noiseSuppression v = fromUndefOrPrimNoDefault
                          "MediaTrackConstraintSet.getnoiseSuppression"
                          prim__noiseSuppression
                          prim__setNoiseSuppression
-                         (v :> MediaTrackConstraintSet)
+                         (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   resizeMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union3
                                    String
@@ -1183,78 +1107,74 @@ namespace MediaTrackConstraintSet
                    "MediaTrackConstraintSet.getresizeMode"
                    prim__resizeMode
                    prim__setResizeMode
-                   (v :> MediaTrackConstraintSet)
+                   (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   sampleRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Bits32 ConstrainULongRange)
   sampleRate v = fromUndefOrPrimNoDefault
                    "MediaTrackConstraintSet.getsampleRate"
                    prim__sampleRate
                    prim__setSampleRate
-                   (v :> MediaTrackConstraintSet)
+                   (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   sampleSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Bits32 ConstrainULongRange)
   sampleSize v = fromUndefOrPrimNoDefault
                    "MediaTrackConstraintSet.getsampleSize"
                    prim__sampleSize
                    prim__setSampleSize
-                   (v :> MediaTrackConstraintSet)
+                   (cast {to = MediaTrackConstraintSet} v)
 
-
+  
   export
   width :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraintSet (Types t)}
+       {auto _ : Cast t MediaTrackConstraintSet}
     -> t
     -> Attribute False Optional (Union2 Bits32 ConstrainULongRange)
   width v = fromUndefOrPrimNoDefault
               "MediaTrackConstraintSet.getwidth"
               prim__width
               prim__setWidth
-              (v :> MediaTrackConstraintSet)
+              (cast {to = MediaTrackConstraintSet} v)
 
 
 
 namespace MediaTrackConstraints
-
+  
   export
   new' :
        (advanced : Optional (Array MediaTrackConstraintSet))
     -> JSIO MediaTrackConstraints
   new' a = primJS $ MediaTrackConstraints.prim__new (toFFI a)
-
+  
   export
   new : JSIO MediaTrackConstraints
   new = primJS $ MediaTrackConstraints.prim__new undef
 
-
+  
   export
   advanced :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackConstraints (Types t)}
+       {auto _ : Cast t MediaTrackConstraints}
     -> t
     -> Attribute False Optional (Array MediaTrackConstraintSet)
   advanced v = fromUndefOrPrimNoDefault
                  "MediaTrackConstraints.getadvanced"
                  prim__advanced
                  prim__setAdvanced
-                 (v :> MediaTrackConstraints)
+                 (cast {to = MediaTrackConstraints} v)
 
 
 
 namespace MediaTrackSettings
-
+  
   export
   new' :
        (width : Optional Int32)
@@ -1290,7 +1210,7 @@ namespace MediaTrackSettings
       (toFFI m)
       (toFFI n)
       (toFFI o)
-
+  
   export
   new : JSIO MediaTrackSettings
   new = primJS $
@@ -1311,205 +1231,190 @@ namespace MediaTrackSettings
       undef
       undef
 
-
+  
   export
   aspectRatio :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Double
   aspectRatio v = fromUndefOrPrimNoDefault
                     "MediaTrackSettings.getaspectRatio"
                     prim__aspectRatio
                     prim__setAspectRatio
-                    (v :> MediaTrackSettings)
+                    (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   autoGainControl :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Bool
   autoGainControl v = fromUndefOrPrimNoDefault
                         "MediaTrackSettings.getautoGainControl"
                         prim__autoGainControl
                         prim__setAutoGainControl
-                        (v :> MediaTrackSettings)
+                        (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   channelCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Int32
   channelCount v = fromUndefOrPrimNoDefault
                      "MediaTrackSettings.getchannelCount"
                      prim__channelCount
                      prim__setChannelCount
-                     (v :> MediaTrackSettings)
+                     (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   deviceId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional String
   deviceId v = fromUndefOrPrimNoDefault
                  "MediaTrackSettings.getdeviceId"
                  prim__deviceId
                  prim__setDeviceId
-                 (v :> MediaTrackSettings)
+                 (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   echoCancellation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Bool
   echoCancellation v = fromUndefOrPrimNoDefault
                          "MediaTrackSettings.getechoCancellation"
                          prim__echoCancellation
                          prim__setEchoCancellation
-                         (v :> MediaTrackSettings)
+                         (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   facingMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional String
   facingMode v = fromUndefOrPrimNoDefault
                    "MediaTrackSettings.getfacingMode"
                    prim__facingMode
                    prim__setFacingMode
-                   (v :> MediaTrackSettings)
+                   (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   frameRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Double
   frameRate v = fromUndefOrPrimNoDefault
                   "MediaTrackSettings.getframeRate"
                   prim__frameRate
                   prim__setFrameRate
-                  (v :> MediaTrackSettings)
+                  (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   groupId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional String
   groupId v = fromUndefOrPrimNoDefault
                 "MediaTrackSettings.getgroupId"
                 prim__groupId
                 prim__setGroupId
-                (v :> MediaTrackSettings)
+                (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   height :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Int32
   height v = fromUndefOrPrimNoDefault
                "MediaTrackSettings.getheight"
                prim__height
                prim__setHeight
-               (v :> MediaTrackSettings)
+               (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   latency :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Double
   latency v = fromUndefOrPrimNoDefault
                 "MediaTrackSettings.getlatency"
                 prim__latency
                 prim__setLatency
-                (v :> MediaTrackSettings)
+                (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   noiseSuppression :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Bool
   noiseSuppression v = fromUndefOrPrimNoDefault
                          "MediaTrackSettings.getnoiseSuppression"
                          prim__noiseSuppression
                          prim__setNoiseSuppression
-                         (v :> MediaTrackSettings)
+                         (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   resizeMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional String
   resizeMode v = fromUndefOrPrimNoDefault
                    "MediaTrackSettings.getresizeMode"
                    prim__resizeMode
                    prim__setResizeMode
-                   (v :> MediaTrackSettings)
+                   (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   sampleRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Int32
   sampleRate v = fromUndefOrPrimNoDefault
                    "MediaTrackSettings.getsampleRate"
                    prim__sampleRate
                    prim__setSampleRate
-                   (v :> MediaTrackSettings)
+                   (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   sampleSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Int32
   sampleSize v = fromUndefOrPrimNoDefault
                    "MediaTrackSettings.getsampleSize"
                    prim__sampleSize
                    prim__setSampleSize
-                   (v :> MediaTrackSettings)
+                   (cast {to = MediaTrackSettings} v)
 
-
+  
   export
   width :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSettings (Types t)}
+       {auto _ : Cast t MediaTrackSettings}
     -> t
     -> Attribute False Optional Int32
   width v = fromUndefOrPrimNoDefault
               "MediaTrackSettings.getwidth"
               prim__width
               prim__setWidth
-              (v :> MediaTrackSettings)
+              (cast {to = MediaTrackSettings} v)
 
 
 
 namespace MediaTrackSupportedConstraints
-
+  
   export
   new' :
        (width : Optional Bool)
@@ -1545,7 +1450,7 @@ namespace MediaTrackSupportedConstraints
       (toFFI m)
       (toFFI n)
       (toFFI o)
-
+  
   export
   new : JSIO MediaTrackSupportedConstraints
   new = primJS $
@@ -1566,11 +1471,10 @@ namespace MediaTrackSupportedConstraints
       undef
       undef
 
-
+  
   export
   aspectRatio :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   aspectRatio v = fromUndefOrPrim
@@ -1578,13 +1482,12 @@ namespace MediaTrackSupportedConstraints
                     prim__aspectRatio
                     prim__setAspectRatio
                     True
-                    (v :> MediaTrackSupportedConstraints)
+                    (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   autoGainControl :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   autoGainControl v = fromUndefOrPrim
@@ -1592,13 +1495,12 @@ namespace MediaTrackSupportedConstraints
                         prim__autoGainControl
                         prim__setAutoGainControl
                         True
-                        (v :> MediaTrackSupportedConstraints)
+                        (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   channelCount :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   channelCount v = fromUndefOrPrim
@@ -1606,13 +1508,12 @@ namespace MediaTrackSupportedConstraints
                      prim__channelCount
                      prim__setChannelCount
                      True
-                     (v :> MediaTrackSupportedConstraints)
+                     (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   deviceId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   deviceId v = fromUndefOrPrim
@@ -1620,13 +1521,12 @@ namespace MediaTrackSupportedConstraints
                  prim__deviceId
                  prim__setDeviceId
                  True
-                 (v :> MediaTrackSupportedConstraints)
+                 (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   echoCancellation :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   echoCancellation v = fromUndefOrPrim
@@ -1634,13 +1534,12 @@ namespace MediaTrackSupportedConstraints
                          prim__echoCancellation
                          prim__setEchoCancellation
                          True
-                         (v :> MediaTrackSupportedConstraints)
+                         (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   facingMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   facingMode v = fromUndefOrPrim
@@ -1648,13 +1547,12 @@ namespace MediaTrackSupportedConstraints
                    prim__facingMode
                    prim__setFacingMode
                    True
-                   (v :> MediaTrackSupportedConstraints)
+                   (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   frameRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   frameRate v = fromUndefOrPrim
@@ -1662,13 +1560,12 @@ namespace MediaTrackSupportedConstraints
                   prim__frameRate
                   prim__setFrameRate
                   True
-                  (v :> MediaTrackSupportedConstraints)
+                  (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   groupId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   groupId v = fromUndefOrPrim
@@ -1676,13 +1573,12 @@ namespace MediaTrackSupportedConstraints
                 prim__groupId
                 prim__setGroupId
                 True
-                (v :> MediaTrackSupportedConstraints)
+                (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   height :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   height v = fromUndefOrPrim
@@ -1690,13 +1586,12 @@ namespace MediaTrackSupportedConstraints
                prim__height
                prim__setHeight
                True
-               (v :> MediaTrackSupportedConstraints)
+               (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   latency :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   latency v = fromUndefOrPrim
@@ -1704,13 +1599,12 @@ namespace MediaTrackSupportedConstraints
                 prim__latency
                 prim__setLatency
                 True
-                (v :> MediaTrackSupportedConstraints)
+                (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   noiseSuppression :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   noiseSuppression v = fromUndefOrPrim
@@ -1718,13 +1612,12 @@ namespace MediaTrackSupportedConstraints
                          prim__noiseSuppression
                          prim__setNoiseSuppression
                          True
-                         (v :> MediaTrackSupportedConstraints)
+                         (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   resizeMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   resizeMode v = fromUndefOrPrim
@@ -1732,13 +1625,12 @@ namespace MediaTrackSupportedConstraints
                    prim__resizeMode
                    prim__setResizeMode
                    True
-                   (v :> MediaTrackSupportedConstraints)
+                   (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   sampleRate :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   sampleRate v = fromUndefOrPrim
@@ -1746,13 +1638,12 @@ namespace MediaTrackSupportedConstraints
                    prim__sampleRate
                    prim__setSampleRate
                    True
-                   (v :> MediaTrackSupportedConstraints)
+                   (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   sampleSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   sampleSize v = fromUndefOrPrim
@@ -1760,13 +1651,12 @@ namespace MediaTrackSupportedConstraints
                    prim__sampleSize
                    prim__setSampleSize
                    True
-                   (v :> MediaTrackSupportedConstraints)
+                   (cast {to = MediaTrackSupportedConstraints} v)
 
-
+  
   export
   width :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MediaTrackSupportedConstraints (Types t)}
+       {auto _ : Cast t MediaTrackSupportedConstraints}
     -> t
     -> Attribute True Optional Bool
   width v = fromUndefOrPrim
@@ -1774,12 +1664,12 @@ namespace MediaTrackSupportedConstraints
               prim__width
               prim__setWidth
               True
-              (v :> MediaTrackSupportedConstraints)
+              (cast {to = MediaTrackSupportedConstraints} v)
 
 
 
 namespace Settings
-
+  
   export
   new : JSIO Settings
   new = primJS $ Settings.prim__new
@@ -1787,40 +1677,32 @@ namespace Settings
 
 
 namespace ULongRange
-
+  
   export
   new' : (max : Optional Bits32) -> (min : Optional Bits32) -> JSIO ULongRange
   new' a b = primJS $ ULongRange.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ULongRange
   new = primJS $ ULongRange.prim__new undef undef
 
-
+  
   export
-  max :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ULongRange (Types t)}
-    -> t
-    -> Attribute False Optional Bits32
+  max : {auto _ : Cast t ULongRange} -> t -> Attribute False Optional Bits32
   max v = fromUndefOrPrimNoDefault
             "ULongRange.getmax"
             prim__max
             prim__setMax
-            (v :> ULongRange)
+            (cast {to = ULongRange} v)
 
-
+  
   export
-  min :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ULongRange (Types t)}
-    -> t
-    -> Attribute False Optional Bits32
+  min : {auto _ : Cast t ULongRange} -> t -> Attribute False Optional Bits32
   min v = fromUndefOrPrimNoDefault
             "ULongRange.getmin"
             prim__min
             prim__setMin
-            (v :> ULongRange)
+            (cast {to = ULongRange} v)
 
 
 
@@ -1830,7 +1712,7 @@ namespace ULongRange
 --------------------------------------------------------------------------------
 
 namespace NavigatorUserMediaErrorCallback
-
+  
   export
   toNavigatorUserMediaErrorCallback :
        (DOMException -> IO ())
@@ -1840,9 +1722,11 @@ namespace NavigatorUserMediaErrorCallback
 
 
 namespace NavigatorUserMediaSuccessCallback
-
+  
   export
   toNavigatorUserMediaSuccessCallback :
        (MediaStream -> IO ())
     -> JSIO NavigatorUserMediaSuccessCallback
   toNavigatorUserMediaSuccessCallback cb = primJS $ prim__toNavigatorUserMediaSuccessCallback cb
+
+

--- a/src/Web/Raw/Permissions.idr
+++ b/src/Web/Raw/Permissions.idr
@@ -12,7 +12,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace PermissionStatus
-
+  
   export
   onchange : PermissionStatus -> Attribute False Maybe EventHandlerNonNull
   onchange v = fromNullablePrim
@@ -21,7 +21,7 @@ namespace PermissionStatus
                  prim__setOnchange
                  v
 
-
+  
   export
   state : (obj : PermissionStatus) -> JSIO PermissionState
   state a = tryJS "PermissionStatus.state" $ PermissionStatus.prim__state a
@@ -29,15 +29,14 @@ namespace PermissionStatus
 
 
 namespace Permissions
-
+  
   export
   query :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Object (Types t2)}
+       {auto _ : Cast t2 Object}
     -> (obj : Permissions)
     -> (permissionDesc : t2)
     -> JSIO (Promise PermissionStatus)
-  query a b = primJS $ Permissions.prim__query a (up b)
+  query a b = primJS $ Permissions.prim__query a (cast b)
 
 
 
@@ -48,20 +47,19 @@ namespace Permissions
 --------------------------------------------------------------------------------
 
 namespace CameraDevicePermissionDescriptor
-
+  
   export
   new' : (panTiltZoom : Optional Bool) -> JSIO CameraDevicePermissionDescriptor
   new' a = primJS $ CameraDevicePermissionDescriptor.prim__new (toFFI a)
-
+  
   export
   new : JSIO CameraDevicePermissionDescriptor
   new = primJS $ CameraDevicePermissionDescriptor.prim__new undef
 
-
+  
   export
   panTiltZoom :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CameraDevicePermissionDescriptor (Types t)}
+       {auto _ : Cast t CameraDevicePermissionDescriptor}
     -> t
     -> Attribute True Optional Bool
   panTiltZoom v = fromUndefOrPrim
@@ -69,50 +67,48 @@ namespace CameraDevicePermissionDescriptor
                     prim__panTiltZoom
                     prim__setPanTiltZoom
                     False
-                    (v :> CameraDevicePermissionDescriptor)
+                    (cast {to = CameraDevicePermissionDescriptor} v)
 
 
 
 namespace DevicePermissionDescriptor
-
+  
   export
   new' : (deviceId : Optional String) -> JSIO DevicePermissionDescriptor
   new' a = primJS $ DevicePermissionDescriptor.prim__new (toFFI a)
-
+  
   export
   new : JSIO DevicePermissionDescriptor
   new = primJS $ DevicePermissionDescriptor.prim__new undef
 
-
+  
   export
   deviceId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem DevicePermissionDescriptor (Types t)}
+       {auto _ : Cast t DevicePermissionDescriptor}
     -> t
     -> Attribute False Optional String
   deviceId v = fromUndefOrPrimNoDefault
                  "DevicePermissionDescriptor.getdeviceId"
                  prim__deviceId
                  prim__setDeviceId
-                 (v :> DevicePermissionDescriptor)
+                 (cast {to = DevicePermissionDescriptor} v)
 
 
 
 namespace MidiPermissionDescriptor
-
+  
   export
   new' : (sysex : Optional Bool) -> JSIO MidiPermissionDescriptor
   new' a = primJS $ MidiPermissionDescriptor.prim__new (toFFI a)
-
+  
   export
   new : JSIO MidiPermissionDescriptor
   new = primJS $ MidiPermissionDescriptor.prim__new undef
 
-
+  
   export
   sysex :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MidiPermissionDescriptor (Types t)}
+       {auto _ : Cast t MidiPermissionDescriptor}
     -> t
     -> Attribute True Optional Bool
   sysex v = fromUndefOrPrim
@@ -120,71 +116,66 @@ namespace MidiPermissionDescriptor
               prim__sysex
               prim__setSysex
               False
-              (v :> MidiPermissionDescriptor)
+              (cast {to = MidiPermissionDescriptor} v)
 
 
 
 namespace PermissionDescriptor
-
+  
   export
   new : (name : PermissionName) -> JSIO PermissionDescriptor
   new a = primJS $ PermissionDescriptor.prim__new (toFFI a)
 
-
+  
   export
   name :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PermissionDescriptor (Types t)}
+       {auto _ : Cast t PermissionDescriptor}
     -> t
     -> Attribute True Prelude.id PermissionName
   name v = fromPrim
              "PermissionDescriptor.getname"
              prim__name
              prim__setName
-             (v :> PermissionDescriptor)
+             (cast {to = PermissionDescriptor} v)
 
 
 
 namespace PermissionSetParameters
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem PermissionDescriptor (Types t1)}
+       {auto _ : Cast t1 PermissionDescriptor}
     -> (descriptor : t1)
     -> (state : PermissionState)
     -> (oneRealm : Optional Bool)
     -> JSIO PermissionSetParameters
   new' a b c = primJS $
-    PermissionSetParameters.prim__new (up a) (toFFI b) (toFFI c)
-
+    PermissionSetParameters.prim__new (cast a) (toFFI b) (toFFI c)
+  
   export
   new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem PermissionDescriptor (Types t1)}
+       {auto _ : Cast t1 PermissionDescriptor}
     -> (descriptor : t1)
     -> (state : PermissionState)
     -> JSIO PermissionSetParameters
-  new a b = primJS $ PermissionSetParameters.prim__new (up a) (toFFI b) undef
+  new a b = primJS $ PermissionSetParameters.prim__new (cast a) (toFFI b) undef
 
-
+  
   export
   descriptor :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PermissionSetParameters (Types t)}
+       {auto _ : Cast t PermissionSetParameters}
     -> t
     -> Attribute True Prelude.id PermissionDescriptor
   descriptor v = fromPrim
                    "PermissionSetParameters.getdescriptor"
                    prim__descriptor
                    prim__setDescriptor
-                   (v :> PermissionSetParameters)
+                   (cast {to = PermissionSetParameters} v)
 
-
+  
   export
   oneRealm :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PermissionSetParameters (Types t)}
+       {auto _ : Cast t PermissionSetParameters}
     -> t
     -> Attribute True Optional Bool
   oneRealm v = fromUndefOrPrim
@@ -192,38 +183,36 @@ namespace PermissionSetParameters
                  prim__oneRealm
                  prim__setOneRealm
                  False
-                 (v :> PermissionSetParameters)
+                 (cast {to = PermissionSetParameters} v)
 
-
+  
   export
   state :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PermissionSetParameters (Types t)}
+       {auto _ : Cast t PermissionSetParameters}
     -> t
     -> Attribute True Prelude.id PermissionState
   state v = fromPrim
               "PermissionSetParameters.getstate"
               prim__state
               prim__setState
-              (v :> PermissionSetParameters)
+              (cast {to = PermissionSetParameters} v)
 
 
 
 namespace PushPermissionDescriptor
-
+  
   export
   new' : (userVisibleOnly : Optional Bool) -> JSIO PushPermissionDescriptor
   new' a = primJS $ PushPermissionDescriptor.prim__new (toFFI a)
-
+  
   export
   new : JSIO PushPermissionDescriptor
   new = primJS $ PushPermissionDescriptor.prim__new undef
 
-
+  
   export
   userVisibleOnly :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem PushPermissionDescriptor (Types t)}
+       {auto _ : Cast t PushPermissionDescriptor}
     -> t
     -> Attribute True Optional Bool
   userVisibleOnly v = fromUndefOrPrim
@@ -231,4 +220,7 @@ namespace PushPermissionDescriptor
                         prim__userVisibleOnly
                         prim__setUserVisibleOnly
                         False
-                        (v :> PushPermissionDescriptor)
+                        (cast {to = PushPermissionDescriptor} v)
+
+
+

--- a/src/Web/Raw/Serviceworker.idr
+++ b/src/Web/Raw/Serviceworker.idr
@@ -12,7 +12,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace Cache
-
+  
   export
   addAll :
        (obj : Cache)
@@ -20,7 +20,7 @@ namespace Cache
     -> JSIO (Promise Undefined)
   addAll a b = primJS $ Cache.prim__addAll a b
 
-
+  
   export
   add :
        (obj : Cache)
@@ -28,17 +28,16 @@ namespace Cache
     -> JSIO (Promise Undefined)
   add a b = primJS $ Cache.prim__add a (toFFI b)
 
-
+  
   export
   delete' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t3)}
+       {auto _ : Cast t3 CacheQueryOptions}
     -> (obj : Cache)
     -> (request : HSum [Request, String])
     -> (options : Optional t3)
     -> JSIO (Promise Boolean)
   delete' a b c = primJS $ Cache.prim__delete a (toFFI b) (optUp c)
-
+  
   export
   delete :
        (obj : Cache)
@@ -46,47 +45,44 @@ namespace Cache
     -> JSIO (Promise Boolean)
   delete a b = primJS $ Cache.prim__delete a (toFFI b) undef
 
-
+  
   export
   keys' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t3)}
+       {auto _ : Cast t3 CacheQueryOptions}
     -> (obj : Cache)
     -> (request : Optional (HSum [Request, String]))
     -> (options : Optional t3)
     -> JSIO (Promise (Array Request))
   keys' a b c = primJS $ Cache.prim__keys a (toFFI b) (optUp c)
-
+  
   export
   keys : (obj : Cache) -> JSIO (Promise (Array Request))
   keys a = primJS $ Cache.prim__keys a undef undef
 
-
+  
   export
   matchAll' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t3)}
+       {auto _ : Cast t3 CacheQueryOptions}
     -> (obj : Cache)
     -> (request : Optional (HSum [Request, String]))
     -> (options : Optional t3)
     -> JSIO (Promise (Array Response))
   matchAll' a b c = primJS $ Cache.prim__matchAll a (toFFI b) (optUp c)
-
+  
   export
   matchAll : (obj : Cache) -> JSIO (Promise (Array Response))
   matchAll a = primJS $ Cache.prim__matchAll a undef undef
 
-
+  
   export
   match' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t3)}
+       {auto _ : Cast t3 CacheQueryOptions}
     -> (obj : Cache)
     -> (request : HSum [Request, String])
     -> (options : Optional t3)
     -> JSIO (Promise (Union2 Response Undefined))
   match' a b c = primJS $ Cache.prim__match a (toFFI b) (optUp c)
-
+  
   export
   match :
        (obj : Cache)
@@ -94,7 +90,7 @@ namespace Cache
     -> JSIO (Promise (Union2 Response Undefined))
   match a b = primJS $ Cache.prim__match a (toFFI b) undef
 
-
+  
   export
   put :
        (obj : Cache)
@@ -106,7 +102,7 @@ namespace Cache
 
 
 namespace CacheStorage
-
+  
   export
   delete :
        (obj : CacheStorage)
@@ -114,27 +110,26 @@ namespace CacheStorage
     -> JSIO (Promise Boolean)
   delete a b = primJS $ CacheStorage.prim__delete a b
 
-
+  
   export
   has : (obj : CacheStorage) -> (cacheName : String) -> JSIO (Promise Boolean)
   has a b = primJS $ CacheStorage.prim__has a b
 
-
+  
   export
   keys : (obj : CacheStorage) -> JSIO (Promise (Array String))
   keys a = primJS $ CacheStorage.prim__keys a
 
-
+  
   export
   match' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem MultiCacheQueryOptions (Types t3)}
+       {auto _ : Cast t3 MultiCacheQueryOptions}
     -> (obj : CacheStorage)
     -> (request : HSum [Request, String])
     -> (options : Optional t3)
     -> JSIO (Promise (Union2 Response Undefined))
   match' a b c = primJS $ CacheStorage.prim__match a (toFFI b) (optUp c)
-
+  
   export
   match :
        (obj : CacheStorage)
@@ -142,7 +137,7 @@ namespace CacheStorage
     -> JSIO (Promise (Union2 Response Undefined))
   match a b = primJS $ CacheStorage.prim__match a (toFFI b) undef
 
-
+  
   export
   open_ : (obj : CacheStorage) -> (cacheName : String) -> JSIO (Promise Cache)
   open_ a b = primJS $ CacheStorage.prim__open a b
@@ -150,85 +145,65 @@ namespace CacheStorage
 
 
 namespace Client
-
+  
   export
-  frameType :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
-    -> (obj : t1)
-    -> JSIO FrameType
-  frameType a = tryJS "Client.frameType" $ Client.prim__frameType (up a)
+  frameType : {auto _ : Cast t1 Client} -> (obj : t1) -> JSIO FrameType
+  frameType a = tryJS "Client.frameType" $ Client.prim__frameType (cast a)
 
-
+  
   export
-  id :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  id a = primJS $ Client.prim__id (up a)
+  id : {auto _ : Cast t1 Client} -> (obj : t1) -> JSIO String
+  id a = primJS $ Client.prim__id (cast a)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
-    -> (obj : t1)
-    -> JSIO ClientType
-  type a = tryJS "Client.type" $ Client.prim__type (up a)
+  type : {auto _ : Cast t1 Client} -> (obj : t1) -> JSIO ClientType
+  type a = tryJS "Client.type" $ Client.prim__type (cast a)
 
-
+  
   export
-  url :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  url a = primJS $ Client.prim__url (up a)
+  url : {auto _ : Cast t1 Client} -> (obj : t1) -> JSIO String
+  url a = primJS $ Client.prim__url (cast a)
 
-
+  
   export
   postMessage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
+       {auto _ : Cast t1 Client}
     -> (obj : t1)
     -> (message : Any)
     -> (transfer : Array Object)
     -> JSIO ()
-  postMessage a b c = primJS $ Client.prim__postMessage (up a) (toFFI b) c
+  postMessage a b c = primJS $ Client.prim__postMessage (cast a) (toFFI b) c
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Client (Types t1)}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t3)}
+       {auto _ : Cast t1 Client}
+    -> {auto _ : Cast t3 PostMessageOptions}
     -> (obj : t1)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $
-    Client.prim__postMessage1 (up a) (toFFI b) (optUp c)
-
+    Client.prim__postMessage1 (cast a) (toFFI b) (optUp c)
+  
   export
   postMessage1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem Client (Types t1)}
+       {auto _ : Cast t1 Client}
     -> (obj : t1)
     -> (message : Any)
     -> JSIO ()
-  postMessage1 a b = primJS $ Client.prim__postMessage1 (up a) (toFFI b) undef
+  postMessage1 a b = primJS $ Client.prim__postMessage1 (cast a) (toFFI b) undef
 
 
 
 namespace Clients
-
+  
   export
   claim : (obj : Clients) -> JSIO (Promise Undefined)
   claim a = primJS $ Clients.prim__claim a
 
-
+  
   export
   get :
        (obj : Clients)
@@ -236,21 +211,20 @@ namespace Clients
     -> JSIO (Promise (Union2 Client Undefined))
   get a b = primJS $ Clients.prim__get a b
 
-
+  
   export
   matchAll' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ClientQueryOptions (Types t2)}
+       {auto _ : Cast t2 ClientQueryOptions}
     -> (obj : Clients)
     -> (options : Optional t2)
     -> JSIO (Promise (Array Client))
   matchAll' a b = primJS $ Clients.prim__matchAll a (optUp b)
-
+  
   export
   matchAll : (obj : Clients) -> JSIO (Promise (Array Client))
   matchAll a = primJS $ Clients.prim__matchAll a undef
 
-
+  
   export
   openWindow :
        (obj : Clients)
@@ -261,69 +235,66 @@ namespace Clients
 
 
 namespace ExtendableEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ExtendableEventInit (Types t2)}
+       {auto _ : Cast t2 ExtendableEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO ExtendableEvent
   new' a b = primJS $ ExtendableEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO ExtendableEvent
   new a = primJS $ ExtendableEvent.prim__new a undef
 
-
+  
   export
   waitUntil :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ExtendableEvent (Types t1)}
+       {auto _ : Cast t1 ExtendableEvent}
     -> (obj : t1)
     -> (f : Promise AnyPtr)
     -> JSIO ()
-  waitUntil a b = primJS $ ExtendableEvent.prim__waitUntil (up a) b
+  waitUntil a b = primJS $ ExtendableEvent.prim__waitUntil (cast a) b
 
 
 
 namespace ExtendableMessageEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t2)}
+       {auto _ : Cast t2 ExtendableMessageEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO ExtendableMessageEvent
   new' a b = primJS $ ExtendableMessageEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO ExtendableMessageEvent
   new a = primJS $ ExtendableMessageEvent.prim__new a undef
 
-
+  
   export
   data_ : (obj : ExtendableMessageEvent) -> JSIO Any
   data_ a = tryJS "ExtendableMessageEvent.data_" $
     ExtendableMessageEvent.prim__data a
 
-
+  
   export
   lastEventId : (obj : ExtendableMessageEvent) -> JSIO String
   lastEventId a = primJS $ ExtendableMessageEvent.prim__lastEventId a
 
-
+  
   export
   origin : (obj : ExtendableMessageEvent) -> JSIO String
   origin a = primJS $ ExtendableMessageEvent.prim__origin a
 
-
+  
   export
   ports : (obj : ExtendableMessageEvent) -> JSIO (Array MessagePort)
   ports a = primJS $ ExtendableMessageEvent.prim__ports a
 
-
+  
   export
   source :
        (obj : ExtendableMessageEvent)
@@ -334,47 +305,46 @@ namespace ExtendableMessageEvent
 
 
 namespace FetchEvent
-
+  
   export
   new :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem FetchEventInit (Types t2)}
+       {auto _ : Cast t2 FetchEventInit}
     -> (type : String)
     -> (eventInitDict : t2)
     -> JSIO FetchEvent
-  new a b = primJS $ FetchEvent.prim__new a (up b)
+  new a b = primJS $ FetchEvent.prim__new a (cast b)
 
-
+  
   export
   clientId : (obj : FetchEvent) -> JSIO String
   clientId a = primJS $ FetchEvent.prim__clientId a
 
-
+  
   export
   handled : (obj : FetchEvent) -> JSIO (Promise Undefined)
   handled a = primJS $ FetchEvent.prim__handled a
 
-
+  
   export
   preloadResponse : (obj : FetchEvent) -> JSIO (Promise AnyPtr)
   preloadResponse a = primJS $ FetchEvent.prim__preloadResponse a
 
-
+  
   export
   replacesClientId : (obj : FetchEvent) -> JSIO String
   replacesClientId a = primJS $ FetchEvent.prim__replacesClientId a
 
-
+  
   export
   request : (obj : FetchEvent) -> JSIO Request
   request a = primJS $ FetchEvent.prim__request a
 
-
+  
   export
   resultingClientId : (obj : FetchEvent) -> JSIO String
   resultingClientId a = primJS $ FetchEvent.prim__resultingClientId a
 
-
+  
   export
   respondWith : (obj : FetchEvent) -> (r : Promise Response) -> JSIO ()
   respondWith a b = primJS $ FetchEvent.prim__respondWith a b
@@ -382,24 +352,24 @@ namespace FetchEvent
 
 
 namespace NavigationPreloadManager
-
+  
   export
   disable : (obj : NavigationPreloadManager) -> JSIO (Promise Undefined)
   disable a = primJS $ NavigationPreloadManager.prim__disable a
 
-
+  
   export
   enable : (obj : NavigationPreloadManager) -> JSIO (Promise Undefined)
   enable a = primJS $ NavigationPreloadManager.prim__enable a
 
-
+  
   export
   getState :
        (obj : NavigationPreloadManager)
     -> JSIO (Promise NavigationPreloadState)
   getState a = primJS $ NavigationPreloadManager.prim__getState a
 
-
+  
   export
   setHeaderValue :
        (obj : NavigationPreloadManager)
@@ -411,7 +381,7 @@ namespace NavigationPreloadManager
 
 
 namespace ServiceWorker
-
+  
   export
   onstatechange : ServiceWorker -> Attribute False Maybe EventHandlerNonNull
   onstatechange v = fromNullablePrim
@@ -420,17 +390,17 @@ namespace ServiceWorker
                       prim__setOnstatechange
                       v
 
-
+  
   export
   scriptURL : (obj : ServiceWorker) -> JSIO String
   scriptURL a = primJS $ ServiceWorker.prim__scriptURL a
 
-
+  
   export
   state : (obj : ServiceWorker) -> JSIO ServiceWorkerState
   state a = tryJS "ServiceWorker.state" $ ServiceWorker.prim__state a
 
-
+  
   export
   postMessage :
        (obj : ServiceWorker)
@@ -439,18 +409,17 @@ namespace ServiceWorker
     -> JSIO ()
   postMessage a b c = primJS $ ServiceWorker.prim__postMessage a (toFFI b) c
 
-
+  
   export
   postMessage1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem PostMessageOptions (Types t3)}
+       {auto _ : Cast t3 PostMessageOptions}
     -> (obj : ServiceWorker)
     -> (message : Any)
     -> (options : Optional t3)
     -> JSIO ()
   postMessage1' a b c = primJS $
     ServiceWorker.prim__postMessage1 a (toFFI b) (optUp c)
-
+  
   export
   postMessage1 : (obj : ServiceWorker) -> (message : Any) -> JSIO ()
   postMessage1 a b = primJS $ ServiceWorker.prim__postMessage1 a (toFFI b) undef
@@ -458,13 +427,13 @@ namespace ServiceWorker
 
 
 namespace ServiceWorkerContainer
-
+  
   export
   controller : (obj : ServiceWorkerContainer) -> JSIO (Maybe ServiceWorker)
   controller a = tryJS "ServiceWorkerContainer.controller" $
     ServiceWorkerContainer.prim__controller a
 
-
+  
   export
   oncontrollerchange :
        ServiceWorkerContainer
@@ -475,7 +444,7 @@ namespace ServiceWorkerContainer
                            prim__setOncontrollerchange
                            v
 
-
+  
   export
   onmessage :
        ServiceWorkerContainer
@@ -486,7 +455,7 @@ namespace ServiceWorkerContainer
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror :
        ServiceWorkerContainer
@@ -497,14 +466,14 @@ namespace ServiceWorkerContainer
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   ready :
        (obj : ServiceWorkerContainer)
     -> JSIO (Promise ServiceWorkerRegistration)
   ready a = primJS $ ServiceWorkerContainer.prim__ready a
 
-
+  
   export
   getRegistration' :
        (obj : ServiceWorkerContainer)
@@ -512,7 +481,7 @@ namespace ServiceWorkerContainer
     -> JSIO (Promise (Union2 ServiceWorkerRegistration Undefined))
   getRegistration' a b = primJS $
     ServiceWorkerContainer.prim__getRegistration a (toFFI b)
-
+  
   export
   getRegistration :
        (obj : ServiceWorkerContainer)
@@ -520,24 +489,23 @@ namespace ServiceWorkerContainer
   getRegistration a = primJS $
     ServiceWorkerContainer.prim__getRegistration a undef
 
-
+  
   export
   getRegistrations :
        (obj : ServiceWorkerContainer)
     -> JSIO (Promise (Array ServiceWorkerRegistration))
   getRegistrations a = primJS $ ServiceWorkerContainer.prim__getRegistrations a
 
-
+  
   export
   register' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem RegistrationOptions (Types t3)}
+       {auto _ : Cast t3 RegistrationOptions}
     -> (obj : ServiceWorkerContainer)
     -> (scriptURL : String)
     -> (options : Optional t3)
     -> JSIO (Promise ServiceWorkerRegistration)
   register' a b c = primJS $ ServiceWorkerContainer.prim__register a b (optUp c)
-
+  
   export
   register :
        (obj : ServiceWorkerContainer)
@@ -545,7 +513,7 @@ namespace ServiceWorkerContainer
     -> JSIO (Promise ServiceWorkerRegistration)
   register a b = primJS $ ServiceWorkerContainer.prim__register a b undef
 
-
+  
   export
   startMessages : (obj : ServiceWorkerContainer) -> JSIO ()
   startMessages a = primJS $ ServiceWorkerContainer.prim__startMessages a
@@ -553,12 +521,12 @@ namespace ServiceWorkerContainer
 
 
 namespace ServiceWorkerGlobalScope
-
+  
   export
   clients : (obj : ServiceWorkerGlobalScope) -> JSIO Clients
   clients a = primJS $ ServiceWorkerGlobalScope.prim__clients a
 
-
+  
   export
   onactivate :
        ServiceWorkerGlobalScope
@@ -569,7 +537,7 @@ namespace ServiceWorkerGlobalScope
                    prim__setOnactivate
                    v
 
-
+  
   export
   onfetch :
        ServiceWorkerGlobalScope
@@ -580,7 +548,7 @@ namespace ServiceWorkerGlobalScope
                 prim__setOnfetch
                 v
 
-
+  
   export
   oninstall :
        ServiceWorkerGlobalScope
@@ -591,7 +559,7 @@ namespace ServiceWorkerGlobalScope
                   prim__setOninstall
                   v
 
-
+  
   export
   onmessage :
        ServiceWorkerGlobalScope
@@ -602,7 +570,7 @@ namespace ServiceWorkerGlobalScope
                   prim__setOnmessage
                   v
 
-
+  
   export
   onmessageerror :
        ServiceWorkerGlobalScope
@@ -613,19 +581,19 @@ namespace ServiceWorkerGlobalScope
                        prim__setOnmessageerror
                        v
 
-
+  
   export
   registration :
        (obj : ServiceWorkerGlobalScope)
     -> JSIO ServiceWorkerRegistration
   registration a = primJS $ ServiceWorkerGlobalScope.prim__registration a
 
-
+  
   export
   serviceWorker : (obj : ServiceWorkerGlobalScope) -> JSIO ServiceWorker
   serviceWorker a = primJS $ ServiceWorkerGlobalScope.prim__serviceWorker a
 
-
+  
   export
   skipWaiting : (obj : ServiceWorkerGlobalScope) -> JSIO (Promise Undefined)
   skipWaiting a = primJS $ ServiceWorkerGlobalScope.prim__skipWaiting a
@@ -633,19 +601,19 @@ namespace ServiceWorkerGlobalScope
 
 
 namespace ServiceWorkerRegistration
-
+  
   export
   active : (obj : ServiceWorkerRegistration) -> JSIO (Maybe ServiceWorker)
   active a = tryJS "ServiceWorkerRegistration.active" $
     ServiceWorkerRegistration.prim__active a
 
-
+  
   export
   installing : (obj : ServiceWorkerRegistration) -> JSIO (Maybe ServiceWorker)
   installing a = tryJS "ServiceWorkerRegistration.installing" $
     ServiceWorkerRegistration.prim__installing a
 
-
+  
   export
   navigationPreload :
        (obj : ServiceWorkerRegistration)
@@ -653,7 +621,7 @@ namespace ServiceWorkerRegistration
   navigationPreload a = primJS $
     ServiceWorkerRegistration.prim__navigationPreload a
 
-
+  
   export
   onupdatefound :
        ServiceWorkerRegistration
@@ -664,12 +632,12 @@ namespace ServiceWorkerRegistration
                       prim__setOnupdatefound
                       v
 
-
+  
   export
   scope : (obj : ServiceWorkerRegistration) -> JSIO String
   scope a = primJS $ ServiceWorkerRegistration.prim__scope a
 
-
+  
   export
   updateViaCache :
        (obj : ServiceWorkerRegistration)
@@ -677,18 +645,18 @@ namespace ServiceWorkerRegistration
   updateViaCache a = tryJS "ServiceWorkerRegistration.updateViaCache" $
     ServiceWorkerRegistration.prim__updateViaCache a
 
-
+  
   export
   waiting : (obj : ServiceWorkerRegistration) -> JSIO (Maybe ServiceWorker)
   waiting a = tryJS "ServiceWorkerRegistration.waiting" $
     ServiceWorkerRegistration.prim__waiting a
 
-
+  
   export
   unregister : (obj : ServiceWorkerRegistration) -> JSIO (Promise Boolean)
   unregister a = primJS $ ServiceWorkerRegistration.prim__unregister a
 
-
+  
   export
   update : (obj : ServiceWorkerRegistration) -> JSIO (Promise Undefined)
   update a = primJS $ ServiceWorkerRegistration.prim__update a
@@ -696,28 +664,28 @@ namespace ServiceWorkerRegistration
 
 
 namespace WindowClient
-
+  
   export
   ancestorOrigins : (obj : WindowClient) -> JSIO (Array String)
   ancestorOrigins a = primJS $ WindowClient.prim__ancestorOrigins a
 
-
+  
   export
   focused : (obj : WindowClient) -> JSIO Bool
   focused a = tryJS "WindowClient.focused" $ WindowClient.prim__focused a
 
-
+  
   export
   visibilityState : (obj : WindowClient) -> JSIO VisibilityState
   visibilityState a = tryJS "WindowClient.visibilityState" $
     WindowClient.prim__visibilityState a
 
-
+  
   export
   focus : (obj : WindowClient) -> JSIO (Promise WindowClient)
   focus a = primJS $ WindowClient.prim__focus a
 
-
+  
   export
   navigate :
        (obj : WindowClient)
@@ -734,7 +702,7 @@ namespace WindowClient
 --------------------------------------------------------------------------------
 
 namespace CacheQueryOptions
-
+  
   export
   new' :
        (ignoreSearch : Optional Bool)
@@ -743,16 +711,15 @@ namespace CacheQueryOptions
     -> JSIO CacheQueryOptions
   new' a b c = primJS $
     CacheQueryOptions.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO CacheQueryOptions
   new = primJS $ CacheQueryOptions.prim__new undef undef undef
 
-
+  
   export
   ignoreMethod :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t)}
+       {auto _ : Cast t CacheQueryOptions}
     -> t
     -> Attribute True Optional Bool
   ignoreMethod v = fromUndefOrPrim
@@ -760,13 +727,12 @@ namespace CacheQueryOptions
                      prim__ignoreMethod
                      prim__setIgnoreMethod
                      False
-                     (v :> CacheQueryOptions)
+                     (cast {to = CacheQueryOptions} v)
 
-
+  
   export
   ignoreSearch :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t)}
+       {auto _ : Cast t CacheQueryOptions}
     -> t
     -> Attribute True Optional Bool
   ignoreSearch v = fromUndefOrPrim
@@ -774,13 +740,12 @@ namespace CacheQueryOptions
                      prim__ignoreSearch
                      prim__setIgnoreSearch
                      False
-                     (v :> CacheQueryOptions)
+                     (cast {to = CacheQueryOptions} v)
 
-
+  
   export
   ignoreVary :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CacheQueryOptions (Types t)}
+       {auto _ : Cast t CacheQueryOptions}
     -> t
     -> Attribute True Optional Bool
   ignoreVary v = fromUndefOrPrim
@@ -788,28 +753,27 @@ namespace CacheQueryOptions
                    prim__ignoreVary
                    prim__setIgnoreVary
                    False
-                   (v :> CacheQueryOptions)
+                   (cast {to = CacheQueryOptions} v)
 
 
 
 namespace ClientQueryOptions
-
+  
   export
   new' :
        (includeUncontrolled : Optional Bool)
     -> (type : Optional ClientType)
     -> JSIO ClientQueryOptions
   new' a b = primJS $ ClientQueryOptions.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ClientQueryOptions
   new = primJS $ ClientQueryOptions.prim__new undef undef
 
-
+  
   export
   includeUncontrolled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ClientQueryOptions (Types t)}
+       {auto _ : Cast t ClientQueryOptions}
     -> t
     -> Attribute True Optional Bool
   includeUncontrolled v = fromUndefOrPrim
@@ -817,25 +781,24 @@ namespace ClientQueryOptions
                             prim__includeUncontrolled
                             prim__setIncludeUncontrolled
                             False
-                            (v :> ClientQueryOptions)
+                            (cast {to = ClientQueryOptions} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ClientQueryOptions (Types t)}
+       {auto _ : Cast t ClientQueryOptions}
     -> t
     -> Attribute False Optional ClientType
   type v = fromUndefOrPrimNoDefault
              "ClientQueryOptions.gettype"
              prim__type
              prim__setType
-             (v :> ClientQueryOptions)
+             (cast {to = ClientQueryOptions} v)
 
 
 
 namespace ExtendableEventInit
-
+  
   export
   new : JSIO ExtendableEventInit
   new = primJS $ ExtendableEventInit.prim__new
@@ -843,7 +806,7 @@ namespace ExtendableEventInit
 
 
 namespace ExtendableMessageEventInit
-
+  
   export
   new' :
        (data_ : Optional Any)
@@ -859,17 +822,16 @@ namespace ExtendableMessageEventInit
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   new : JSIO ExtendableMessageEventInit
   new = primJS $
     ExtendableMessageEventInit.prim__new undef undef undef undef undef
 
-
+  
   export
   data_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t)}
+       {auto _ : Cast t ExtendableMessageEventInit}
     -> t
     -> Attribute True Optional Any
   data_ v = fromUndefOrPrim
@@ -877,13 +839,12 @@ namespace ExtendableMessageEventInit
               prim__data
               prim__setData
               (MkAny $ null {a = ()})
-              (v :> ExtendableMessageEventInit)
+              (cast {to = ExtendableMessageEventInit} v)
 
-
+  
   export
   lastEventId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t)}
+       {auto _ : Cast t ExtendableMessageEventInit}
     -> t
     -> Attribute True Optional String
   lastEventId v = fromUndefOrPrim
@@ -891,13 +852,12 @@ namespace ExtendableMessageEventInit
                     prim__lastEventId
                     prim__setLastEventId
                     ""
-                    (v :> ExtendableMessageEventInit)
+                    (cast {to = ExtendableMessageEventInit} v)
 
-
+  
   export
   origin :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t)}
+       {auto _ : Cast t ExtendableMessageEventInit}
     -> t
     -> Attribute True Optional String
   origin v = fromUndefOrPrim
@@ -905,26 +865,24 @@ namespace ExtendableMessageEventInit
                prim__origin
                prim__setOrigin
                ""
-               (v :> ExtendableMessageEventInit)
+               (cast {to = ExtendableMessageEventInit} v)
 
-
+  
   export
   ports :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t)}
+       {auto _ : Cast t ExtendableMessageEventInit}
     -> t
     -> Attribute False Optional (Array MessagePort)
   ports v = fromUndefOrPrimNoDefault
               "ExtendableMessageEventInit.getports"
               prim__ports
               prim__setPorts
-              (v :> ExtendableMessageEventInit)
+              (cast {to = ExtendableMessageEventInit} v)
 
-
+  
   export
   source :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ExtendableMessageEventInit (Types t)}
+       {auto _ : Cast t ExtendableMessageEventInit}
     -> t
     -> Attribute True Optional (Maybe
                                   (HSum [Client, ServiceWorker, MessagePort]))
@@ -933,12 +891,12 @@ namespace ExtendableMessageEventInit
                prim__source
                prim__setSource
                Nothing
-               (v :> ExtendableMessageEventInit)
+               (cast {to = ExtendableMessageEventInit} v)
 
 
 
 namespace FetchEventInit
-
+  
   export
   new' :
        (request : Request)
@@ -950,16 +908,15 @@ namespace FetchEventInit
     -> JSIO FetchEventInit
   new' a b c d e f = primJS $
     FetchEventInit.prim__new a (toFFI b) (toFFI c) (toFFI d) (toFFI e) (toFFI f)
-
+  
   export
   new : (request : Request) -> JSIO FetchEventInit
   new a = primJS $ FetchEventInit.prim__new a undef undef undef undef undef
 
-
+  
   export
   clientId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute True Optional String
   clientId v = fromUndefOrPrim
@@ -967,39 +924,36 @@ namespace FetchEventInit
                  prim__clientId
                  prim__setClientId
                  ""
-                 (v :> FetchEventInit)
+                 (cast {to = FetchEventInit} v)
 
-
+  
   export
   handled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute False Optional (Promise Undefined)
   handled v = fromUndefOrPrimNoDefault
                 "FetchEventInit.gethandled"
                 prim__handled
                 prim__setHandled
-                (v :> FetchEventInit)
+                (cast {to = FetchEventInit} v)
 
-
+  
   export
   preloadResponse :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute False Optional (Promise AnyPtr)
   preloadResponse v = fromUndefOrPrimNoDefault
                         "FetchEventInit.getpreloadResponse"
                         prim__preloadResponse
                         prim__setPreloadResponse
-                        (v :> FetchEventInit)
+                        (cast {to = FetchEventInit} v)
 
-
+  
   export
   replacesClientId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute True Optional String
   replacesClientId v = fromUndefOrPrim
@@ -1007,26 +961,24 @@ namespace FetchEventInit
                          prim__replacesClientId
                          prim__setReplacesClientId
                          ""
-                         (v :> FetchEventInit)
+                         (cast {to = FetchEventInit} v)
 
-
+  
   export
   request :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute True Prelude.id Request
   request v = fromPrim
                 "FetchEventInit.getrequest"
                 prim__request
                 prim__setRequest
-                (v :> FetchEventInit)
+                (cast {to = FetchEventInit} v)
 
-
+  
   export
   resultingClientId :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FetchEventInit (Types t)}
+       {auto _ : Cast t FetchEventInit}
     -> t
     -> Attribute True Optional String
   resultingClientId v = fromUndefOrPrim
@@ -1034,53 +986,51 @@ namespace FetchEventInit
                           prim__resultingClientId
                           prim__setResultingClientId
                           ""
-                          (v :> FetchEventInit)
+                          (cast {to = FetchEventInit} v)
 
 
 
 namespace MultiCacheQueryOptions
-
+  
   export
   new' : (cacheName : Optional String) -> JSIO MultiCacheQueryOptions
   new' a = primJS $ MultiCacheQueryOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO MultiCacheQueryOptions
   new = primJS $ MultiCacheQueryOptions.prim__new undef
 
-
+  
   export
   cacheName :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MultiCacheQueryOptions (Types t)}
+       {auto _ : Cast t MultiCacheQueryOptions}
     -> t
     -> Attribute False Optional String
   cacheName v = fromUndefOrPrimNoDefault
                   "MultiCacheQueryOptions.getcacheName"
                   prim__cacheName
                   prim__setCacheName
-                  (v :> MultiCacheQueryOptions)
+                  (cast {to = MultiCacheQueryOptions} v)
 
 
 
 namespace NavigationPreloadState
-
+  
   export
   new' :
        (enabled : Optional Bool)
     -> (headerValue : Optional ByteString)
     -> JSIO NavigationPreloadState
   new' a b = primJS $ NavigationPreloadState.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO NavigationPreloadState
   new = primJS $ NavigationPreloadState.prim__new undef undef
 
-
+  
   export
   enabled :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem NavigationPreloadState (Types t)}
+       {auto _ : Cast t NavigationPreloadState}
     -> t
     -> Attribute True Optional Bool
   enabled v = fromUndefOrPrim
@@ -1088,25 +1038,24 @@ namespace NavigationPreloadState
                 prim__enabled
                 prim__setEnabled
                 False
-                (v :> NavigationPreloadState)
+                (cast {to = NavigationPreloadState} v)
 
-
+  
   export
   headerValue :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem NavigationPreloadState (Types t)}
+       {auto _ : Cast t NavigationPreloadState}
     -> t
     -> Attribute False Optional ByteString
   headerValue v = fromUndefOrPrimNoDefault
                     "NavigationPreloadState.getheaderValue"
                     prim__headerValue
                     prim__setHeaderValue
-                    (v :> NavigationPreloadState)
+                    (cast {to = NavigationPreloadState} v)
 
 
 
 namespace RegistrationOptions
-
+  
   export
   new' :
        (scope : Optional String)
@@ -1115,46 +1064,46 @@ namespace RegistrationOptions
     -> JSIO RegistrationOptions
   new' a b c = primJS $
     RegistrationOptions.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO RegistrationOptions
   new = primJS $ RegistrationOptions.prim__new undef undef undef
 
-
+  
   export
   scope :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RegistrationOptions (Types t)}
+       {auto _ : Cast t RegistrationOptions}
     -> t
     -> Attribute False Optional String
   scope v = fromUndefOrPrimNoDefault
               "RegistrationOptions.getscope"
               prim__scope
               prim__setScope
-              (v :> RegistrationOptions)
+              (cast {to = RegistrationOptions} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RegistrationOptions (Types t)}
+       {auto _ : Cast t RegistrationOptions}
     -> t
     -> Attribute False Optional WorkerType
   type v = fromUndefOrPrimNoDefault
              "RegistrationOptions.gettype"
              prim__type
              prim__setType
-             (v :> RegistrationOptions)
+             (cast {to = RegistrationOptions} v)
 
-
+  
   export
   updateViaCache :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem RegistrationOptions (Types t)}
+       {auto _ : Cast t RegistrationOptions}
     -> t
     -> Attribute False Optional ServiceWorkerUpdateViaCache
   updateViaCache v = fromUndefOrPrimNoDefault
                        "RegistrationOptions.getupdateViaCache"
                        prim__updateViaCache
                        prim__setUpdateViaCache
-                       (v :> RegistrationOptions)
+                       (cast {to = RegistrationOptions} v)
+
+
+

--- a/src/Web/Raw/Streams.idr
+++ b/src/Web/Raw/Streams.idr
@@ -12,21 +12,20 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace ByteLengthQueuingStrategy
-
+  
   export
   new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem QueuingStrategyInit (Types t1)}
+       {auto _ : Cast t1 QueuingStrategyInit}
     -> (init : t1)
     -> JSIO ByteLengthQueuingStrategy
-  new a = primJS $ ByteLengthQueuingStrategy.prim__new (up a)
+  new a = primJS $ ByteLengthQueuingStrategy.prim__new (cast a)
 
-
+  
   export
   highWaterMark : (obj : ByteLengthQueuingStrategy) -> JSIO Double
   highWaterMark a = primJS $ ByteLengthQueuingStrategy.prim__highWaterMark a
 
-
+  
   export
   size : (obj : ByteLengthQueuingStrategy) -> JSIO Function
   size a = primJS $ ByteLengthQueuingStrategy.prim__size a
@@ -34,21 +33,20 @@ namespace ByteLengthQueuingStrategy
 
 
 namespace CountQueuingStrategy
-
+  
   export
   new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem QueuingStrategyInit (Types t1)}
+       {auto _ : Cast t1 QueuingStrategyInit}
     -> (init : t1)
     -> JSIO CountQueuingStrategy
-  new a = primJS $ CountQueuingStrategy.prim__new (up a)
+  new a = primJS $ CountQueuingStrategy.prim__new (cast a)
 
-
+  
   export
   highWaterMark : (obj : CountQueuingStrategy) -> JSIO Double
   highWaterMark a = primJS $ CountQueuingStrategy.prim__highWaterMark a
 
-
+  
   export
   size : (obj : CountQueuingStrategy) -> JSIO Function
   size a = primJS $ CountQueuingStrategy.prim__size a
@@ -56,7 +54,7 @@ namespace CountQueuingStrategy
 
 
 namespace ReadableByteStreamController
-
+  
   export
   byobRequest :
        (obj : ReadableByteStreamController)
@@ -64,18 +62,18 @@ namespace ReadableByteStreamController
   byobRequest a = tryJS "ReadableByteStreamController.byobRequest" $
     ReadableByteStreamController.prim__byobRequest a
 
-
+  
   export
   desiredSize : (obj : ReadableByteStreamController) -> JSIO (Maybe Double)
   desiredSize a = tryJS "ReadableByteStreamController.desiredSize" $
     ReadableByteStreamController.prim__desiredSize a
 
-
+  
   export
   close : (obj : ReadableByteStreamController) -> JSIO ()
   close a = primJS $ ReadableByteStreamController.prim__close a
 
-
+  
   export
   enqueue :
        (obj : ReadableByteStreamController)
@@ -94,11 +92,11 @@ namespace ReadableByteStreamController
     -> JSIO ()
   enqueue a b = primJS $ ReadableByteStreamController.prim__enqueue a (toFFI b)
 
-
+  
   export
   error' : (obj : ReadableByteStreamController) -> (e : Optional Any) -> JSIO ()
   error' a b = primJS $ ReadableByteStreamController.prim__error a (toFFI b)
-
+  
   export
   error : (obj : ReadableByteStreamController) -> JSIO ()
   error a = primJS $ ReadableByteStreamController.prim__error a undef
@@ -106,50 +104,47 @@ namespace ReadableByteStreamController
 
 
 namespace ReadableStream
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Object (Types t1)}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t2)}
+       {auto _ : Cast t1 Object}
+    -> {auto _ : Cast t2 QueuingStrategy}
     -> (underlyingSource : Optional t1)
     -> (strategy : Optional t2)
     -> JSIO ReadableStream
   new' a b = primJS $ ReadableStream.prim__new (optUp a) (optUp b)
-
+  
   export
   new : JSIO ReadableStream
   new = primJS $ ReadableStream.prim__new undef undef
 
-
+  
   export
   locked : (obj : ReadableStream) -> JSIO Bool
   locked a = tryJS "ReadableStream.locked" $ ReadableStream.prim__locked a
 
-
+  
   export
   cancel' :
        (obj : ReadableStream)
     -> (reason : Optional Any)
     -> JSIO (Promise Undefined)
   cancel' a b = primJS $ ReadableStream.prim__cancel a (toFFI b)
-
+  
   export
   cancel : (obj : ReadableStream) -> JSIO (Promise Undefined)
   cancel a = primJS $ ReadableStream.prim__cancel a undef
 
-
+  
   export
   getReader' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ReadableStreamGetReaderOptions (Types t2)}
+       {auto _ : Cast t2 ReadableStreamGetReaderOptions}
     -> (obj : ReadableStream)
     -> (options : Optional t2)
     -> JSIO (HSum [ReadableStreamDefaultReader, ReadableStreamBYOBReader])
   getReader' a b = tryJS "ReadableStream.getReader'" $
     ReadableStream.prim__getReader a (optUp b)
-
+  
   export
   getReader :
        (obj : ReadableStream)
@@ -157,40 +152,36 @@ namespace ReadableStream
   getReader a = tryJS "ReadableStream.getReader" $
     ReadableStream.prim__getReader a undef
 
-
+  
   export
   pipeThrough' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem ReadableWritablePair (Types t2)}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t3)}
+       {auto _ : Cast t2 ReadableWritablePair}
+    -> {auto _ : Cast t3 StreamPipeOptions}
     -> (obj : ReadableStream)
     -> (transform : t2)
     -> (options : Optional t3)
     -> JSIO ReadableStream
   pipeThrough' a b c = primJS $
-    ReadableStream.prim__pipeThrough a (up b) (optUp c)
-
+    ReadableStream.prim__pipeThrough a (cast b) (optUp c)
+  
   export
   pipeThrough :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ReadableWritablePair (Types t2)}
+       {auto _ : Cast t2 ReadableWritablePair}
     -> (obj : ReadableStream)
     -> (transform : t2)
     -> JSIO ReadableStream
-  pipeThrough a b = primJS $ ReadableStream.prim__pipeThrough a (up b) undef
+  pipeThrough a b = primJS $ ReadableStream.prim__pipeThrough a (cast b) undef
 
-
+  
   export
   pipeTo' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t3)}
+       {auto _ : Cast t3 StreamPipeOptions}
     -> (obj : ReadableStream)
     -> (destination : WritableStream)
     -> (options : Optional t3)
     -> JSIO (Promise Undefined)
   pipeTo' a b c = primJS $ ReadableStream.prim__pipeTo a b (optUp c)
-
+  
   export
   pipeTo :
        (obj : ReadableStream)
@@ -198,7 +189,7 @@ namespace ReadableStream
     -> JSIO (Promise Undefined)
   pipeTo a b = primJS $ ReadableStream.prim__pipeTo a b undef
 
-
+  
   export
   tee : (obj : ReadableStream) -> JSIO (Array ReadableStream)
   tee a = primJS $ ReadableStream.prim__tee a
@@ -206,12 +197,12 @@ namespace ReadableStream
 
 
 namespace ReadableStreamBYOBReader
-
+  
   export
   new : (stream : ReadableStream) -> JSIO ReadableStreamBYOBReader
   new a = primJS $ ReadableStreamBYOBReader.prim__new a
 
-
+  
   export
   read :
        (obj : ReadableStreamBYOBReader)
@@ -230,7 +221,7 @@ namespace ReadableStreamBYOBReader
     -> JSIO (Promise ReadableStreamBYOBReadResult)
   read a b = primJS $ ReadableStreamBYOBReader.prim__read a (toFFI b)
 
-
+  
   export
   releaseLock : (obj : ReadableStreamBYOBReader) -> JSIO ()
   releaseLock a = primJS $ ReadableStreamBYOBReader.prim__releaseLock a
@@ -238,7 +229,7 @@ namespace ReadableStreamBYOBReader
 
 
 namespace ReadableStreamBYOBRequest
-
+  
   export
   view :
        (obj : ReadableStreamBYOBRequest)
@@ -258,7 +249,7 @@ namespace ReadableStreamBYOBRequest
   view a = tryJS "ReadableStreamBYOBRequest.view" $
     ReadableStreamBYOBRequest.prim__view a
 
-
+  
   export
   respond :
        (obj : ReadableStreamBYOBRequest)
@@ -266,7 +257,7 @@ namespace ReadableStreamBYOBRequest
     -> JSIO ()
   respond a b = primJS $ ReadableStreamBYOBRequest.prim__respond a b
 
-
+  
   export
   respondWithNewView :
        (obj : ReadableStreamBYOBRequest)
@@ -289,18 +280,18 @@ namespace ReadableStreamBYOBRequest
 
 
 namespace ReadableStreamDefaultController
-
+  
   export
   desiredSize : (obj : ReadableStreamDefaultController) -> JSIO (Maybe Double)
   desiredSize a = tryJS "ReadableStreamDefaultController.desiredSize" $
     ReadableStreamDefaultController.prim__desiredSize a
 
-
+  
   export
   close : (obj : ReadableStreamDefaultController) -> JSIO ()
   close a = primJS $ ReadableStreamDefaultController.prim__close a
 
-
+  
   export
   enqueue' :
        (obj : ReadableStreamDefaultController)
@@ -308,19 +299,19 @@ namespace ReadableStreamDefaultController
     -> JSIO ()
   enqueue' a b = primJS $
     ReadableStreamDefaultController.prim__enqueue a (toFFI b)
-
+  
   export
   enqueue : (obj : ReadableStreamDefaultController) -> JSIO ()
   enqueue a = primJS $ ReadableStreamDefaultController.prim__enqueue a undef
 
-
+  
   export
   error' :
        (obj : ReadableStreamDefaultController)
     -> (e : Optional Any)
     -> JSIO ()
   error' a b = primJS $ ReadableStreamDefaultController.prim__error a (toFFI b)
-
+  
   export
   error : (obj : ReadableStreamDefaultController) -> JSIO ()
   error a = primJS $ ReadableStreamDefaultController.prim__error a undef
@@ -328,19 +319,19 @@ namespace ReadableStreamDefaultController
 
 
 namespace ReadableStreamDefaultReader
-
+  
   export
   new : (stream : ReadableStream) -> JSIO ReadableStreamDefaultReader
   new a = primJS $ ReadableStreamDefaultReader.prim__new a
 
-
+  
   export
   read :
        (obj : ReadableStreamDefaultReader)
     -> JSIO (Promise ReadableStreamDefaultReadResult)
   read a = primJS $ ReadableStreamDefaultReader.prim__read a
 
-
+  
   export
   releaseLock : (obj : ReadableStreamDefaultReader) -> JSIO ()
   releaseLock a = primJS $ ReadableStreamDefaultReader.prim__releaseLock a
@@ -348,31 +339,28 @@ namespace ReadableStreamDefaultReader
 
 
 namespace TransformStream
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Object (Types t1)}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t2)}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t3)}
+       {auto _ : Cast t1 Object}
+    -> {auto _ : Cast t2 QueuingStrategy}
+    -> {auto _ : Cast t3 QueuingStrategy}
     -> (transformer : Optional t1)
     -> (writableStrategy : Optional t2)
     -> (readableStrategy : Optional t3)
     -> JSIO TransformStream
   new' a b c = primJS $ TransformStream.prim__new (optUp a) (optUp b) (optUp c)
-
+  
   export
   new : JSIO TransformStream
   new = primJS $ TransformStream.prim__new undef undef undef
 
-
+  
   export
   readable : (obj : TransformStream) -> JSIO ReadableStream
   readable a = primJS $ TransformStream.prim__readable a
 
-
+  
   export
   writable : (obj : TransformStream) -> JSIO WritableStream
   writable a = primJS $ TransformStream.prim__writable a
@@ -380,13 +368,13 @@ namespace TransformStream
 
 
 namespace TransformStreamDefaultController
-
+  
   export
   desiredSize : (obj : TransformStreamDefaultController) -> JSIO (Maybe Double)
   desiredSize a = tryJS "TransformStreamDefaultController.desiredSize" $
     TransformStreamDefaultController.prim__desiredSize a
 
-
+  
   export
   enqueue' :
        (obj : TransformStreamDefaultController)
@@ -394,24 +382,24 @@ namespace TransformStreamDefaultController
     -> JSIO ()
   enqueue' a b = primJS $
     TransformStreamDefaultController.prim__enqueue a (toFFI b)
-
+  
   export
   enqueue : (obj : TransformStreamDefaultController) -> JSIO ()
   enqueue a = primJS $ TransformStreamDefaultController.prim__enqueue a undef
 
-
+  
   export
   error' :
        (obj : TransformStreamDefaultController)
     -> (reason : Optional Any)
     -> JSIO ()
   error' a b = primJS $ TransformStreamDefaultController.prim__error a (toFFI b)
-
+  
   export
   error : (obj : TransformStreamDefaultController) -> JSIO ()
   error a = primJS $ TransformStreamDefaultController.prim__error a undef
 
-
+  
   export
   terminate : (obj : TransformStreamDefaultController) -> JSIO ()
   terminate a = primJS $ TransformStreamDefaultController.prim__terminate a
@@ -419,45 +407,43 @@ namespace TransformStreamDefaultController
 
 
 namespace WritableStream
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Object (Types t1)}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t2)}
+       {auto _ : Cast t1 Object}
+    -> {auto _ : Cast t2 QueuingStrategy}
     -> (underlyingSink : Optional t1)
     -> (strategy : Optional t2)
     -> JSIO WritableStream
   new' a b = primJS $ WritableStream.prim__new (optUp a) (optUp b)
-
+  
   export
   new : JSIO WritableStream
   new = primJS $ WritableStream.prim__new undef undef
 
-
+  
   export
   locked : (obj : WritableStream) -> JSIO Bool
   locked a = tryJS "WritableStream.locked" $ WritableStream.prim__locked a
 
-
+  
   export
   abort' :
        (obj : WritableStream)
     -> (reason : Optional Any)
     -> JSIO (Promise Undefined)
   abort' a b = primJS $ WritableStream.prim__abort a (toFFI b)
-
+  
   export
   abort : (obj : WritableStream) -> JSIO (Promise Undefined)
   abort a = primJS $ WritableStream.prim__abort a undef
 
-
+  
   export
   close : (obj : WritableStream) -> JSIO (Promise Undefined)
   close a = primJS $ WritableStream.prim__close a
 
-
+  
   export
   getWriter : (obj : WritableStream) -> JSIO WritableStreamDefaultWriter
   getWriter a = primJS $ WritableStream.prim__getWriter a
@@ -465,14 +451,14 @@ namespace WritableStream
 
 
 namespace WritableStreamDefaultController
-
+  
   export
   error' :
        (obj : WritableStreamDefaultController)
     -> (e : Optional Any)
     -> JSIO ()
   error' a b = primJS $ WritableStreamDefaultController.prim__error a (toFFI b)
-
+  
   export
   error : (obj : WritableStreamDefaultController) -> JSIO ()
   error a = primJS $ WritableStreamDefaultController.prim__error a undef
@@ -480,57 +466,57 @@ namespace WritableStreamDefaultController
 
 
 namespace WritableStreamDefaultWriter
-
+  
   export
   new : (stream : WritableStream) -> JSIO WritableStreamDefaultWriter
   new a = primJS $ WritableStreamDefaultWriter.prim__new a
 
-
+  
   export
   closed : (obj : WritableStreamDefaultWriter) -> JSIO (Promise Undefined)
   closed a = primJS $ WritableStreamDefaultWriter.prim__closed a
 
-
+  
   export
   desiredSize : (obj : WritableStreamDefaultWriter) -> JSIO (Maybe Double)
   desiredSize a = tryJS "WritableStreamDefaultWriter.desiredSize" $
     WritableStreamDefaultWriter.prim__desiredSize a
 
-
+  
   export
   ready : (obj : WritableStreamDefaultWriter) -> JSIO (Promise Undefined)
   ready a = primJS $ WritableStreamDefaultWriter.prim__ready a
 
-
+  
   export
   abort' :
        (obj : WritableStreamDefaultWriter)
     -> (reason : Optional Any)
     -> JSIO (Promise Undefined)
   abort' a b = primJS $ WritableStreamDefaultWriter.prim__abort a (toFFI b)
-
+  
   export
   abort : (obj : WritableStreamDefaultWriter) -> JSIO (Promise Undefined)
   abort a = primJS $ WritableStreamDefaultWriter.prim__abort a undef
 
-
+  
   export
   close : (obj : WritableStreamDefaultWriter) -> JSIO (Promise Undefined)
   close a = primJS $ WritableStreamDefaultWriter.prim__close a
 
-
+  
   export
   releaseLock : (obj : WritableStreamDefaultWriter) -> JSIO ()
   releaseLock a = primJS $ WritableStreamDefaultWriter.prim__releaseLock a
 
-
+  
   export
   write' :
        (obj : WritableStreamDefaultWriter)
     -> (chunk : Optional Any)
     -> JSIO (Promise Undefined)
   write' a b = primJS $ WritableStreamDefaultWriter.prim__write a (toFFI b)
-
+  
   export
   write : (obj : WritableStreamDefaultWriter) -> JSIO (Promise Undefined)
   write a = primJS $ WritableStreamDefaultWriter.prim__write a undef
@@ -543,54 +529,49 @@ namespace WritableStreamDefaultWriter
 --------------------------------------------------------------------------------
 
 namespace GenericTransformStream
-
+  
   export
   readable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem GenericTransformStream (Types t1)}
+       {auto _ : Cast t1 GenericTransformStream}
     -> (obj : t1)
     -> JSIO ReadableStream
-  readable a = primJS $ GenericTransformStream.prim__readable (up a)
+  readable a = primJS $ GenericTransformStream.prim__readable (cast a)
 
-
+  
   export
   writable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem GenericTransformStream (Types t1)}
+       {auto _ : Cast t1 GenericTransformStream}
     -> (obj : t1)
     -> JSIO WritableStream
-  writable a = primJS $ GenericTransformStream.prim__writable (up a)
+  writable a = primJS $ GenericTransformStream.prim__writable (cast a)
 
 
 
 namespace ReadableStreamGenericReader
-
+  
   export
   closed :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ReadableStreamGenericReader (Types t1)}
+       {auto _ : Cast t1 ReadableStreamGenericReader}
     -> (obj : t1)
     -> JSIO (Promise Undefined)
-  closed a = primJS $ ReadableStreamGenericReader.prim__closed (up a)
+  closed a = primJS $ ReadableStreamGenericReader.prim__closed (cast a)
 
-
+  
   export
   cancel' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ReadableStreamGenericReader (Types t1)}
+       {auto _ : Cast t1 ReadableStreamGenericReader}
     -> (obj : t1)
     -> (reason : Optional Any)
     -> JSIO (Promise Undefined)
   cancel' a b = primJS $
-    ReadableStreamGenericReader.prim__cancel (up a) (toFFI b)
-
+    ReadableStreamGenericReader.prim__cancel (cast a) (toFFI b)
+  
   export
   cancel :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem ReadableStreamGenericReader (Types t1)}
+       {auto _ : Cast t1 ReadableStreamGenericReader}
     -> (obj : t1)
     -> JSIO (Promise Undefined)
-  cancel a = primJS $ ReadableStreamGenericReader.prim__cancel (up a) undef
+  cancel a = primJS $ ReadableStreamGenericReader.prim__cancel (cast a) undef
 
 
 
@@ -600,69 +581,66 @@ namespace ReadableStreamGenericReader
 --------------------------------------------------------------------------------
 
 namespace QueuingStrategy
-
+  
   export
   new' :
        (highWaterMark : Optional Double)
     -> (size : Optional QueuingStrategySize)
     -> JSIO QueuingStrategy
   new' a b = primJS $ QueuingStrategy.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO QueuingStrategy
   new = primJS $ QueuingStrategy.prim__new undef undef
 
-
+  
   export
   highWaterMark :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t)}
+       {auto _ : Cast t QueuingStrategy}
     -> t
     -> Attribute False Optional Double
   highWaterMark v = fromUndefOrPrimNoDefault
                       "QueuingStrategy.gethighWaterMark"
                       prim__highWaterMark
                       prim__setHighWaterMark
-                      (v :> QueuingStrategy)
+                      (cast {to = QueuingStrategy} v)
 
-
+  
   export
   size :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem QueuingStrategy (Types t)}
+       {auto _ : Cast t QueuingStrategy}
     -> t
     -> Attribute False Optional QueuingStrategySize
   size v = fromUndefOrPrimNoDefault
              "QueuingStrategy.getsize"
              prim__size
              prim__setSize
-             (v :> QueuingStrategy)
+             (cast {to = QueuingStrategy} v)
 
 
 
 namespace QueuingStrategyInit
-
+  
   export
   new : (highWaterMark : Double) -> JSIO QueuingStrategyInit
   new a = primJS $ QueuingStrategyInit.prim__new a
 
-
+  
   export
   highWaterMark :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem QueuingStrategyInit (Types t)}
+       {auto _ : Cast t QueuingStrategyInit}
     -> t
     -> Attribute True Prelude.id Double
   highWaterMark v = fromPrim
                       "QueuingStrategyInit.gethighWaterMark"
                       prim__highWaterMark
                       prim__setHighWaterMark
-                      (v :> QueuingStrategyInit)
+                      (cast {to = QueuingStrategyInit} v)
 
 
 
 namespace ReadableStreamBYOBReadResult
-
+  
   export
   new' :
        (value : Optional
@@ -681,29 +659,27 @@ namespace ReadableStreamBYOBReadResult
     -> (done : Optional Bool)
     -> JSIO ReadableStreamBYOBReadResult
   new' a b = primJS $ ReadableStreamBYOBReadResult.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ReadableStreamBYOBReadResult
   new = primJS $ ReadableStreamBYOBReadResult.prim__new undef undef
 
-
+  
   export
   done :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamBYOBReadResult (Types t)}
+       {auto _ : Cast t ReadableStreamBYOBReadResult}
     -> t
     -> Attribute False Optional Bool
   done v = fromUndefOrPrimNoDefault
              "ReadableStreamBYOBReadResult.getdone"
              prim__done
              prim__setDone
-             (v :> ReadableStreamBYOBReadResult)
+             (cast {to = ReadableStreamBYOBReadResult} v)
 
-
+  
   export
   value :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamBYOBReadResult (Types t)}
+       {auto _ : Cast t ReadableStreamBYOBReadResult}
     -> t
     -> Attribute False Optional (Union10
                                    Int8Array
@@ -720,12 +696,12 @@ namespace ReadableStreamBYOBReadResult
               "ReadableStreamBYOBReadResult.getvalue"
               prim__value
               prim__setValue
-              (v :> ReadableStreamBYOBReadResult)
+              (cast {to = ReadableStreamBYOBReadResult} v)
 
 
 
 namespace ReadableStreamDefaultReadResult
-
+  
   export
   new' :
        (value : Optional Any)
@@ -733,81 +709,77 @@ namespace ReadableStreamDefaultReadResult
     -> JSIO ReadableStreamDefaultReadResult
   new' a b = primJS $
     ReadableStreamDefaultReadResult.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO ReadableStreamDefaultReadResult
   new = primJS $ ReadableStreamDefaultReadResult.prim__new undef undef
 
-
+  
   export
   done :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamDefaultReadResult (Types t)}
+       {auto _ : Cast t ReadableStreamDefaultReadResult}
     -> t
     -> Attribute False Optional Bool
   done v = fromUndefOrPrimNoDefault
              "ReadableStreamDefaultReadResult.getdone"
              prim__done
              prim__setDone
-             (v :> ReadableStreamDefaultReadResult)
+             (cast {to = ReadableStreamDefaultReadResult} v)
 
-
+  
   export
   value :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamDefaultReadResult (Types t)}
+       {auto _ : Cast t ReadableStreamDefaultReadResult}
     -> t
     -> Attribute False Optional Any
   value v = fromUndefOrPrimNoDefault
               "ReadableStreamDefaultReadResult.getvalue"
               prim__value
               prim__setValue
-              (v :> ReadableStreamDefaultReadResult)
+              (cast {to = ReadableStreamDefaultReadResult} v)
 
 
 
 namespace ReadableStreamGetReaderOptions
-
+  
   export
   new' :
        (mode : Optional ReadableStreamReaderMode)
     -> JSIO ReadableStreamGetReaderOptions
   new' a = primJS $ ReadableStreamGetReaderOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ReadableStreamGetReaderOptions
   new = primJS $ ReadableStreamGetReaderOptions.prim__new undef
 
-
+  
   export
   mode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamGetReaderOptions (Types t)}
+       {auto _ : Cast t ReadableStreamGetReaderOptions}
     -> t
     -> Attribute False Optional ReadableStreamReaderMode
   mode v = fromUndefOrPrimNoDefault
              "ReadableStreamGetReaderOptions.getmode"
              prim__mode
              prim__setMode
-             (v :> ReadableStreamGetReaderOptions)
+             (cast {to = ReadableStreamGetReaderOptions} v)
 
 
 
 namespace ReadableStreamIteratorOptions
-
+  
   export
   new' : (preventCancel : Optional Bool) -> JSIO ReadableStreamIteratorOptions
   new' a = primJS $ ReadableStreamIteratorOptions.prim__new (toFFI a)
-
+  
   export
   new : JSIO ReadableStreamIteratorOptions
   new = primJS $ ReadableStreamIteratorOptions.prim__new undef
 
-
+  
   export
   preventCancel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableStreamIteratorOptions (Types t)}
+       {auto _ : Cast t ReadableStreamIteratorOptions}
     -> t
     -> Attribute True Optional Bool
   preventCancel v = fromUndefOrPrim
@@ -815,12 +787,12 @@ namespace ReadableStreamIteratorOptions
                       prim__preventCancel
                       prim__setPreventCancel
                       False
-                      (v :> ReadableStreamIteratorOptions)
+                      (cast {to = ReadableStreamIteratorOptions} v)
 
 
 
 namespace ReadableWritablePair
-
+  
   export
   new :
        (readable : ReadableStream)
@@ -828,36 +800,34 @@ namespace ReadableWritablePair
     -> JSIO ReadableWritablePair
   new a b = primJS $ ReadableWritablePair.prim__new a b
 
-
+  
   export
   readable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableWritablePair (Types t)}
+       {auto _ : Cast t ReadableWritablePair}
     -> t
     -> Attribute True Prelude.id ReadableStream
   readable v = fromPrim
                  "ReadableWritablePair.getreadable"
                  prim__readable
                  prim__setReadable
-                 (v :> ReadableWritablePair)
+                 (cast {to = ReadableWritablePair} v)
 
-
+  
   export
   writable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ReadableWritablePair (Types t)}
+       {auto _ : Cast t ReadableWritablePair}
     -> t
     -> Attribute True Prelude.id WritableStream
   writable v = fromPrim
                  "ReadableWritablePair.getwritable"
                  prim__writable
                  prim__setWritable
-                 (v :> ReadableWritablePair)
+                 (cast {to = ReadableWritablePair} v)
 
 
 
 namespace StreamPipeOptions
-
+  
   export
   new' :
        (preventClose : Optional Bool)
@@ -867,16 +837,15 @@ namespace StreamPipeOptions
     -> JSIO StreamPipeOptions
   new' a b c d = primJS $
     StreamPipeOptions.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO StreamPipeOptions
   new = primJS $ StreamPipeOptions.prim__new undef undef undef undef
 
-
+  
   export
   preventAbort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t)}
+       {auto _ : Cast t StreamPipeOptions}
     -> t
     -> Attribute True Optional Bool
   preventAbort v = fromUndefOrPrim
@@ -884,13 +853,12 @@ namespace StreamPipeOptions
                      prim__preventAbort
                      prim__setPreventAbort
                      False
-                     (v :> StreamPipeOptions)
+                     (cast {to = StreamPipeOptions} v)
 
-
+  
   export
   preventCancel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t)}
+       {auto _ : Cast t StreamPipeOptions}
     -> t
     -> Attribute True Optional Bool
   preventCancel v = fromUndefOrPrim
@@ -898,13 +866,12 @@ namespace StreamPipeOptions
                       prim__preventCancel
                       prim__setPreventCancel
                       False
-                      (v :> StreamPipeOptions)
+                      (cast {to = StreamPipeOptions} v)
 
-
+  
   export
   preventClose :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t)}
+       {auto _ : Cast t StreamPipeOptions}
     -> t
     -> Attribute True Optional Bool
   preventClose v = fromUndefOrPrim
@@ -912,25 +879,24 @@ namespace StreamPipeOptions
                      prim__preventClose
                      prim__setPreventClose
                      False
-                     (v :> StreamPipeOptions)
+                     (cast {to = StreamPipeOptions} v)
 
-
+  
   export
   signal :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem StreamPipeOptions (Types t)}
+       {auto _ : Cast t StreamPipeOptions}
     -> t
     -> Attribute False Optional AbortSignal
   signal v = fromUndefOrPrimNoDefault
                "StreamPipeOptions.getsignal"
                prim__signal
                prim__setSignal
-               (v :> StreamPipeOptions)
+               (cast {to = StreamPipeOptions} v)
 
 
 
 namespace Transformer
-
+  
   export
   new' :
        (start : Optional TransformerStartCallback)
@@ -941,80 +907,75 @@ namespace Transformer
     -> JSIO Transformer
   new' a b c d e = primJS $
     Transformer.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO Transformer
   new = primJS $ Transformer.prim__new undef undef undef undef undef
 
-
+  
   export
   flush :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Transformer (Types t)}
+       {auto _ : Cast t Transformer}
     -> t
     -> Attribute False Optional TransformerFlushCallback
   flush v = fromUndefOrPrimNoDefault
               "Transformer.getflush"
               prim__flush
               prim__setFlush
-              (v :> Transformer)
+              (cast {to = Transformer} v)
 
-
+  
   export
   readableType :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Transformer (Types t)}
+       {auto _ : Cast t Transformer}
     -> t
     -> Attribute False Optional Any
   readableType v = fromUndefOrPrimNoDefault
                      "Transformer.getreadableType"
                      prim__readableType
                      prim__setReadableType
-                     (v :> Transformer)
+                     (cast {to = Transformer} v)
 
-
+  
   export
   start :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Transformer (Types t)}
+       {auto _ : Cast t Transformer}
     -> t
     -> Attribute False Optional TransformerStartCallback
   start v = fromUndefOrPrimNoDefault
               "Transformer.getstart"
               prim__start
               prim__setStart
-              (v :> Transformer)
+              (cast {to = Transformer} v)
 
-
+  
   export
   transform :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Transformer (Types t)}
+       {auto _ : Cast t Transformer}
     -> t
     -> Attribute False Optional TransformerTransformCallback
   transform v = fromUndefOrPrimNoDefault
                   "Transformer.gettransform"
                   prim__transform
                   prim__setTransform
-                  (v :> Transformer)
+                  (cast {to = Transformer} v)
 
-
+  
   export
   writableType :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem Transformer (Types t)}
+       {auto _ : Cast t Transformer}
     -> t
     -> Attribute False Optional Any
   writableType v = fromUndefOrPrimNoDefault
                      "Transformer.getwritableType"
                      prim__writableType
                      prim__setWritableType
-                     (v :> Transformer)
+                     (cast {to = Transformer} v)
 
 
 
 namespace UnderlyingSink
-
+  
   export
   new' :
        (start : Optional UnderlyingSinkStartCallback)
@@ -1025,80 +986,72 @@ namespace UnderlyingSink
     -> JSIO UnderlyingSink
   new' a b c d e = primJS $
     UnderlyingSink.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO UnderlyingSink
   new = primJS $ UnderlyingSink.prim__new undef undef undef undef undef
 
-
+  
   export
   abort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSink (Types t)}
+       {auto _ : Cast t UnderlyingSink}
     -> t
     -> Attribute False Optional UnderlyingSinkAbortCallback
   abort v = fromUndefOrPrimNoDefault
               "UnderlyingSink.getabort"
               prim__abort
               prim__setAbort
-              (v :> UnderlyingSink)
+              (cast {to = UnderlyingSink} v)
 
-
+  
   export
   close :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSink (Types t)}
+       {auto _ : Cast t UnderlyingSink}
     -> t
     -> Attribute False Optional UnderlyingSinkCloseCallback
   close v = fromUndefOrPrimNoDefault
               "UnderlyingSink.getclose"
               prim__close
               prim__setClose
-              (v :> UnderlyingSink)
+              (cast {to = UnderlyingSink} v)
 
-
+  
   export
   start :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSink (Types t)}
+       {auto _ : Cast t UnderlyingSink}
     -> t
     -> Attribute False Optional UnderlyingSinkStartCallback
   start v = fromUndefOrPrimNoDefault
               "UnderlyingSink.getstart"
               prim__start
               prim__setStart
-              (v :> UnderlyingSink)
+              (cast {to = UnderlyingSink} v)
 
-
+  
   export
-  type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSink (Types t)}
-    -> t
-    -> Attribute False Optional Any
+  type : {auto _ : Cast t UnderlyingSink} -> t -> Attribute False Optional Any
   type v = fromUndefOrPrimNoDefault
              "UnderlyingSink.gettype"
              prim__type
              prim__setType
-             (v :> UnderlyingSink)
+             (cast {to = UnderlyingSink} v)
 
-
+  
   export
   write :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSink (Types t)}
+       {auto _ : Cast t UnderlyingSink}
     -> t
     -> Attribute False Optional UnderlyingSinkWriteCallback
   write v = fromUndefOrPrimNoDefault
               "UnderlyingSink.getwrite"
               prim__write
               prim__setWrite
-              (v :> UnderlyingSink)
+              (cast {to = UnderlyingSink} v)
 
 
 
 namespace UnderlyingSource
-
+  
   export
   new' :
        (start : Optional UnderlyingSourceStartCallback)
@@ -1109,75 +1062,70 @@ namespace UnderlyingSource
     -> JSIO UnderlyingSource
   new' a b c d e = primJS $
     UnderlyingSource.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d) (toFFI e)
-
+  
   export
   new : JSIO UnderlyingSource
   new = primJS $ UnderlyingSource.prim__new undef undef undef undef undef
 
-
+  
   export
   autoAllocateChunkSize :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSource (Types t)}
+       {auto _ : Cast t UnderlyingSource}
     -> t
     -> Attribute False Optional JSBits64
   autoAllocateChunkSize v = fromUndefOrPrimNoDefault
                               "UnderlyingSource.getautoAllocateChunkSize"
                               prim__autoAllocateChunkSize
                               prim__setAutoAllocateChunkSize
-                              (v :> UnderlyingSource)
+                              (cast {to = UnderlyingSource} v)
 
-
+  
   export
   cancel :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSource (Types t)}
+       {auto _ : Cast t UnderlyingSource}
     -> t
     -> Attribute False Optional UnderlyingSourceCancelCallback
   cancel v = fromUndefOrPrimNoDefault
                "UnderlyingSource.getcancel"
                prim__cancel
                prim__setCancel
-               (v :> UnderlyingSource)
+               (cast {to = UnderlyingSource} v)
 
-
+  
   export
   pull :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSource (Types t)}
+       {auto _ : Cast t UnderlyingSource}
     -> t
     -> Attribute False Optional UnderlyingSourcePullCallback
   pull v = fromUndefOrPrimNoDefault
              "UnderlyingSource.getpull"
              prim__pull
              prim__setPull
-             (v :> UnderlyingSource)
+             (cast {to = UnderlyingSource} v)
 
-
+  
   export
   start :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSource (Types t)}
+       {auto _ : Cast t UnderlyingSource}
     -> t
     -> Attribute False Optional UnderlyingSourceStartCallback
   start v = fromUndefOrPrimNoDefault
               "UnderlyingSource.getstart"
               prim__start
               prim__setStart
-              (v :> UnderlyingSource)
+              (cast {to = UnderlyingSource} v)
 
-
+  
   export
   type :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UnderlyingSource (Types t)}
+       {auto _ : Cast t UnderlyingSource}
     -> t
     -> Attribute False Optional ReadableStreamType
   type v = fromUndefOrPrimNoDefault
              "UnderlyingSource.gettype"
              prim__type
              prim__setType
-             (v :> UnderlyingSource)
+             (cast {to = UnderlyingSource} v)
 
 
 
@@ -1187,7 +1135,7 @@ namespace UnderlyingSource
 --------------------------------------------------------------------------------
 
 namespace QueuingStrategySize
-
+  
   export
   toQueuingStrategySize :
        (UndefOr AnyPtr -> IO Double)
@@ -1197,7 +1145,7 @@ namespace QueuingStrategySize
 
 
 namespace TransformerFlushCallback
-
+  
   export
   toTransformerFlushCallback :
        (TransformStreamDefaultController -> IO (Promise Undefined))
@@ -1207,7 +1155,7 @@ namespace TransformerFlushCallback
 
 
 namespace TransformerStartCallback
-
+  
   export
   toTransformerStartCallback :
        (TransformStreamDefaultController -> IO AnyPtr)
@@ -1217,7 +1165,7 @@ namespace TransformerStartCallback
 
 
 namespace TransformerTransformCallback
-
+  
   export
   toTransformerTransformCallback :
        (AnyPtr -> TransformStreamDefaultController -> IO (Promise Undefined))
@@ -1227,7 +1175,7 @@ namespace TransformerTransformCallback
 
 
 namespace UnderlyingSinkAbortCallback
-
+  
   export
   toUnderlyingSinkAbortCallback :
        (UndefOr AnyPtr -> IO (Promise Undefined))
@@ -1237,7 +1185,7 @@ namespace UnderlyingSinkAbortCallback
 
 
 namespace UnderlyingSinkCloseCallback
-
+  
   export
   toUnderlyingSinkCloseCallback :
        (() -> IO (Promise Undefined))
@@ -1247,7 +1195,7 @@ namespace UnderlyingSinkCloseCallback
 
 
 namespace UnderlyingSinkStartCallback
-
+  
   export
   toUnderlyingSinkStartCallback :
        (WritableStreamDefaultController -> IO AnyPtr)
@@ -1257,7 +1205,7 @@ namespace UnderlyingSinkStartCallback
 
 
 namespace UnderlyingSinkWriteCallback
-
+  
   export
   toUnderlyingSinkWriteCallback :
        (AnyPtr -> WritableStreamDefaultController -> IO (Promise Undefined))
@@ -1267,7 +1215,7 @@ namespace UnderlyingSinkWriteCallback
 
 
 namespace UnderlyingSourceCancelCallback
-
+  
   export
   toUnderlyingSourceCancelCallback :
        (UndefOr AnyPtr -> IO (Promise Undefined))
@@ -1277,7 +1225,7 @@ namespace UnderlyingSourceCancelCallback
 
 
 namespace UnderlyingSourcePullCallback
-
+  
   export
   toUnderlyingSourcePullCallback :
        (  Union2 ReadableStreamDefaultController ReadableByteStreamController
@@ -1289,7 +1237,7 @@ namespace UnderlyingSourcePullCallback
 
 
 namespace UnderlyingSourceStartCallback
-
+  
   export
   toUnderlyingSourceStartCallback :
        (  Union2 ReadableStreamDefaultController ReadableByteStreamController
@@ -1297,3 +1245,5 @@ namespace UnderlyingSourceStartCallback
        )
     -> JSIO UnderlyingSourceStartCallback
   toUnderlyingSourceStartCallback cb = primJS $ prim__toUnderlyingSourceStartCallback cb
+
+

--- a/src/Web/Raw/Svg.idr
+++ b/src/Web/Raw/Svg.idr
@@ -13,7 +13,7 @@ import Web.Internal.Types
 
 
 namespace SVGAElement
-
+  
   export
   download : SVGAElement -> Attribute True Prelude.id String
   download v = fromPrim
@@ -22,7 +22,7 @@ namespace SVGAElement
                  prim__setDownload
                  v
 
-
+  
   export
   hreflang : SVGAElement -> Attribute True Prelude.id String
   hreflang v = fromPrim
@@ -31,12 +31,12 @@ namespace SVGAElement
                  prim__setHreflang
                  v
 
-
+  
   export
   ping : SVGAElement -> Attribute True Prelude.id String
   ping v = fromPrim "SVGAElement.getping" prim__ping prim__setPing v
 
-
+  
   export
   referrerPolicy : SVGAElement -> Attribute True Prelude.id String
   referrerPolicy v = fromPrim
@@ -45,27 +45,27 @@ namespace SVGAElement
                        prim__setReferrerPolicy
                        v
 
-
+  
   export
   rel : SVGAElement -> Attribute True Prelude.id String
   rel v = fromPrim "SVGAElement.getrel" prim__rel prim__setRel v
 
-
+  
   export
   relList : (obj : SVGAElement) -> JSIO DOMTokenList
   relList a = primJS $ SVGAElement.prim__relList a
 
-
+  
   export
   target : (obj : SVGAElement) -> JSIO SVGAnimatedString
   target a = primJS $ SVGAElement.prim__target a
 
-
+  
   export
   text : SVGAElement -> Attribute True Prelude.id String
   text v = fromPrim "SVGAElement.gettext" prim__text prim__setText v
 
-
+  
   export
   type : SVGAElement -> Attribute True Prelude.id String
   type v = fromPrim "SVGAElement.gettype" prim__type prim__setType v
@@ -73,42 +73,42 @@ namespace SVGAElement
 
 
 namespace SVGAngle
-
-  public export
+  
+  export
   SVG_ANGLETYPE_DEG : Bits16
   SVG_ANGLETYPE_DEG = 2
 
-
-  public export
+  
+  export
   SVG_ANGLETYPE_GRAD : Bits16
   SVG_ANGLETYPE_GRAD = 4
 
-
-  public export
+  
+  export
   SVG_ANGLETYPE_RAD : Bits16
   SVG_ANGLETYPE_RAD = 3
 
-
-  public export
+  
+  export
   SVG_ANGLETYPE_UNKNOWN : Bits16
   SVG_ANGLETYPE_UNKNOWN = 0
 
-
-  public export
+  
+  export
   SVG_ANGLETYPE_UNSPECIFIED : Bits16
   SVG_ANGLETYPE_UNSPECIFIED = 1
 
-
+  
   export
   unitType : (obj : SVGAngle) -> JSIO Bits16
   unitType a = primJS $ SVGAngle.prim__unitType a
 
-
+  
   export
   value : SVGAngle -> Attribute True Prelude.id Double
   value v = fromPrim "SVGAngle.getvalue" prim__value prim__setValue v
 
-
+  
   export
   valueAsString : SVGAngle -> Attribute True Prelude.id String
   valueAsString v = fromPrim
@@ -117,7 +117,7 @@ namespace SVGAngle
                       prim__setValueAsString
                       v
 
-
+  
   export
   valueInSpecifiedUnits : SVGAngle -> Attribute True Prelude.id Double
   valueInSpecifiedUnits v = fromPrim
@@ -126,13 +126,13 @@ namespace SVGAngle
                               prim__setValueInSpecifiedUnits
                               v
 
-
+  
   export
   convertToSpecifiedUnits : (obj : SVGAngle) -> (unitType : Bits16) -> JSIO ()
   convertToSpecifiedUnits a b = primJS $
     SVGAngle.prim__convertToSpecifiedUnits a b
 
-
+  
   export
   newValueSpecifiedUnits :
        (obj : SVGAngle)
@@ -145,12 +145,12 @@ namespace SVGAngle
 
 
 namespace SVGAnimatedAngle
-
+  
   export
   animVal : (obj : SVGAnimatedAngle) -> JSIO SVGAngle
   animVal a = primJS $ SVGAnimatedAngle.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedAngle) -> JSIO SVGAngle
   baseVal a = primJS $ SVGAnimatedAngle.prim__baseVal a
@@ -158,13 +158,13 @@ namespace SVGAnimatedAngle
 
 
 namespace SVGAnimatedBoolean
-
+  
   export
   animVal : (obj : SVGAnimatedBoolean) -> JSIO Bool
   animVal a = tryJS "SVGAnimatedBoolean.animVal" $
     SVGAnimatedBoolean.prim__animVal a
 
-
+  
   export
   baseVal : SVGAnimatedBoolean -> Attribute True Prelude.id Bool
   baseVal v = fromPrim
@@ -176,12 +176,12 @@ namespace SVGAnimatedBoolean
 
 
 namespace SVGAnimatedEnumeration
-
+  
   export
   animVal : (obj : SVGAnimatedEnumeration) -> JSIO Bits16
   animVal a = primJS $ SVGAnimatedEnumeration.prim__animVal a
 
-
+  
   export
   baseVal : SVGAnimatedEnumeration -> Attribute True Prelude.id Bits16
   baseVal v = fromPrim
@@ -193,12 +193,12 @@ namespace SVGAnimatedEnumeration
 
 
 namespace SVGAnimatedInteger
-
+  
   export
   animVal : (obj : SVGAnimatedInteger) -> JSIO Int32
   animVal a = primJS $ SVGAnimatedInteger.prim__animVal a
 
-
+  
   export
   baseVal : SVGAnimatedInteger -> Attribute True Prelude.id Int32
   baseVal v = fromPrim
@@ -210,12 +210,12 @@ namespace SVGAnimatedInteger
 
 
 namespace SVGAnimatedLength
-
+  
   export
   animVal : (obj : SVGAnimatedLength) -> JSIO SVGLength
   animVal a = primJS $ SVGAnimatedLength.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedLength) -> JSIO SVGLength
   baseVal a = primJS $ SVGAnimatedLength.prim__baseVal a
@@ -223,12 +223,12 @@ namespace SVGAnimatedLength
 
 
 namespace SVGAnimatedLengthList
-
+  
   export
   animVal : (obj : SVGAnimatedLengthList) -> JSIO SVGLengthList
   animVal a = primJS $ SVGAnimatedLengthList.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedLengthList) -> JSIO SVGLengthList
   baseVal a = primJS $ SVGAnimatedLengthList.prim__baseVal a
@@ -236,12 +236,12 @@ namespace SVGAnimatedLengthList
 
 
 namespace SVGAnimatedNumber
-
+  
   export
   animVal : (obj : SVGAnimatedNumber) -> JSIO Double
   animVal a = primJS $ SVGAnimatedNumber.prim__animVal a
 
-
+  
   export
   baseVal : SVGAnimatedNumber -> Attribute True Prelude.id Double
   baseVal v = fromPrim
@@ -253,12 +253,12 @@ namespace SVGAnimatedNumber
 
 
 namespace SVGAnimatedNumberList
-
+  
   export
   animVal : (obj : SVGAnimatedNumberList) -> JSIO SVGNumberList
   animVal a = primJS $ SVGAnimatedNumberList.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedNumberList) -> JSIO SVGNumberList
   baseVal a = primJS $ SVGAnimatedNumberList.prim__baseVal a
@@ -266,14 +266,14 @@ namespace SVGAnimatedNumberList
 
 
 namespace SVGAnimatedPreserveAspectRatio
-
+  
   export
   animVal :
        (obj : SVGAnimatedPreserveAspectRatio)
     -> JSIO SVGPreserveAspectRatio
   animVal a = primJS $ SVGAnimatedPreserveAspectRatio.prim__animVal a
 
-
+  
   export
   baseVal :
        (obj : SVGAnimatedPreserveAspectRatio)
@@ -283,12 +283,12 @@ namespace SVGAnimatedPreserveAspectRatio
 
 
 namespace SVGAnimatedRect
-
+  
   export
   animVal : (obj : SVGAnimatedRect) -> JSIO DOMRectReadOnly
   animVal a = primJS $ SVGAnimatedRect.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedRect) -> JSIO DOMRect
   baseVal a = primJS $ SVGAnimatedRect.prim__baseVal a
@@ -296,12 +296,12 @@ namespace SVGAnimatedRect
 
 
 namespace SVGAnimatedString
-
+  
   export
   animVal : (obj : SVGAnimatedString) -> JSIO String
   animVal a = primJS $ SVGAnimatedString.prim__animVal a
 
-
+  
   export
   baseVal : SVGAnimatedString -> Attribute True Prelude.id String
   baseVal v = fromPrim
@@ -313,12 +313,12 @@ namespace SVGAnimatedString
 
 
 namespace SVGAnimatedTransformList
-
+  
   export
   animVal : (obj : SVGAnimatedTransformList) -> JSIO SVGTransformList
   animVal a = primJS $ SVGAnimatedTransformList.prim__animVal a
 
-
+  
   export
   baseVal : (obj : SVGAnimatedTransformList) -> JSIO SVGTransformList
   baseVal a = primJS $ SVGAnimatedTransformList.prim__baseVal a
@@ -326,17 +326,17 @@ namespace SVGAnimatedTransformList
 
 
 namespace SVGCircleElement
-
+  
   export
   cx : (obj : SVGCircleElement) -> JSIO SVGAnimatedLength
   cx a = primJS $ SVGCircleElement.prim__cx a
 
-
+  
   export
   cy : (obj : SVGCircleElement) -> JSIO SVGAnimatedLength
   cy a = primJS $ SVGCircleElement.prim__cy a
 
-
+  
   export
   r : (obj : SVGCircleElement) -> JSIO SVGAnimatedLength
   r a = primJS $ SVGCircleElement.prim__r a
@@ -346,54 +346,51 @@ namespace SVGCircleElement
 
 
 namespace SVGElement
-
+  
   export
   className :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGElement (Types t1)}
+       {auto _ : Cast t1 SVGElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedString
-  className a = primJS $ SVGElement.prim__className (up a)
+  className a = primJS $ SVGElement.prim__className (cast a)
 
-
+  
   export
   ownerSVGElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGElement (Types t1)}
+       {auto _ : Cast t1 SVGElement}
     -> (obj : t1)
     -> JSIO (Maybe SVGSVGElement)
   ownerSVGElement a = tryJS "SVGElement.ownerSVGElement" $
-    SVGElement.prim__ownerSVGElement (up a)
+    SVGElement.prim__ownerSVGElement (cast a)
 
-
+  
   export
   viewportElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGElement (Types t1)}
+       {auto _ : Cast t1 SVGElement}
     -> (obj : t1)
     -> JSIO (Maybe SVGElement)
   viewportElement a = tryJS "SVGElement.viewportElement" $
-    SVGElement.prim__viewportElement (up a)
+    SVGElement.prim__viewportElement (cast a)
 
 
 
 namespace SVGEllipseElement
-
+  
   export
   cx : (obj : SVGEllipseElement) -> JSIO SVGAnimatedLength
   cx a = primJS $ SVGEllipseElement.prim__cx a
 
-
+  
   export
   cy : (obj : SVGEllipseElement) -> JSIO SVGAnimatedLength
   cy a = primJS $ SVGEllipseElement.prim__cy a
 
-
+  
   export
   rx : (obj : SVGEllipseElement) -> JSIO SVGAnimatedLength
   rx a = primJS $ SVGEllipseElement.prim__rx a
 
-
+  
   export
   ry : (obj : SVGEllipseElement) -> JSIO SVGAnimatedLength
   ry a = primJS $ SVGEllipseElement.prim__ry a
@@ -401,22 +398,22 @@ namespace SVGEllipseElement
 
 
 namespace SVGForeignObjectElement
-
+  
   export
   height : (obj : SVGForeignObjectElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGForeignObjectElement.prim__height a
 
-
+  
   export
   width : (obj : SVGForeignObjectElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGForeignObjectElement.prim__width a
 
-
+  
   export
   x : (obj : SVGForeignObjectElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGForeignObjectElement.prim__x a
 
-
+  
   export
   y : (obj : SVGForeignObjectElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGForeignObjectElement.prim__y a
@@ -425,186 +422,165 @@ namespace SVGForeignObjectElement
 
 
 namespace SVGGeometryElement
-
+  
   export
   pathLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
+       {auto _ : Cast t1 SVGGeometryElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedNumber
-  pathLength a = primJS $ SVGGeometryElement.prim__pathLength (up a)
+  pathLength a = primJS $ SVGGeometryElement.prim__pathLength (cast a)
 
-
+  
   export
   getPointAtLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
+       {auto _ : Cast t1 SVGGeometryElement}
     -> (obj : t1)
     -> (distance : Double)
     -> JSIO DOMPoint
   getPointAtLength a b = primJS $
-    SVGGeometryElement.prim__getPointAtLength (up a) b
+    SVGGeometryElement.prim__getPointAtLength (cast a) b
 
-
+  
   export
   getTotalLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
+       {auto _ : Cast t1 SVGGeometryElement}
     -> (obj : t1)
     -> JSIO Double
-  getTotalLength a = primJS $ SVGGeometryElement.prim__getTotalLength (up a)
+  getTotalLength a = primJS $ SVGGeometryElement.prim__getTotalLength (cast a)
 
-
+  
   export
   isPointInFill' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
+       {auto _ : Cast t1 SVGGeometryElement}
+    -> {auto _ : Cast t2 DOMPointInit}
     -> (obj : t1)
     -> (point : Optional t2)
     -> JSIO Bool
   isPointInFill' a b = tryJS "SVGGeometryElement.isPointInFill'" $
-    SVGGeometryElement.prim__isPointInFill (up a) (optUp b)
-
+    SVGGeometryElement.prim__isPointInFill (cast a) (optUp b)
+  
   export
   isPointInFill :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
+       {auto _ : Cast t1 SVGGeometryElement}
     -> (obj : t1)
     -> JSIO Bool
   isPointInFill a = tryJS "SVGGeometryElement.isPointInFill" $
-    SVGGeometryElement.prim__isPointInFill (up a) undef
+    SVGGeometryElement.prim__isPointInFill (cast a) undef
 
-
+  
   export
   isPointInStroke' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
+       {auto _ : Cast t1 SVGGeometryElement}
+    -> {auto _ : Cast t2 DOMPointInit}
     -> (obj : t1)
     -> (point : Optional t2)
     -> JSIO Bool
   isPointInStroke' a b = tryJS "SVGGeometryElement.isPointInStroke'" $
-    SVGGeometryElement.prim__isPointInStroke (up a) (optUp b)
-
+    SVGGeometryElement.prim__isPointInStroke (cast a) (optUp b)
+  
   export
   isPointInStroke :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGeometryElement (Types t1)}
+       {auto _ : Cast t1 SVGGeometryElement}
     -> (obj : t1)
     -> JSIO Bool
   isPointInStroke a = tryJS "SVGGeometryElement.isPointInStroke" $
-    SVGGeometryElement.prim__isPointInStroke (up a) undef
+    SVGGeometryElement.prim__isPointInStroke (cast a) undef
 
 
 
 namespace SVGGradientElement
-
-  public export
+  
+  export
   SVG_SPREADMETHOD_PAD : Bits16
   SVG_SPREADMETHOD_PAD = 1
 
-
-  public export
+  
+  export
   SVG_SPREADMETHOD_REFLECT : Bits16
   SVG_SPREADMETHOD_REFLECT = 2
 
-
-  public export
+  
+  export
   SVG_SPREADMETHOD_REPEAT : Bits16
   SVG_SPREADMETHOD_REPEAT = 3
 
-
-  public export
+  
+  export
   SVG_SPREADMETHOD_UNKNOWN : Bits16
   SVG_SPREADMETHOD_UNKNOWN = 0
 
-
+  
   export
   gradientTransform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGradientElement (Types t1)}
+       {auto _ : Cast t1 SVGGradientElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedTransformList
   gradientTransform a = primJS $
-    SVGGradientElement.prim__gradientTransform (up a)
+    SVGGradientElement.prim__gradientTransform (cast a)
 
-
+  
   export
   gradientUnits :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGradientElement (Types t1)}
+       {auto _ : Cast t1 SVGGradientElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedEnumeration
-  gradientUnits a = primJS $ SVGGradientElement.prim__gradientUnits (up a)
+  gradientUnits a = primJS $ SVGGradientElement.prim__gradientUnits (cast a)
 
-
+  
   export
   spreadMethod :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGradientElement (Types t1)}
+       {auto _ : Cast t1 SVGGradientElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedEnumeration
-  spreadMethod a = primJS $ SVGGradientElement.prim__spreadMethod (up a)
+  spreadMethod a = primJS $ SVGGradientElement.prim__spreadMethod (cast a)
 
 
 
 namespace SVGGraphicsElement
-
+  
   export
   transform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGraphicsElement (Types t1)}
+       {auto _ : Cast t1 SVGGraphicsElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedTransformList
-  transform a = primJS $ SVGGraphicsElement.prim__transform (up a)
+  transform a = primJS $ SVGGraphicsElement.prim__transform (cast a)
 
-
+  
   export
   getBBox' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem SVGGraphicsElement (Types t1)}
-    -> {auto 0 _ : Elem SVGBoundingBoxOptions (Types t2)}
+       {auto _ : Cast t1 SVGGraphicsElement}
+    -> {auto _ : Cast t2 SVGBoundingBoxOptions}
     -> (obj : t1)
     -> (options : Optional t2)
     -> JSIO DOMRect
-  getBBox' a b = primJS $ SVGGraphicsElement.prim__getBBox (up a) (optUp b)
-
+  getBBox' a b = primJS $ SVGGraphicsElement.prim__getBBox (cast a) (optUp b)
+  
   export
-  getBBox :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGraphicsElement (Types t1)}
-    -> (obj : t1)
-    -> JSIO DOMRect
-  getBBox a = primJS $ SVGGraphicsElement.prim__getBBox (up a) undef
+  getBBox : {auto _ : Cast t1 SVGGraphicsElement} -> (obj : t1) -> JSIO DOMRect
+  getBBox a = primJS $ SVGGraphicsElement.prim__getBBox (cast a) undef
 
-
+  
   export
   getCTM :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGraphicsElement (Types t1)}
+       {auto _ : Cast t1 SVGGraphicsElement}
     -> (obj : t1)
     -> JSIO (Maybe DOMMatrix)
   getCTM a = tryJS "SVGGraphicsElement.getCTM" $
-    SVGGraphicsElement.prim__getCTM (up a)
+    SVGGraphicsElement.prim__getCTM (cast a)
 
-
+  
   export
   getScreenCTM :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGGraphicsElement (Types t1)}
+       {auto _ : Cast t1 SVGGraphicsElement}
     -> (obj : t1)
     -> JSIO (Maybe DOMMatrix)
   getScreenCTM a = tryJS "SVGGraphicsElement.getScreenCTM" $
-    SVGGraphicsElement.prim__getScreenCTM (up a)
+    SVGGraphicsElement.prim__getScreenCTM (cast a)
 
 
 
 namespace SVGImageElement
-
+  
   export
   crossOrigin : SVGImageElement -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
@@ -613,29 +589,29 @@ namespace SVGImageElement
                     prim__setCrossOrigin
                     v
 
-
+  
   export
   height : (obj : SVGImageElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGImageElement.prim__height a
 
-
+  
   export
   preserveAspectRatio :
        (obj : SVGImageElement)
     -> JSIO SVGAnimatedPreserveAspectRatio
   preserveAspectRatio a = primJS $ SVGImageElement.prim__preserveAspectRatio a
 
-
+  
   export
   width : (obj : SVGImageElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGImageElement.prim__width a
 
-
+  
   export
   x : (obj : SVGImageElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGImageElement.prim__x a
 
-
+  
   export
   y : (obj : SVGImageElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGImageElement.prim__y a
@@ -643,72 +619,72 @@ namespace SVGImageElement
 
 
 namespace SVGLength
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_CM : Bits16
   SVG_LENGTHTYPE_CM = 6
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_EMS : Bits16
   SVG_LENGTHTYPE_EMS = 3
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_EXS : Bits16
   SVG_LENGTHTYPE_EXS = 4
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_IN : Bits16
   SVG_LENGTHTYPE_IN = 8
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_MM : Bits16
   SVG_LENGTHTYPE_MM = 7
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_NUMBER : Bits16
   SVG_LENGTHTYPE_NUMBER = 1
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_PC : Bits16
   SVG_LENGTHTYPE_PC = 10
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_PERCENTAGE : Bits16
   SVG_LENGTHTYPE_PERCENTAGE = 2
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_PT : Bits16
   SVG_LENGTHTYPE_PT = 9
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_PX : Bits16
   SVG_LENGTHTYPE_PX = 5
 
-
-  public export
+  
+  export
   SVG_LENGTHTYPE_UNKNOWN : Bits16
   SVG_LENGTHTYPE_UNKNOWN = 0
 
-
+  
   export
   unitType : (obj : SVGLength) -> JSIO Bits16
   unitType a = primJS $ SVGLength.prim__unitType a
 
-
+  
   export
   value : SVGLength -> Attribute True Prelude.id Double
   value v = fromPrim "SVGLength.getvalue" prim__value prim__setValue v
 
-
+  
   export
   valueAsString : SVGLength -> Attribute True Prelude.id String
   valueAsString v = fromPrim
@@ -717,7 +693,7 @@ namespace SVGLength
                       prim__setValueAsString
                       v
 
-
+  
   export
   valueInSpecifiedUnits : SVGLength -> Attribute True Prelude.id Double
   valueInSpecifiedUnits v = fromPrim
@@ -726,13 +702,13 @@ namespace SVGLength
                               prim__setValueInSpecifiedUnits
                               v
 
-
+  
   export
   convertToSpecifiedUnits : (obj : SVGLength) -> (unitType : Bits16) -> JSIO ()
   convertToSpecifiedUnits a b = primJS $
     SVGLength.prim__convertToSpecifiedUnits a b
 
-
+  
   export
   newValueSpecifiedUnits :
        (obj : SVGLength)
@@ -745,7 +721,7 @@ namespace SVGLength
 
 
 namespace SVGLengthList
-
+  
   export
   set :
        (obj : SVGLengthList)
@@ -754,37 +730,37 @@ namespace SVGLengthList
     -> JSIO ()
   set a b c = primJS $ SVGLengthList.prim__set a b c
 
-
+  
   export
   length : (obj : SVGLengthList) -> JSIO Bits32
   length a = primJS $ SVGLengthList.prim__length a
 
-
+  
   export
   numberOfItems : (obj : SVGLengthList) -> JSIO Bits32
   numberOfItems a = primJS $ SVGLengthList.prim__numberOfItems a
 
-
+  
   export
   appendItem : (obj : SVGLengthList) -> (newItem : SVGLength) -> JSIO SVGLength
   appendItem a b = primJS $ SVGLengthList.prim__appendItem a b
 
-
+  
   export
   clear : (obj : SVGLengthList) -> JSIO ()
   clear a = primJS $ SVGLengthList.prim__clear a
 
-
+  
   export
   getItem : (obj : SVGLengthList) -> (index : Bits32) -> JSIO SVGLength
   getItem a b = primJS $ SVGLengthList.prim__getItem a b
 
-
+  
   export
   initialize : (obj : SVGLengthList) -> (newItem : SVGLength) -> JSIO SVGLength
   initialize a b = primJS $ SVGLengthList.prim__initialize a b
 
-
+  
   export
   insertItemBefore :
        (obj : SVGLengthList)
@@ -793,12 +769,12 @@ namespace SVGLengthList
     -> JSIO SVGLength
   insertItemBefore a b c = primJS $ SVGLengthList.prim__insertItemBefore a b c
 
-
+  
   export
   removeItem : (obj : SVGLengthList) -> (index : Bits32) -> JSIO SVGLength
   removeItem a b = primJS $ SVGLengthList.prim__removeItem a b
 
-
+  
   export
   replaceItem :
        (obj : SVGLengthList)
@@ -810,22 +786,22 @@ namespace SVGLengthList
 
 
 namespace SVGLineElement
-
+  
   export
   x1 : (obj : SVGLineElement) -> JSIO SVGAnimatedLength
   x1 a = primJS $ SVGLineElement.prim__x1 a
 
-
+  
   export
   x2 : (obj : SVGLineElement) -> JSIO SVGAnimatedLength
   x2 a = primJS $ SVGLineElement.prim__x2 a
 
-
+  
   export
   y1 : (obj : SVGLineElement) -> JSIO SVGAnimatedLength
   y1 a = primJS $ SVGLineElement.prim__y1 a
 
-
+  
   export
   y2 : (obj : SVGLineElement) -> JSIO SVGAnimatedLength
   y2 a = primJS $ SVGLineElement.prim__y2 a
@@ -833,22 +809,22 @@ namespace SVGLineElement
 
 
 namespace SVGLinearGradientElement
-
+  
   export
   x1 : (obj : SVGLinearGradientElement) -> JSIO SVGAnimatedLength
   x1 a = primJS $ SVGLinearGradientElement.prim__x1 a
 
-
+  
   export
   x2 : (obj : SVGLinearGradientElement) -> JSIO SVGAnimatedLength
   x2 a = primJS $ SVGLinearGradientElement.prim__x2 a
 
-
+  
   export
   y1 : (obj : SVGLinearGradientElement) -> JSIO SVGAnimatedLength
   y1 a = primJS $ SVGLinearGradientElement.prim__y1 a
 
-
+  
   export
   y2 : (obj : SVGLinearGradientElement) -> JSIO SVGAnimatedLength
   y2 a = primJS $ SVGLinearGradientElement.prim__y2 a
@@ -856,52 +832,52 @@ namespace SVGLinearGradientElement
 
 
 namespace SVGMarkerElement
-
-  public export
+  
+  export
   SVG_MARKERUNITS_STROKEWIDTH : Bits16
   SVG_MARKERUNITS_STROKEWIDTH = 2
 
-
-  public export
+  
+  export
   SVG_MARKERUNITS_UNKNOWN : Bits16
   SVG_MARKERUNITS_UNKNOWN = 0
 
-
-  public export
+  
+  export
   SVG_MARKERUNITS_USERSPACEONUSE : Bits16
   SVG_MARKERUNITS_USERSPACEONUSE = 1
 
-
-  public export
+  
+  export
   SVG_MARKER_ORIENT_ANGLE : Bits16
   SVG_MARKER_ORIENT_ANGLE = 2
 
-
-  public export
+  
+  export
   SVG_MARKER_ORIENT_AUTO : Bits16
   SVG_MARKER_ORIENT_AUTO = 1
 
-
-  public export
+  
+  export
   SVG_MARKER_ORIENT_UNKNOWN : Bits16
   SVG_MARKER_ORIENT_UNKNOWN = 0
 
-
+  
   export
   markerHeight : (obj : SVGMarkerElement) -> JSIO SVGAnimatedLength
   markerHeight a = primJS $ SVGMarkerElement.prim__markerHeight a
 
-
+  
   export
   markerUnits : (obj : SVGMarkerElement) -> JSIO SVGAnimatedEnumeration
   markerUnits a = primJS $ SVGMarkerElement.prim__markerUnits a
 
-
+  
   export
   markerWidth : (obj : SVGMarkerElement) -> JSIO SVGAnimatedLength
   markerWidth a = primJS $ SVGMarkerElement.prim__markerWidth a
 
-
+  
   export
   orient : SVGMarkerElement -> Attribute True Prelude.id String
   orient v = fromPrim
@@ -910,32 +886,32 @@ namespace SVGMarkerElement
                prim__setOrient
                v
 
-
+  
   export
   orientAngle : (obj : SVGMarkerElement) -> JSIO SVGAnimatedAngle
   orientAngle a = primJS $ SVGMarkerElement.prim__orientAngle a
 
-
+  
   export
   orientType : (obj : SVGMarkerElement) -> JSIO SVGAnimatedEnumeration
   orientType a = primJS $ SVGMarkerElement.prim__orientType a
 
-
+  
   export
   refX : (obj : SVGMarkerElement) -> JSIO SVGAnimatedLength
   refX a = primJS $ SVGMarkerElement.prim__refX a
 
-
+  
   export
   refY : (obj : SVGMarkerElement) -> JSIO SVGAnimatedLength
   refY a = primJS $ SVGMarkerElement.prim__refY a
 
-
+  
   export
   setOrientToAngle : (obj : SVGMarkerElement) -> (angle : SVGAngle) -> JSIO ()
   setOrientToAngle a b = primJS $ SVGMarkerElement.prim__setOrientToAngle a b
 
-
+  
   export
   setOrientToAuto : (obj : SVGMarkerElement) -> JSIO ()
   setOrientToAuto a = primJS $ SVGMarkerElement.prim__setOrientToAuto a
@@ -944,7 +920,7 @@ namespace SVGMarkerElement
 
 
 namespace SVGNumber
-
+  
   export
   value : SVGNumber -> Attribute True Prelude.id Double
   value v = fromPrim "SVGNumber.getvalue" prim__value prim__setValue v
@@ -952,7 +928,7 @@ namespace SVGNumber
 
 
 namespace SVGNumberList
-
+  
   export
   set :
        (obj : SVGNumberList)
@@ -961,37 +937,37 @@ namespace SVGNumberList
     -> JSIO ()
   set a b c = primJS $ SVGNumberList.prim__set a b c
 
-
+  
   export
   length : (obj : SVGNumberList) -> JSIO Bits32
   length a = primJS $ SVGNumberList.prim__length a
 
-
+  
   export
   numberOfItems : (obj : SVGNumberList) -> JSIO Bits32
   numberOfItems a = primJS $ SVGNumberList.prim__numberOfItems a
 
-
+  
   export
   appendItem : (obj : SVGNumberList) -> (newItem : SVGNumber) -> JSIO SVGNumber
   appendItem a b = primJS $ SVGNumberList.prim__appendItem a b
 
-
+  
   export
   clear : (obj : SVGNumberList) -> JSIO ()
   clear a = primJS $ SVGNumberList.prim__clear a
 
-
+  
   export
   getItem : (obj : SVGNumberList) -> (index : Bits32) -> JSIO SVGNumber
   getItem a b = primJS $ SVGNumberList.prim__getItem a b
 
-
+  
   export
   initialize : (obj : SVGNumberList) -> (newItem : SVGNumber) -> JSIO SVGNumber
   initialize a b = primJS $ SVGNumberList.prim__initialize a b
 
-
+  
   export
   insertItemBefore :
        (obj : SVGNumberList)
@@ -1000,12 +976,12 @@ namespace SVGNumberList
     -> JSIO SVGNumber
   insertItemBefore a b c = primJS $ SVGNumberList.prim__insertItemBefore a b c
 
-
+  
   export
   removeItem : (obj : SVGNumberList) -> (index : Bits32) -> JSIO SVGNumber
   removeItem a b = primJS $ SVGNumberList.prim__removeItem a b
 
-
+  
   export
   replaceItem :
        (obj : SVGNumberList)
@@ -1018,37 +994,37 @@ namespace SVGNumberList
 
 
 namespace SVGPatternElement
-
+  
   export
   height : (obj : SVGPatternElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGPatternElement.prim__height a
 
-
+  
   export
   patternContentUnits : (obj : SVGPatternElement) -> JSIO SVGAnimatedEnumeration
   patternContentUnits a = primJS $ SVGPatternElement.prim__patternContentUnits a
 
-
+  
   export
   patternTransform : (obj : SVGPatternElement) -> JSIO SVGAnimatedTransformList
   patternTransform a = primJS $ SVGPatternElement.prim__patternTransform a
 
-
+  
   export
   patternUnits : (obj : SVGPatternElement) -> JSIO SVGAnimatedEnumeration
   patternUnits a = primJS $ SVGPatternElement.prim__patternUnits a
 
-
+  
   export
   width : (obj : SVGPatternElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGPatternElement.prim__width a
 
-
+  
   export
   x : (obj : SVGPatternElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGPatternElement.prim__x a
 
-
+  
   export
   y : (obj : SVGPatternElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGPatternElement.prim__y a
@@ -1056,7 +1032,7 @@ namespace SVGPatternElement
 
 
 namespace SVGPointList
-
+  
   export
   set :
        (obj : SVGPointList)
@@ -1065,37 +1041,37 @@ namespace SVGPointList
     -> JSIO ()
   set a b c = primJS $ SVGPointList.prim__set a b c
 
-
+  
   export
   length : (obj : SVGPointList) -> JSIO Bits32
   length a = primJS $ SVGPointList.prim__length a
 
-
+  
   export
   numberOfItems : (obj : SVGPointList) -> JSIO Bits32
   numberOfItems a = primJS $ SVGPointList.prim__numberOfItems a
 
-
+  
   export
   appendItem : (obj : SVGPointList) -> (newItem : DOMPoint) -> JSIO DOMPoint
   appendItem a b = primJS $ SVGPointList.prim__appendItem a b
 
-
+  
   export
   clear : (obj : SVGPointList) -> JSIO ()
   clear a = primJS $ SVGPointList.prim__clear a
 
-
+  
   export
   getItem : (obj : SVGPointList) -> (index : Bits32) -> JSIO DOMPoint
   getItem a b = primJS $ SVGPointList.prim__getItem a b
 
-
+  
   export
   initialize : (obj : SVGPointList) -> (newItem : DOMPoint) -> JSIO DOMPoint
   initialize a b = primJS $ SVGPointList.prim__initialize a b
 
-
+  
   export
   insertItemBefore :
        (obj : SVGPointList)
@@ -1104,12 +1080,12 @@ namespace SVGPointList
     -> JSIO DOMPoint
   insertItemBefore a b c = primJS $ SVGPointList.prim__insertItemBefore a b c
 
-
+  
   export
   removeItem : (obj : SVGPointList) -> (index : Bits32) -> JSIO DOMPoint
   removeItem a b = primJS $ SVGPointList.prim__removeItem a b
 
-
+  
   export
   replaceItem :
        (obj : SVGPointList)
@@ -1123,77 +1099,77 @@ namespace SVGPointList
 
 
 namespace SVGPreserveAspectRatio
-
-  public export
+  
+  export
   SVG_MEETORSLICE_MEET : Bits16
   SVG_MEETORSLICE_MEET = 1
 
-
-  public export
+  
+  export
   SVG_MEETORSLICE_SLICE : Bits16
   SVG_MEETORSLICE_SLICE = 2
 
-
-  public export
+  
+  export
   SVG_MEETORSLICE_UNKNOWN : Bits16
   SVG_MEETORSLICE_UNKNOWN = 0
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_NONE : Bits16
   SVG_PRESERVEASPECTRATIO_NONE = 1
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_UNKNOWN : Bits16
   SVG_PRESERVEASPECTRATIO_UNKNOWN = 0
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMAXYMAX : Bits16
   SVG_PRESERVEASPECTRATIO_XMAXYMAX = 10
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMAXYMID : Bits16
   SVG_PRESERVEASPECTRATIO_XMAXYMID = 7
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMAXYMIN : Bits16
   SVG_PRESERVEASPECTRATIO_XMAXYMIN = 4
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMIDYMAX : Bits16
   SVG_PRESERVEASPECTRATIO_XMIDYMAX = 9
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMIDYMID : Bits16
   SVG_PRESERVEASPECTRATIO_XMIDYMID = 6
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMIDYMIN : Bits16
   SVG_PRESERVEASPECTRATIO_XMIDYMIN = 3
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMINYMAX : Bits16
   SVG_PRESERVEASPECTRATIO_XMINYMAX = 8
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMINYMID : Bits16
   SVG_PRESERVEASPECTRATIO_XMINYMID = 5
 
-
-  public export
+  
+  export
   SVG_PRESERVEASPECTRATIO_XMINYMIN : Bits16
   SVG_PRESERVEASPECTRATIO_XMINYMIN = 2
 
-
+  
   export
   align : SVGPreserveAspectRatio -> Attribute True Prelude.id Bits16
   align v = fromPrim
@@ -1202,7 +1178,7 @@ namespace SVGPreserveAspectRatio
               prim__setAlign
               v
 
-
+  
   export
   meetOrSlice : SVGPreserveAspectRatio -> Attribute True Prelude.id Bits16
   meetOrSlice v = fromPrim
@@ -1214,32 +1190,32 @@ namespace SVGPreserveAspectRatio
 
 
 namespace SVGRadialGradientElement
-
+  
   export
   cx : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   cx a = primJS $ SVGRadialGradientElement.prim__cx a
 
-
+  
   export
   cy : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   cy a = primJS $ SVGRadialGradientElement.prim__cy a
 
-
+  
   export
   fr : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   fr a = primJS $ SVGRadialGradientElement.prim__fr a
 
-
+  
   export
   fx : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   fx a = primJS $ SVGRadialGradientElement.prim__fx a
 
-
+  
   export
   fy : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   fy a = primJS $ SVGRadialGradientElement.prim__fy a
 
-
+  
   export
   r : (obj : SVGRadialGradientElement) -> JSIO SVGAnimatedLength
   r a = primJS $ SVGRadialGradientElement.prim__r a
@@ -1247,32 +1223,32 @@ namespace SVGRadialGradientElement
 
 
 namespace SVGRectElement
-
+  
   export
   height : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGRectElement.prim__height a
 
-
+  
   export
   rx : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   rx a = primJS $ SVGRectElement.prim__rx a
 
-
+  
   export
   ry : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   ry a = primJS $ SVGRectElement.prim__ry a
 
-
+  
   export
   width : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGRectElement.prim__width a
 
-
+  
   export
   x : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGRectElement.prim__x a
 
-
+  
   export
   y : (obj : SVGRectElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGRectElement.prim__y a
@@ -1280,7 +1256,7 @@ namespace SVGRectElement
 
 
 namespace SVGSVGElement
-
+  
   export
   currentScale : SVGSVGElement -> Attribute True Prelude.id Double
   currentScale v = fromPrim
@@ -1289,154 +1265,145 @@ namespace SVGSVGElement
                      prim__setCurrentScale
                      v
 
-
+  
   export
   currentTranslate : (obj : SVGSVGElement) -> JSIO DOMPointReadOnly
   currentTranslate a = primJS $ SVGSVGElement.prim__currentTranslate a
 
-
+  
   export
   height : (obj : SVGSVGElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGSVGElement.prim__height a
 
-
+  
   export
   width : (obj : SVGSVGElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGSVGElement.prim__width a
 
-
+  
   export
   x : (obj : SVGSVGElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGSVGElement.prim__x a
 
-
+  
   export
   y : (obj : SVGSVGElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGSVGElement.prim__y a
 
-
+  
   export
   checkEnclosure :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem SVGElement (Types t2)}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t3)}
+       {auto _ : Cast t2 SVGElement}
+    -> {auto _ : Cast t3 DOMRectReadOnly}
     -> (obj : SVGSVGElement)
     -> (element : t2)
     -> (rect : t3)
     -> JSIO Bool
   checkEnclosure a b c = tryJS "SVGSVGElement.checkEnclosure" $
-    SVGSVGElement.prim__checkEnclosure a (up b) (up c)
+    SVGSVGElement.prim__checkEnclosure a (cast b) (cast c)
 
-
+  
   export
   checkIntersection :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem SVGElement (Types t2)}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t3)}
+       {auto _ : Cast t2 SVGElement}
+    -> {auto _ : Cast t3 DOMRectReadOnly}
     -> (obj : SVGSVGElement)
     -> (element : t2)
     -> (rect : t3)
     -> JSIO Bool
   checkIntersection a b c = tryJS "SVGSVGElement.checkIntersection" $
-    SVGSVGElement.prim__checkIntersection a (up b) (up c)
+    SVGSVGElement.prim__checkIntersection a (cast b) (cast c)
 
-
+  
   export
   createSVGAngle : (obj : SVGSVGElement) -> JSIO SVGAngle
   createSVGAngle a = primJS $ SVGSVGElement.prim__createSVGAngle a
 
-
+  
   export
   createSVGLength : (obj : SVGSVGElement) -> JSIO SVGLength
   createSVGLength a = primJS $ SVGSVGElement.prim__createSVGLength a
 
-
+  
   export
   createSVGMatrix : (obj : SVGSVGElement) -> JSIO DOMMatrix
   createSVGMatrix a = primJS $ SVGSVGElement.prim__createSVGMatrix a
 
-
+  
   export
   createSVGNumber : (obj : SVGSVGElement) -> JSIO SVGNumber
   createSVGNumber a = primJS $ SVGSVGElement.prim__createSVGNumber a
 
-
+  
   export
   createSVGPoint : (obj : SVGSVGElement) -> JSIO DOMPoint
   createSVGPoint a = primJS $ SVGSVGElement.prim__createSVGPoint a
 
-
+  
   export
   createSVGRect : (obj : SVGSVGElement) -> JSIO DOMRect
   createSVGRect a = primJS $ SVGSVGElement.prim__createSVGRect a
 
-
+  
   export
   createSVGTransformFromMatrix' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrix2DInit}
     -> (obj : SVGSVGElement)
     -> (matrix : Optional t2)
     -> JSIO SVGTransform
   createSVGTransformFromMatrix' a b = primJS $
     SVGSVGElement.prim__createSVGTransformFromMatrix a (optUp b)
-
+  
   export
   createSVGTransformFromMatrix : (obj : SVGSVGElement) -> JSIO SVGTransform
   createSVGTransformFromMatrix a = primJS $
     SVGSVGElement.prim__createSVGTransformFromMatrix a undef
 
-
+  
   export
   createSVGTransform : (obj : SVGSVGElement) -> JSIO SVGTransform
   createSVGTransform a = primJS $ SVGSVGElement.prim__createSVGTransform a
 
-
+  
   export
   deselectAll : (obj : SVGSVGElement) -> JSIO ()
   deselectAll a = primJS $ SVGSVGElement.prim__deselectAll a
 
-
+  
   export
   forceRedraw : (obj : SVGSVGElement) -> JSIO ()
   forceRedraw a = primJS $ SVGSVGElement.prim__forceRedraw a
 
-
+  
   export
   getElementById : (obj : SVGSVGElement) -> (elementId : String) -> JSIO Element
   getElementById a b = primJS $ SVGSVGElement.prim__getElementById a b
 
-
+  
   export
   getEnclosureList :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t2)}
-    -> {auto 0 _ : Elem SVGElement (Types t3)}
+       {auto _ : Cast t2 DOMRectReadOnly}
+    -> {auto _ : Cast t3 SVGElement}
     -> (obj : SVGSVGElement)
     -> (rect : t2)
     -> (referenceElement : Maybe t3)
     -> JSIO NodeList
   getEnclosureList a b c = primJS $
-    SVGSVGElement.prim__getEnclosureList a (up b) (mayUp c)
+    SVGSVGElement.prim__getEnclosureList a (cast b) (mayUp c)
 
-
+  
   export
   getIntersectionList :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem DOMRectReadOnly (Types t2)}
-    -> {auto 0 _ : Elem SVGElement (Types t3)}
+       {auto _ : Cast t2 DOMRectReadOnly}
+    -> {auto _ : Cast t3 SVGElement}
     -> (obj : SVGSVGElement)
     -> (rect : t2)
     -> (referenceElement : Maybe t3)
     -> JSIO NodeList
   getIntersectionList a b c = primJS $
-    SVGSVGElement.prim__getIntersectionList a (up b) (mayUp c)
+    SVGSVGElement.prim__getIntersectionList a (cast b) (mayUp c)
 
-
+  
   export
   suspendRedraw :
        (obj : SVGSVGElement)
@@ -1444,12 +1411,12 @@ namespace SVGSVGElement
     -> JSIO Bits32
   suspendRedraw a b = primJS $ SVGSVGElement.prim__suspendRedraw a b
 
-
+  
   export
   unsuspendRedrawAll : (obj : SVGSVGElement) -> JSIO ()
   unsuspendRedrawAll a = primJS $ SVGSVGElement.prim__unsuspendRedrawAll a
 
-
+  
   export
   unsuspendRedraw :
        (obj : SVGSVGElement)
@@ -1460,7 +1427,7 @@ namespace SVGSVGElement
 
 
 namespace SVGScriptElement
-
+  
   export
   crossOrigin : SVGScriptElement -> Attribute False Maybe String
   crossOrigin v = fromNullablePrim
@@ -1469,7 +1436,7 @@ namespace SVGScriptElement
                     prim__setCrossOrigin
                     v
 
-
+  
   export
   type : SVGScriptElement -> Attribute True Prelude.id String
   type v = fromPrim "SVGScriptElement.gettype" prim__type prim__setType v
@@ -1477,7 +1444,7 @@ namespace SVGScriptElement
 
 
 namespace SVGStopElement
-
+  
   export
   offset : (obj : SVGStopElement) -> JSIO SVGAnimatedNumber
   offset a = primJS $ SVGStopElement.prim__offset a
@@ -1485,7 +1452,7 @@ namespace SVGStopElement
 
 
 namespace SVGStringList
-
+  
   export
   set :
        (obj : SVGStringList)
@@ -1494,37 +1461,37 @@ namespace SVGStringList
     -> JSIO ()
   set a b c = primJS $ SVGStringList.prim__set a b c
 
-
+  
   export
   length : (obj : SVGStringList) -> JSIO Bits32
   length a = primJS $ SVGStringList.prim__length a
 
-
+  
   export
   numberOfItems : (obj : SVGStringList) -> JSIO Bits32
   numberOfItems a = primJS $ SVGStringList.prim__numberOfItems a
 
-
+  
   export
   appendItem : (obj : SVGStringList) -> (newItem : String) -> JSIO String
   appendItem a b = primJS $ SVGStringList.prim__appendItem a b
 
-
+  
   export
   clear : (obj : SVGStringList) -> JSIO ()
   clear a = primJS $ SVGStringList.prim__clear a
 
-
+  
   export
   getItem : (obj : SVGStringList) -> (index : Bits32) -> JSIO String
   getItem a b = primJS $ SVGStringList.prim__getItem a b
 
-
+  
   export
   initialize : (obj : SVGStringList) -> (newItem : String) -> JSIO String
   initialize a b = primJS $ SVGStringList.prim__initialize a b
 
-
+  
   export
   insertItemBefore :
        (obj : SVGStringList)
@@ -1533,12 +1500,12 @@ namespace SVGStringList
     -> JSIO String
   insertItemBefore a b c = primJS $ SVGStringList.prim__insertItemBefore a b c
 
-
+  
   export
   removeItem : (obj : SVGStringList) -> (index : Bits32) -> JSIO String
   removeItem a b = primJS $ SVGStringList.prim__removeItem a b
 
-
+  
   export
   replaceItem :
        (obj : SVGStringList)
@@ -1550,17 +1517,17 @@ namespace SVGStringList
 
 
 namespace SVGStyleElement
-
+  
   export
   media : SVGStyleElement -> Attribute True Prelude.id String
   media v = fromPrim "SVGStyleElement.getmedia" prim__media prim__setMedia v
 
-
+  
   export
   title : SVGStyleElement -> Attribute True Prelude.id String
   title v = fromPrim "SVGStyleElement.gettitle" prim__title prim__setTitle v
 
-
+  
   export
   type : SVGStyleElement -> Attribute True Prelude.id String
   type v = fromPrim "SVGStyleElement.gettype" prim__type prim__setType v
@@ -1571,194 +1538,181 @@ namespace SVGStyleElement
 
 
 namespace SVGTextContentElement
-
-  public export
+  
+  export
   LENGTHADJUST_SPACING : Bits16
   LENGTHADJUST_SPACING = 1
 
-
-  public export
+  
+  export
   LENGTHADJUST_SPACINGANDGLYPHS : Bits16
   LENGTHADJUST_SPACINGANDGLYPHS = 2
 
-
-  public export
+  
+  export
   LENGTHADJUST_UNKNOWN : Bits16
   LENGTHADJUST_UNKNOWN = 0
 
-
+  
   export
   lengthAdjust :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedEnumeration
-  lengthAdjust a = primJS $ SVGTextContentElement.prim__lengthAdjust (up a)
+  lengthAdjust a = primJS $ SVGTextContentElement.prim__lengthAdjust (cast a)
 
-
+  
   export
   textLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedLength
-  textLength a = primJS $ SVGTextContentElement.prim__textLength (up a)
+  textLength a = primJS $ SVGTextContentElement.prim__textLength (cast a)
 
-
+  
   export
   getCharNumAtPosition' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
-    -> {auto 0 _ : Elem DOMPointInit (Types t2)}
+       {auto _ : Cast t1 SVGTextContentElement}
+    -> {auto _ : Cast t2 DOMPointInit}
     -> (obj : t1)
     -> (point : Optional t2)
     -> JSIO Int32
   getCharNumAtPosition' a b = primJS $
-    SVGTextContentElement.prim__getCharNumAtPosition (up a) (optUp b)
-
+    SVGTextContentElement.prim__getCharNumAtPosition (cast a) (optUp b)
+  
   export
   getCharNumAtPosition :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> JSIO Int32
   getCharNumAtPosition a = primJS $
-    SVGTextContentElement.prim__getCharNumAtPosition (up a) undef
+    SVGTextContentElement.prim__getCharNumAtPosition (cast a) undef
 
-
+  
   export
   getComputedTextLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> JSIO Double
   getComputedTextLength a = primJS $
-    SVGTextContentElement.prim__getComputedTextLength (up a)
+    SVGTextContentElement.prim__getComputedTextLength (cast a)
 
-
+  
   export
   getEndPositionOfChar :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> JSIO DOMPoint
   getEndPositionOfChar a b = primJS $
-    SVGTextContentElement.prim__getEndPositionOfChar (up a) b
+    SVGTextContentElement.prim__getEndPositionOfChar (cast a) b
 
-
+  
   export
   getExtentOfChar :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> JSIO DOMRect
   getExtentOfChar a b = primJS $
-    SVGTextContentElement.prim__getExtentOfChar (up a) b
+    SVGTextContentElement.prim__getExtentOfChar (cast a) b
 
-
+  
   export
   getNumberOfChars :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> JSIO Int32
   getNumberOfChars a = primJS $
-    SVGTextContentElement.prim__getNumberOfChars (up a)
+    SVGTextContentElement.prim__getNumberOfChars (cast a)
 
-
+  
   export
   getRotationOfChar :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> JSIO Double
   getRotationOfChar a b = primJS $
-    SVGTextContentElement.prim__getRotationOfChar (up a) b
+    SVGTextContentElement.prim__getRotationOfChar (cast a) b
 
-
+  
   export
   getStartPositionOfChar :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> JSIO DOMPoint
   getStartPositionOfChar a b = primJS $
-    SVGTextContentElement.prim__getStartPositionOfChar (up a) b
+    SVGTextContentElement.prim__getStartPositionOfChar (cast a) b
 
-
+  
   export
   getSubStringLength :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> (nchars : Bits32)
     -> JSIO Double
   getSubStringLength a b c = primJS $
-    SVGTextContentElement.prim__getSubStringLength (up a) b c
+    SVGTextContentElement.prim__getSubStringLength (cast a) b c
 
-
+  
   export
   selectSubString :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextContentElement (Types t1)}
+       {auto _ : Cast t1 SVGTextContentElement}
     -> (obj : t1)
     -> (charnum : Bits32)
     -> (nchars : Bits32)
     -> JSIO ()
   selectSubString a b c = primJS $
-    SVGTextContentElement.prim__selectSubString (up a) b c
+    SVGTextContentElement.prim__selectSubString (cast a) b c
 
 
 
 
 namespace SVGTextPathElement
-
-  public export
+  
+  export
   TEXTPATH_METHODTYPE_ALIGN : Bits16
   TEXTPATH_METHODTYPE_ALIGN = 1
 
-
-  public export
+  
+  export
   TEXTPATH_METHODTYPE_STRETCH : Bits16
   TEXTPATH_METHODTYPE_STRETCH = 2
 
-
-  public export
+  
+  export
   TEXTPATH_METHODTYPE_UNKNOWN : Bits16
   TEXTPATH_METHODTYPE_UNKNOWN = 0
 
-
-  public export
+  
+  export
   TEXTPATH_SPACINGTYPE_AUTO : Bits16
   TEXTPATH_SPACINGTYPE_AUTO = 1
 
-
-  public export
+  
+  export
   TEXTPATH_SPACINGTYPE_EXACT : Bits16
   TEXTPATH_SPACINGTYPE_EXACT = 2
 
-
-  public export
+  
+  export
   TEXTPATH_SPACINGTYPE_UNKNOWN : Bits16
   TEXTPATH_SPACINGTYPE_UNKNOWN = 0
 
-
+  
   export
   method : (obj : SVGTextPathElement) -> JSIO SVGAnimatedEnumeration
   method a = primJS $ SVGTextPathElement.prim__method a
 
-
+  
   export
   spacing : (obj : SVGTextPathElement) -> JSIO SVGAnimatedEnumeration
   spacing a = primJS $ SVGTextPathElement.prim__spacing a
 
-
+  
   export
   startOffset : (obj : SVGTextPathElement) -> JSIO SVGAnimatedLength
   startOffset a = primJS $ SVGTextPathElement.prim__startOffset a
@@ -1766,120 +1720,114 @@ namespace SVGTextPathElement
 
 
 namespace SVGTextPositioningElement
-
+  
   export
   dx :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextPositioningElement (Types t1)}
+       {auto _ : Cast t1 SVGTextPositioningElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedLengthList
-  dx a = primJS $ SVGTextPositioningElement.prim__dx (up a)
+  dx a = primJS $ SVGTextPositioningElement.prim__dx (cast a)
 
-
+  
   export
   dy :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextPositioningElement (Types t1)}
+       {auto _ : Cast t1 SVGTextPositioningElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedLengthList
-  dy a = primJS $ SVGTextPositioningElement.prim__dy (up a)
+  dy a = primJS $ SVGTextPositioningElement.prim__dy (cast a)
 
-
+  
   export
   rotate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextPositioningElement (Types t1)}
+       {auto _ : Cast t1 SVGTextPositioningElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedNumberList
-  rotate a = primJS $ SVGTextPositioningElement.prim__rotate (up a)
+  rotate a = primJS $ SVGTextPositioningElement.prim__rotate (cast a)
 
-
+  
   export
   x :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextPositioningElement (Types t1)}
+       {auto _ : Cast t1 SVGTextPositioningElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedLengthList
-  x a = primJS $ SVGTextPositioningElement.prim__x (up a)
+  x a = primJS $ SVGTextPositioningElement.prim__x (cast a)
 
-
+  
   export
   y :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTextPositioningElement (Types t1)}
+       {auto _ : Cast t1 SVGTextPositioningElement}
     -> (obj : t1)
     -> JSIO SVGAnimatedLengthList
-  y a = primJS $ SVGTextPositioningElement.prim__y (up a)
+  y a = primJS $ SVGTextPositioningElement.prim__y (cast a)
 
 
 
 
 namespace SVGTransform
-
-  public export
+  
+  export
   SVG_TRANSFORM_MATRIX : Bits16
   SVG_TRANSFORM_MATRIX = 1
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_ROTATE : Bits16
   SVG_TRANSFORM_ROTATE = 4
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_SCALE : Bits16
   SVG_TRANSFORM_SCALE = 3
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_SKEWX : Bits16
   SVG_TRANSFORM_SKEWX = 5
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_SKEWY : Bits16
   SVG_TRANSFORM_SKEWY = 6
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_TRANSLATE : Bits16
   SVG_TRANSFORM_TRANSLATE = 2
 
-
-  public export
+  
+  export
   SVG_TRANSFORM_UNKNOWN : Bits16
   SVG_TRANSFORM_UNKNOWN = 0
 
-
+  
   export
   angle : (obj : SVGTransform) -> JSIO Double
   angle a = primJS $ SVGTransform.prim__angle a
 
-
+  
   export
   matrix : (obj : SVGTransform) -> JSIO DOMMatrix
   matrix a = primJS $ SVGTransform.prim__matrix a
 
-
+  
   export
   type : (obj : SVGTransform) -> JSIO Bits16
   type a = primJS $ SVGTransform.prim__type a
 
-
+  
   export
   setMatrix' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrix2DInit}
     -> (obj : SVGTransform)
     -> (matrix : Optional t2)
     -> JSIO ()
   setMatrix' a b = primJS $ SVGTransform.prim__setMatrix a (optUp b)
-
+  
   export
   setMatrix : (obj : SVGTransform) -> JSIO ()
   setMatrix a = primJS $ SVGTransform.prim__setMatrix a undef
 
-
+  
   export
   setRotate :
        (obj : SVGTransform)
@@ -1889,22 +1837,22 @@ namespace SVGTransform
     -> JSIO ()
   setRotate a b c d = primJS $ SVGTransform.prim__setRotate a b c d
 
-
+  
   export
   setScale : (obj : SVGTransform) -> (sx : Double) -> (sy : Double) -> JSIO ()
   setScale a b c = primJS $ SVGTransform.prim__setScale a b c
 
-
+  
   export
   setSkewX : (obj : SVGTransform) -> (angle : Double) -> JSIO ()
   setSkewX a b = primJS $ SVGTransform.prim__setSkewX a b
 
-
+  
   export
   setSkewY : (obj : SVGTransform) -> (angle : Double) -> JSIO ()
   setSkewY a b = primJS $ SVGTransform.prim__setSkewY a b
 
-
+  
   export
   setTranslate :
        (obj : SVGTransform)
@@ -1916,7 +1864,7 @@ namespace SVGTransform
 
 
 namespace SVGTransformList
-
+  
   export
   set :
        (obj : SVGTransformList)
@@ -1925,17 +1873,17 @@ namespace SVGTransformList
     -> JSIO ()
   set a b c = primJS $ SVGTransformList.prim__set a b c
 
-
+  
   export
   length : (obj : SVGTransformList) -> JSIO Bits32
   length a = primJS $ SVGTransformList.prim__length a
 
-
+  
   export
   numberOfItems : (obj : SVGTransformList) -> JSIO Bits32
   numberOfItems a = primJS $ SVGTransformList.prim__numberOfItems a
 
-
+  
   export
   appendItem :
        (obj : SVGTransformList)
@@ -1943,39 +1891,38 @@ namespace SVGTransformList
     -> JSIO SVGTransform
   appendItem a b = primJS $ SVGTransformList.prim__appendItem a b
 
-
+  
   export
   clear : (obj : SVGTransformList) -> JSIO ()
   clear a = primJS $ SVGTransformList.prim__clear a
 
-
+  
   export
   consolidate : (obj : SVGTransformList) -> JSIO (Maybe SVGTransform)
   consolidate a = tryJS "SVGTransformList.consolidate" $
     SVGTransformList.prim__consolidate a
 
-
+  
   export
   createSVGTransformFromMatrix' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem DOMMatrix2DInit (Types t2)}
+       {auto _ : Cast t2 DOMMatrix2DInit}
     -> (obj : SVGTransformList)
     -> (matrix : Optional t2)
     -> JSIO SVGTransform
   createSVGTransformFromMatrix' a b = primJS $
     SVGTransformList.prim__createSVGTransformFromMatrix a (optUp b)
-
+  
   export
   createSVGTransformFromMatrix : (obj : SVGTransformList) -> JSIO SVGTransform
   createSVGTransformFromMatrix a = primJS $
     SVGTransformList.prim__createSVGTransformFromMatrix a undef
 
-
+  
   export
   getItem : (obj : SVGTransformList) -> (index : Bits32) -> JSIO SVGTransform
   getItem a b = primJS $ SVGTransformList.prim__getItem a b
 
-
+  
   export
   initialize :
        (obj : SVGTransformList)
@@ -1983,7 +1930,7 @@ namespace SVGTransformList
     -> JSIO SVGTransform
   initialize a b = primJS $ SVGTransformList.prim__initialize a b
 
-
+  
   export
   insertItemBefore :
        (obj : SVGTransformList)
@@ -1993,12 +1940,12 @@ namespace SVGTransformList
   insertItemBefore a b c = primJS $
     SVGTransformList.prim__insertItemBefore a b c
 
-
+  
   export
   removeItem : (obj : SVGTransformList) -> (index : Bits32) -> JSIO SVGTransform
   removeItem a b = primJS $ SVGTransformList.prim__removeItem a b
 
-
+  
   export
   replaceItem :
        (obj : SVGTransformList)
@@ -2010,52 +1957,52 @@ namespace SVGTransformList
 
 
 namespace SVGUnitTypes
-
-  public export
+  
+  export
   SVG_UNIT_TYPE_OBJECTBOUNDINGBOX : Bits16
   SVG_UNIT_TYPE_OBJECTBOUNDINGBOX = 2
 
-
-  public export
+  
+  export
   SVG_UNIT_TYPE_UNKNOWN : Bits16
   SVG_UNIT_TYPE_UNKNOWN = 0
 
-
-  public export
+  
+  export
   SVG_UNIT_TYPE_USERSPACEONUSE : Bits16
   SVG_UNIT_TYPE_USERSPACEONUSE = 1
 
 
 
 namespace SVGUseElement
-
+  
   export
   animatedInstanceRoot : (obj : SVGUseElement) -> JSIO (Maybe SVGElement)
   animatedInstanceRoot a = tryJS "SVGUseElement.animatedInstanceRoot" $
     SVGUseElement.prim__animatedInstanceRoot a
 
-
+  
   export
   height : (obj : SVGUseElement) -> JSIO SVGAnimatedLength
   height a = primJS $ SVGUseElement.prim__height a
 
-
+  
   export
   instanceRoot : (obj : SVGUseElement) -> JSIO (Maybe SVGElement)
   instanceRoot a = tryJS "SVGUseElement.instanceRoot" $
     SVGUseElement.prim__instanceRoot a
 
-
+  
   export
   width : (obj : SVGUseElement) -> JSIO SVGAnimatedLength
   width a = primJS $ SVGUseElement.prim__width a
 
-
+  
   export
   x : (obj : SVGUseElement) -> JSIO SVGAnimatedLength
   x a = primJS $ SVGUseElement.prim__x a
 
-
+  
   export
   y : (obj : SVGUseElement) -> JSIO SVGAnimatedLength
   y a = primJS $ SVGUseElement.prim__y a
@@ -2065,19 +2012,17 @@ namespace SVGUseElement
 
 
 namespace ShadowAnimation
-
+  
   export
   new :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem Animation (Types t1)}
-    -> {auto 0 _ : Elem Animatable (Types t2)}
+       {auto _ : Cast t1 Animation}
+    -> {auto _ : Cast t2 Animatable}
     -> (source : t1)
     -> (newTarget : t2)
     -> JSIO ShadowAnimation
-  new a b = primJS $ ShadowAnimation.prim__new (up a) (up b)
+  new a b = primJS $ ShadowAnimation.prim__new (cast a) (cast b)
 
-
+  
   export
   sourceAnimation : (obj : ShadowAnimation) -> JSIO Animation
   sourceAnimation a = primJS $ ShadowAnimation.prim__sourceAnimation a
@@ -2090,113 +2035,103 @@ namespace ShadowAnimation
 --------------------------------------------------------------------------------
 
 namespace GetSVGDocument
-
+  
   export
   getSVGDocument :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem GetSVGDocument (Types t1)}
+       {auto _ : Cast t1 GetSVGDocument}
     -> (obj : t1)
     -> JSIO Document
-  getSVGDocument a = primJS $ GetSVGDocument.prim__getSVGDocument (up a)
+  getSVGDocument a = primJS $ GetSVGDocument.prim__getSVGDocument (cast a)
 
 
 
 namespace SVGAnimatedPoints
-
+  
   export
   animatedPoints :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGAnimatedPoints (Types t1)}
+       {auto _ : Cast t1 SVGAnimatedPoints}
     -> (obj : t1)
     -> JSIO SVGPointList
-  animatedPoints a = primJS $ SVGAnimatedPoints.prim__animatedPoints (up a)
+  animatedPoints a = primJS $ SVGAnimatedPoints.prim__animatedPoints (cast a)
 
-
+  
   export
   points :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGAnimatedPoints (Types t1)}
+       {auto _ : Cast t1 SVGAnimatedPoints}
     -> (obj : t1)
     -> JSIO SVGPointList
-  points a = primJS $ SVGAnimatedPoints.prim__points (up a)
+  points a = primJS $ SVGAnimatedPoints.prim__points (cast a)
 
 
 
 namespace SVGElementInstance
-
+  
   export
   correspondingElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGElementInstance (Types t1)}
+       {auto _ : Cast t1 SVGElementInstance}
     -> (obj : t1)
     -> JSIO (Maybe SVGElement)
   correspondingElement a = tryJS "SVGElementInstance.correspondingElement" $
-    SVGElementInstance.prim__correspondingElement (up a)
+    SVGElementInstance.prim__correspondingElement (cast a)
 
-
+  
   export
   correspondingUseElement :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGElementInstance (Types t1)}
+       {auto _ : Cast t1 SVGElementInstance}
     -> (obj : t1)
     -> JSIO (Maybe SVGUseElement)
   correspondingUseElement a = tryJS "SVGElementInstance.correspondingUseElement" $
-    SVGElementInstance.prim__correspondingUseElement (up a)
+    SVGElementInstance.prim__correspondingUseElement (cast a)
 
 
 
 namespace SVGFitToViewBox
-
+  
   export
   preserveAspectRatio :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGFitToViewBox (Types t1)}
+       {auto _ : Cast t1 SVGFitToViewBox}
     -> (obj : t1)
     -> JSIO SVGAnimatedPreserveAspectRatio
   preserveAspectRatio a = primJS $
-    SVGFitToViewBox.prim__preserveAspectRatio (up a)
+    SVGFitToViewBox.prim__preserveAspectRatio (cast a)
 
-
+  
   export
   viewBox :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGFitToViewBox (Types t1)}
+       {auto _ : Cast t1 SVGFitToViewBox}
     -> (obj : t1)
     -> JSIO SVGAnimatedRect
-  viewBox a = primJS $ SVGFitToViewBox.prim__viewBox (up a)
+  viewBox a = primJS $ SVGFitToViewBox.prim__viewBox (cast a)
 
 
 
 namespace SVGTests
-
+  
   export
   requiredExtensions :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTests (Types t1)}
+       {auto _ : Cast t1 SVGTests}
     -> (obj : t1)
     -> JSIO SVGStringList
-  requiredExtensions a = primJS $ SVGTests.prim__requiredExtensions (up a)
+  requiredExtensions a = primJS $ SVGTests.prim__requiredExtensions (cast a)
 
-
+  
   export
   systemLanguage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGTests (Types t1)}
+       {auto _ : Cast t1 SVGTests}
     -> (obj : t1)
     -> JSIO SVGStringList
-  systemLanguage a = primJS $ SVGTests.prim__systemLanguage (up a)
+  systemLanguage a = primJS $ SVGTests.prim__systemLanguage (cast a)
 
 
 
 namespace SVGURIReference
-
+  
   export
   href :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem SVGURIReference (Types t1)}
+       {auto _ : Cast t1 SVGURIReference}
     -> (obj : t1)
     -> JSIO SVGAnimatedString
-  href a = primJS $ SVGURIReference.prim__href (up a)
+  href a = primJS $ SVGURIReference.prim__href (cast a)
 
 
 
@@ -2206,7 +2141,7 @@ namespace SVGURIReference
 --------------------------------------------------------------------------------
 
 namespace SVGBoundingBoxOptions
-
+  
   export
   new' :
        (fill : Optional Bool)
@@ -2216,16 +2151,15 @@ namespace SVGBoundingBoxOptions
     -> JSIO SVGBoundingBoxOptions
   new' a b c d = primJS $
     SVGBoundingBoxOptions.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO SVGBoundingBoxOptions
   new = primJS $ SVGBoundingBoxOptions.prim__new undef undef undef undef
 
-
+  
   export
   clipped :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem SVGBoundingBoxOptions (Types t)}
+       {auto _ : Cast t SVGBoundingBoxOptions}
     -> t
     -> Attribute True Optional Bool
   clipped v = fromUndefOrPrim
@@ -2233,13 +2167,12 @@ namespace SVGBoundingBoxOptions
                 prim__clipped
                 prim__setClipped
                 False
-                (v :> SVGBoundingBoxOptions)
+                (cast {to = SVGBoundingBoxOptions} v)
 
-
+  
   export
   fill :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem SVGBoundingBoxOptions (Types t)}
+       {auto _ : Cast t SVGBoundingBoxOptions}
     -> t
     -> Attribute True Optional Bool
   fill v = fromUndefOrPrim
@@ -2247,13 +2180,12 @@ namespace SVGBoundingBoxOptions
              prim__fill
              prim__setFill
              True
-             (v :> SVGBoundingBoxOptions)
+             (cast {to = SVGBoundingBoxOptions} v)
 
-
+  
   export
   markers :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem SVGBoundingBoxOptions (Types t)}
+       {auto _ : Cast t SVGBoundingBoxOptions}
     -> t
     -> Attribute True Optional Bool
   markers v = fromUndefOrPrim
@@ -2261,13 +2193,12 @@ namespace SVGBoundingBoxOptions
                 prim__markers
                 prim__setMarkers
                 False
-                (v :> SVGBoundingBoxOptions)
+                (cast {to = SVGBoundingBoxOptions} v)
 
-
+  
   export
   stroke :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem SVGBoundingBoxOptions (Types t)}
+       {auto _ : Cast t SVGBoundingBoxOptions}
     -> t
     -> Attribute True Optional Bool
   stroke v = fromUndefOrPrim
@@ -2275,4 +2206,7 @@ namespace SVGBoundingBoxOptions
                prim__stroke
                prim__setStroke
                False
-               (v :> SVGBoundingBoxOptions)
+               (cast {to = SVGBoundingBoxOptions} v)
+
+
+

--- a/src/Web/Raw/UIEvents.idr
+++ b/src/Web/Raw/UIEvents.idr
@@ -12,7 +12,7 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace CompositionEvent
-
+  
   export
   data_ : (obj : CompositionEvent) -> JSIO String
   data_ a = primJS $ CompositionEvent.prim__data a
@@ -20,7 +20,7 @@ namespace CompositionEvent
 
 
 namespace FocusEvent
-
+  
   export
   relatedTarget : (obj : FocusEvent) -> JSIO (Maybe EventTarget)
   relatedTarget a = tryJS "FocusEvent.relatedTarget" $
@@ -29,17 +29,17 @@ namespace FocusEvent
 
 
 namespace InputEvent
-
+  
   export
   data_ : (obj : InputEvent) -> JSIO (Maybe String)
   data_ a = tryJS "InputEvent.data_" $ InputEvent.prim__data a
 
-
+  
   export
   inputType : (obj : InputEvent) -> JSIO String
   inputType a = primJS $ InputEvent.prim__inputType a
 
-
+  
   export
   isComposing : (obj : InputEvent) -> JSIO Bool
   isComposing a = tryJS "InputEvent.isComposing" $
@@ -48,83 +48,83 @@ namespace InputEvent
 
 
 namespace KeyboardEvent
-
-  public export
+  
+  export
   DOM_KEY_LOCATION_LEFT : Bits32
   DOM_KEY_LOCATION_LEFT = 0x1
 
-
-  public export
+  
+  export
   DOM_KEY_LOCATION_NUMPAD : Bits32
   DOM_KEY_LOCATION_NUMPAD = 0x3
 
-
-  public export
+  
+  export
   DOM_KEY_LOCATION_RIGHT : Bits32
   DOM_KEY_LOCATION_RIGHT = 0x2
 
-
-  public export
+  
+  export
   DOM_KEY_LOCATION_STANDARD : Bits32
   DOM_KEY_LOCATION_STANDARD = 0x0
 
-
+  
   export
   altKey : (obj : KeyboardEvent) -> JSIO Bool
   altKey a = tryJS "KeyboardEvent.altKey" $ KeyboardEvent.prim__altKey a
 
-
+  
   export
   charCode : (obj : KeyboardEvent) -> JSIO Bits32
   charCode a = primJS $ KeyboardEvent.prim__charCode a
 
-
+  
   export
   code : (obj : KeyboardEvent) -> JSIO String
   code a = primJS $ KeyboardEvent.prim__code a
 
-
+  
   export
   ctrlKey : (obj : KeyboardEvent) -> JSIO Bool
   ctrlKey a = tryJS "KeyboardEvent.ctrlKey" $ KeyboardEvent.prim__ctrlKey a
 
-
+  
   export
   isComposing : (obj : KeyboardEvent) -> JSIO Bool
   isComposing a = tryJS "KeyboardEvent.isComposing" $
     KeyboardEvent.prim__isComposing a
 
-
+  
   export
   key : (obj : KeyboardEvent) -> JSIO String
   key a = primJS $ KeyboardEvent.prim__key a
 
-
+  
   export
   keyCode : (obj : KeyboardEvent) -> JSIO Bits32
   keyCode a = primJS $ KeyboardEvent.prim__keyCode a
 
-
+  
   export
   location : (obj : KeyboardEvent) -> JSIO Bits32
   location a = primJS $ KeyboardEvent.prim__location a
 
-
+  
   export
   metaKey : (obj : KeyboardEvent) -> JSIO Bool
   metaKey a = tryJS "KeyboardEvent.metaKey" $ KeyboardEvent.prim__metaKey a
 
-
+  
   export
   repeat : (obj : KeyboardEvent) -> JSIO Bool
   repeat a = tryJS "KeyboardEvent.repeat" $ KeyboardEvent.prim__repeat a
 
-
+  
   export
   shiftKey : (obj : KeyboardEvent) -> JSIO Bool
   shiftKey a = tryJS "KeyboardEvent.shiftKey" $ KeyboardEvent.prim__shiftKey a
 
-
+  
   export
   getModifierState : (obj : KeyboardEvent) -> (keyArg : String) -> JSIO Bool
   getModifierState a b = tryJS "KeyboardEvent.getModifierState" $
@@ -133,235 +133,157 @@ namespace KeyboardEvent
 
 
 namespace MouseEvent
-
+  
   export
-  altKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  altKey a = tryJS "MouseEvent.altKey" $ MouseEvent.prim__altKey (up a)
+  altKey : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Bool
+  altKey a = tryJS "MouseEvent.altKey" $ MouseEvent.prim__altKey (cast a)
 
-
+  
   export
-  button :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int16
-  button a = primJS $ MouseEvent.prim__button (up a)
+  button : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Int16
+  button a = primJS $ MouseEvent.prim__button (cast a)
 
-
+  
   export
-  buttons :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  buttons a = primJS $ MouseEvent.prim__buttons (up a)
+  buttons : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Bits16
+  buttons a = primJS $ MouseEvent.prim__buttons (cast a)
 
-
+  
   export
-  clientX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  clientX a = primJS $ MouseEvent.prim__clientX (up a)
+  clientX : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  clientX a = primJS $ MouseEvent.prim__clientX (cast a)
 
-
+  
   export
-  clientY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  clientY a = primJS $ MouseEvent.prim__clientY (up a)
+  clientY : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  clientY a = primJS $ MouseEvent.prim__clientY (cast a)
 
-
+  
   export
-  ctrlKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  ctrlKey a = tryJS "MouseEvent.ctrlKey" $ MouseEvent.prim__ctrlKey (up a)
+  ctrlKey : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Bool
+  ctrlKey a = tryJS "MouseEvent.ctrlKey" $ MouseEvent.prim__ctrlKey (cast a)
 
-
+  
   export
-  metaKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  metaKey a = tryJS "MouseEvent.metaKey" $ MouseEvent.prim__metaKey (up a)
+  metaKey : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Bool
+  metaKey a = tryJS "MouseEvent.metaKey" $ MouseEvent.prim__metaKey (cast a)
 
-
+  
   export
-  offsetX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  offsetX a = primJS $ MouseEvent.prim__offsetX (up a)
+  offsetX : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  offsetX a = primJS $ MouseEvent.prim__offsetX (cast a)
 
-
+  
   export
-  offsetY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  offsetY a = primJS $ MouseEvent.prim__offsetY (up a)
+  offsetY : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  offsetY a = primJS $ MouseEvent.prim__offsetY (cast a)
 
-
+  
   export
-  pageX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  pageX a = primJS $ MouseEvent.prim__pageX (up a)
+  pageX : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  pageX a = primJS $ MouseEvent.prim__pageX (cast a)
 
-
+  
   export
-  pageY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  pageY a = primJS $ MouseEvent.prim__pageY (up a)
+  pageY : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  pageY a = primJS $ MouseEvent.prim__pageY (cast a)
 
-
+  
   export
   relatedTarget :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
+       {auto _ : Cast t1 MouseEvent}
     -> (obj : t1)
     -> JSIO (Maybe EventTarget)
   relatedTarget a = tryJS "MouseEvent.relatedTarget" $
-    MouseEvent.prim__relatedTarget (up a)
+    MouseEvent.prim__relatedTarget (cast a)
 
-
+  
   export
-  screenX :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  screenX a = primJS $ MouseEvent.prim__screenX (up a)
+  screenX : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  screenX a = primJS $ MouseEvent.prim__screenX (cast a)
 
-
+  
   export
-  screenY :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  screenY a = primJS $ MouseEvent.prim__screenY (up a)
+  screenY : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  screenY a = primJS $ MouseEvent.prim__screenY (cast a)
 
-
+  
   export
-  shiftKey :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bool
-  shiftKey a = tryJS "MouseEvent.shiftKey" $ MouseEvent.prim__shiftKey (up a)
+  shiftKey : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Bool
+  shiftKey a = tryJS "MouseEvent.shiftKey" $ MouseEvent.prim__shiftKey (cast a)
 
-
+  
   export
-  x :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  x a = primJS $ MouseEvent.prim__x (up a)
+  x : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  x a = primJS $ MouseEvent.prim__x (cast a)
 
-
+  
   export
-  y :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Double
-  y a = primJS $ MouseEvent.prim__y (up a)
+  y : {auto _ : Cast t1 MouseEvent} -> (obj : t1) -> JSIO Double
+  y a = primJS $ MouseEvent.prim__y (cast a)
 
-
+  
   export
   getModifierState :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem MouseEvent (Types t1)}
+       {auto _ : Cast t1 MouseEvent}
     -> (obj : t1)
     -> (keyArg : String)
     -> JSIO Bool
   getModifierState a b = tryJS "MouseEvent.getModifierState" $
-    MouseEvent.prim__getModifierState (up a) b
+    MouseEvent.prim__getModifierState (cast a) b
 
 
 
 namespace UIEvent
-
+  
   export
-  detail :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem UIEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Int32
-  detail a = primJS $ UIEvent.prim__detail (up a)
+  detail : {auto _ : Cast t1 UIEvent} -> (obj : t1) -> JSIO Int32
+  detail a = primJS $ UIEvent.prim__detail (cast a)
 
-
+  
   export
-  view :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem UIEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO (Maybe Window)
-  view a = tryJS "UIEvent.view" $ UIEvent.prim__view (up a)
+  view : {auto _ : Cast t1 UIEvent} -> (obj : t1) -> JSIO (Maybe Window)
+  view a = tryJS "UIEvent.view" $ UIEvent.prim__view (cast a)
 
-
+  
   export
-  which :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem UIEvent (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits32
-  which a = primJS $ UIEvent.prim__which (up a)
+  which : {auto _ : Cast t1 UIEvent} -> (obj : t1) -> JSIO Bits32
+  which a = primJS $ UIEvent.prim__which (cast a)
 
 
 
 namespace WheelEvent
-
-  public export
+  
+  export
   DOM_DELTA_LINE : Bits32
   DOM_DELTA_LINE = 0x1
 
-
-  public export
+  
+  export
   DOM_DELTA_PAGE : Bits32
   DOM_DELTA_PAGE = 0x2
 
-
-  public export
+  
+  export
   DOM_DELTA_PIXEL : Bits32
   DOM_DELTA_PIXEL = 0x0
 
-
+  
   export
   deltaMode : (obj : WheelEvent) -> JSIO Bits32
   deltaMode a = primJS $ WheelEvent.prim__deltaMode a
 
-
+  
   export
   deltaX : (obj : WheelEvent) -> JSIO Double
   deltaX a = primJS $ WheelEvent.prim__deltaX a
 
-
+  
   export
   deltaY : (obj : WheelEvent) -> JSIO Double
   deltaY a = primJS $ WheelEvent.prim__deltaY a
 
-
+  
   export
   deltaZ : (obj : WheelEvent) -> JSIO Double
   deltaZ a = primJS $ WheelEvent.prim__deltaZ a
@@ -375,20 +297,19 @@ namespace WheelEvent
 --------------------------------------------------------------------------------
 
 namespace CompositionEventInit
-
+  
   export
   new' : (data_ : Optional String) -> JSIO CompositionEventInit
   new' a = primJS $ CompositionEventInit.prim__new (toFFI a)
-
+  
   export
   new : JSIO CompositionEventInit
   new = primJS $ CompositionEventInit.prim__new undef
 
-
+  
   export
   data_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem CompositionEventInit (Types t)}
+       {auto _ : Cast t CompositionEventInit}
     -> t
     -> Attribute True Optional String
   data_ v = fromUndefOrPrim
@@ -396,12 +317,12 @@ namespace CompositionEventInit
               prim__data
               prim__setData
               ""
-              (v :> CompositionEventInit)
+              (cast {to = CompositionEventInit} v)
 
 
 
 namespace EventModifierInit
-
+  
   export
   new' :
        (ctrlKey : Optional Bool)
@@ -435,7 +356,7 @@ namespace EventModifierInit
       (toFFI l)
       (toFFI m)
       (toFFI n)
-
+  
   export
   new : JSIO EventModifierInit
   new = primJS $
@@ -455,11 +376,10 @@ namespace EventModifierInit
       undef
       undef
 
-
+  
   export
   altKey :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   altKey v = fromUndefOrPrim
@@ -467,13 +387,12 @@ namespace EventModifierInit
                prim__altKey
                prim__setAltKey
                False
-               (v :> EventModifierInit)
+               (cast {to = EventModifierInit} v)
 
-
+  
   export
   ctrlKey :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   ctrlKey v = fromUndefOrPrim
@@ -481,13 +400,12 @@ namespace EventModifierInit
                 prim__ctrlKey
                 prim__setCtrlKey
                 False
-                (v :> EventModifierInit)
+                (cast {to = EventModifierInit} v)
 
-
+  
   export
   metaKey :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   metaKey v = fromUndefOrPrim
@@ -495,13 +413,12 @@ namespace EventModifierInit
                 prim__metaKey
                 prim__setMetaKey
                 False
-                (v :> EventModifierInit)
+                (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierAltGraph :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierAltGraph v = fromUndefOrPrim
@@ -509,13 +426,12 @@ namespace EventModifierInit
                          prim__modifierAltGraph
                          prim__setModifierAltGraph
                          False
-                         (v :> EventModifierInit)
+                         (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierCapsLock :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierCapsLock v = fromUndefOrPrim
@@ -523,13 +439,12 @@ namespace EventModifierInit
                          prim__modifierCapsLock
                          prim__setModifierCapsLock
                          False
-                         (v :> EventModifierInit)
+                         (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierFn :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierFn v = fromUndefOrPrim
@@ -537,13 +452,12 @@ namespace EventModifierInit
                    prim__modifierFn
                    prim__setModifierFn
                    False
-                   (v :> EventModifierInit)
+                   (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierFnLock :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierFnLock v = fromUndefOrPrim
@@ -551,13 +465,12 @@ namespace EventModifierInit
                        prim__modifierFnLock
                        prim__setModifierFnLock
                        False
-                       (v :> EventModifierInit)
+                       (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierHyper :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierHyper v = fromUndefOrPrim
@@ -565,13 +478,12 @@ namespace EventModifierInit
                       prim__modifierHyper
                       prim__setModifierHyper
                       False
-                      (v :> EventModifierInit)
+                      (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierNumLock :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierNumLock v = fromUndefOrPrim
@@ -579,13 +491,12 @@ namespace EventModifierInit
                         prim__modifierNumLock
                         prim__setModifierNumLock
                         False
-                        (v :> EventModifierInit)
+                        (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierScrollLock :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierScrollLock v = fromUndefOrPrim
@@ -593,13 +504,12 @@ namespace EventModifierInit
                            prim__modifierScrollLock
                            prim__setModifierScrollLock
                            False
-                           (v :> EventModifierInit)
+                           (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierSuper :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierSuper v = fromUndefOrPrim
@@ -607,13 +517,12 @@ namespace EventModifierInit
                       prim__modifierSuper
                       prim__setModifierSuper
                       False
-                      (v :> EventModifierInit)
+                      (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierSymbol :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierSymbol v = fromUndefOrPrim
@@ -621,13 +530,12 @@ namespace EventModifierInit
                        prim__modifierSymbol
                        prim__setModifierSymbol
                        False
-                       (v :> EventModifierInit)
+                       (cast {to = EventModifierInit} v)
 
-
+  
   export
   modifierSymbolLock :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   modifierSymbolLock v = fromUndefOrPrim
@@ -635,13 +543,12 @@ namespace EventModifierInit
                            prim__modifierSymbolLock
                            prim__setModifierSymbolLock
                            False
-                           (v :> EventModifierInit)
+                           (cast {to = EventModifierInit} v)
 
-
+  
   export
   shiftKey :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem EventModifierInit (Types t)}
+       {auto _ : Cast t EventModifierInit}
     -> t
     -> Attribute True Optional Bool
   shiftKey v = fromUndefOrPrim
@@ -649,29 +556,27 @@ namespace EventModifierInit
                  prim__shiftKey
                  prim__setShiftKey
                  False
-                 (v :> EventModifierInit)
+                 (cast {to = EventModifierInit} v)
 
 
 
 namespace FocusEventInit
-
+  
   export
   new' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem EventTarget (Types t1)}
+       {auto _ : Cast t1 EventTarget}
     -> (relatedTarget : Optional (Maybe t1))
     -> JSIO FocusEventInit
   new' a = primJS $ FocusEventInit.prim__new (omyUp a)
-
+  
   export
   new : JSIO FocusEventInit
   new = primJS $ FocusEventInit.prim__new undef
 
-
+  
   export
   relatedTarget :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem FocusEventInit (Types t)}
+       {auto _ : Cast t FocusEventInit}
     -> t
     -> Attribute True Optional (Maybe EventTarget)
   relatedTarget v = fromUndefOrPrim
@@ -679,12 +584,12 @@ namespace FocusEventInit
                       prim__relatedTarget
                       prim__setRelatedTarget
                       Nothing
-                      (v :> FocusEventInit)
+                      (cast {to = FocusEventInit} v)
 
 
 
 namespace InputEventInit
-
+  
   export
   new' :
        (data_ : Optional (Maybe String))
@@ -692,16 +597,15 @@ namespace InputEventInit
     -> (inputType : Optional String)
     -> JSIO InputEventInit
   new' a b c = primJS $ InputEventInit.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO InputEventInit
   new = primJS $ InputEventInit.prim__new undef undef undef
 
-
+  
   export
   data_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem InputEventInit (Types t)}
+       {auto _ : Cast t InputEventInit}
     -> t
     -> Attribute True Optional (Maybe String)
   data_ v = fromUndefOrPrim
@@ -709,13 +613,12 @@ namespace InputEventInit
               prim__data
               prim__setData
               (Just "")
-              (v :> InputEventInit)
+              (cast {to = InputEventInit} v)
 
-
+  
   export
   inputType :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem InputEventInit (Types t)}
+       {auto _ : Cast t InputEventInit}
     -> t
     -> Attribute True Optional String
   inputType v = fromUndefOrPrim
@@ -723,13 +626,12 @@ namespace InputEventInit
                   prim__inputType
                   prim__setInputType
                   ""
-                  (v :> InputEventInit)
+                  (cast {to = InputEventInit} v)
 
-
+  
   export
   isComposing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem InputEventInit (Types t)}
+       {auto _ : Cast t InputEventInit}
     -> t
     -> Attribute True Optional Bool
   isComposing v = fromUndefOrPrim
@@ -737,12 +639,12 @@ namespace InputEventInit
                     prim__isComposing
                     prim__setIsComposing
                     False
-                    (v :> InputEventInit)
+                    (cast {to = InputEventInit} v)
 
 
 
 namespace KeyboardEventInit
-
+  
   export
   new' :
        (key : Optional String)
@@ -758,16 +660,15 @@ namespace KeyboardEventInit
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   new : JSIO KeyboardEventInit
   new = primJS $ KeyboardEventInit.prim__new undef undef undef undef undef
 
-
+  
   export
   code :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyboardEventInit (Types t)}
+       {auto _ : Cast t KeyboardEventInit}
     -> t
     -> Attribute True Optional String
   code v = fromUndefOrPrim
@@ -775,13 +676,12 @@ namespace KeyboardEventInit
              prim__code
              prim__setCode
              ""
-             (v :> KeyboardEventInit)
+             (cast {to = KeyboardEventInit} v)
 
-
+  
   export
   isComposing :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyboardEventInit (Types t)}
+       {auto _ : Cast t KeyboardEventInit}
     -> t
     -> Attribute True Optional Bool
   isComposing v = fromUndefOrPrim
@@ -789,13 +689,12 @@ namespace KeyboardEventInit
                     prim__isComposing
                     prim__setIsComposing
                     False
-                    (v :> KeyboardEventInit)
+                    (cast {to = KeyboardEventInit} v)
 
-
+  
   export
   key :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyboardEventInit (Types t)}
+       {auto _ : Cast t KeyboardEventInit}
     -> t
     -> Attribute True Optional String
   key v = fromUndefOrPrim
@@ -803,13 +702,12 @@ namespace KeyboardEventInit
             prim__key
             prim__setKey
             ""
-            (v :> KeyboardEventInit)
+            (cast {to = KeyboardEventInit} v)
 
-
+  
   export
   location :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyboardEventInit (Types t)}
+       {auto _ : Cast t KeyboardEventInit}
     -> t
     -> Attribute True Optional Bits32
   location v = fromUndefOrPrim
@@ -817,13 +715,12 @@ namespace KeyboardEventInit
                  prim__location
                  prim__setLocation
                  0
-                 (v :> KeyboardEventInit)
+                 (cast {to = KeyboardEventInit} v)
 
-
+  
   export
   repeat :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem KeyboardEventInit (Types t)}
+       {auto _ : Cast t KeyboardEventInit}
     -> t
     -> Attribute True Optional Bool
   repeat v = fromUndefOrPrim
@@ -831,16 +728,15 @@ namespace KeyboardEventInit
                prim__repeat
                prim__setRepeat
                False
-               (v :> KeyboardEventInit)
+               (cast {to = KeyboardEventInit} v)
 
 
 
 namespace MouseEventInit
-
+  
   export
   new' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem EventTarget (Types t3)}
+       {auto _ : Cast t3 EventTarget}
     -> (button : Optional Int16)
     -> (buttons : Optional Bits16)
     -> (relatedTarget : Optional (Maybe t3))
@@ -858,17 +754,16 @@ namespace MouseEventInit
       (toFFI e)
       (toFFI f)
       (toFFI g)
-
+  
   export
   new : JSIO MouseEventInit
   new = primJS $
     MouseEventInit.prim__new undef undef undef undef undef undef undef
 
-
+  
   export
   button :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Int16
   button v = fromUndefOrPrim
@@ -876,13 +771,12 @@ namespace MouseEventInit
                prim__button
                prim__setButton
                0
-               (v :> MouseEventInit)
+               (cast {to = MouseEventInit} v)
 
-
+  
   export
   buttons :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Bits16
   buttons v = fromUndefOrPrim
@@ -890,13 +784,12 @@ namespace MouseEventInit
                 prim__buttons
                 prim__setButtons
                 0
-                (v :> MouseEventInit)
+                (cast {to = MouseEventInit} v)
 
-
+  
   export
   clientX :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Double
   clientX v = fromUndefOrPrim
@@ -904,13 +797,12 @@ namespace MouseEventInit
                 prim__clientX
                 prim__setClientX
                 0.0
-                (v :> MouseEventInit)
+                (cast {to = MouseEventInit} v)
 
-
+  
   export
   clientY :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Double
   clientY v = fromUndefOrPrim
@@ -918,13 +810,12 @@ namespace MouseEventInit
                 prim__clientY
                 prim__setClientY
                 0.0
-                (v :> MouseEventInit)
+                (cast {to = MouseEventInit} v)
 
-
+  
   export
   relatedTarget :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional (Maybe EventTarget)
   relatedTarget v = fromUndefOrPrim
@@ -932,13 +823,12 @@ namespace MouseEventInit
                       prim__relatedTarget
                       prim__setRelatedTarget
                       Nothing
-                      (v :> MouseEventInit)
+                      (cast {to = MouseEventInit} v)
 
-
+  
   export
   screenX :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Double
   screenX v = fromUndefOrPrim
@@ -946,13 +836,12 @@ namespace MouseEventInit
                 prim__screenX
                 prim__setScreenX
                 0.0
-                (v :> MouseEventInit)
+                (cast {to = MouseEventInit} v)
 
-
+  
   export
   screenY :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem MouseEventInit (Types t)}
+       {auto _ : Cast t MouseEventInit}
     -> t
     -> Attribute True Optional Double
   screenY v = fromUndefOrPrim
@@ -960,42 +849,37 @@ namespace MouseEventInit
                 prim__screenY
                 prim__setScreenY
                 0.0
-                (v :> MouseEventInit)
+                (cast {to = MouseEventInit} v)
 
 
 
 namespace UIEventInit
-
+  
   export
   new' :
        (view : Optional (Maybe Window))
     -> (detail : Optional Int32)
     -> JSIO UIEventInit
   new' a b = primJS $ UIEventInit.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO UIEventInit
   new = primJS $ UIEventInit.prim__new undef undef
 
-
+  
   export
-  detail :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UIEventInit (Types t)}
-    -> t
-    -> Attribute True Optional Int32
+  detail : {auto _ : Cast t UIEventInit} -> t -> Attribute True Optional Int32
   detail v = fromUndefOrPrim
                "UIEventInit.getdetail"
                prim__detail
                prim__setDetail
                0
-               (v :> UIEventInit)
+               (cast {to = UIEventInit} v)
 
-
+  
   export
   view :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem UIEventInit (Types t)}
+       {auto _ : Cast t UIEventInit}
     -> t
     -> Attribute True Optional (Maybe Window)
   view v = fromUndefOrPrim
@@ -1003,12 +887,12 @@ namespace UIEventInit
              prim__view
              prim__setView
              Nothing
-             (v :> UIEventInit)
+             (cast {to = UIEventInit} v)
 
 
 
 namespace WheelEventInit
-
+  
   export
   new' :
        (deltaX : Optional Double)
@@ -1018,16 +902,15 @@ namespace WheelEventInit
     -> JSIO WheelEventInit
   new' a b c d = primJS $
     WheelEventInit.prim__new (toFFI a) (toFFI b) (toFFI c) (toFFI d)
-
+  
   export
   new : JSIO WheelEventInit
   new = primJS $ WheelEventInit.prim__new undef undef undef undef
 
-
+  
   export
   deltaMode :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WheelEventInit (Types t)}
+       {auto _ : Cast t WheelEventInit}
     -> t
     -> Attribute True Optional Bits32
   deltaMode v = fromUndefOrPrim
@@ -1035,13 +918,12 @@ namespace WheelEventInit
                   prim__deltaMode
                   prim__setDeltaMode
                   0
-                  (v :> WheelEventInit)
+                  (cast {to = WheelEventInit} v)
 
-
+  
   export
   deltaX :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WheelEventInit (Types t)}
+       {auto _ : Cast t WheelEventInit}
     -> t
     -> Attribute True Optional Double
   deltaX v = fromUndefOrPrim
@@ -1049,13 +931,12 @@ namespace WheelEventInit
                prim__deltaX
                prim__setDeltaX
                0.0
-               (v :> WheelEventInit)
+               (cast {to = WheelEventInit} v)
 
-
+  
   export
   deltaY :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WheelEventInit (Types t)}
+       {auto _ : Cast t WheelEventInit}
     -> t
     -> Attribute True Optional Double
   deltaY v = fromUndefOrPrim
@@ -1063,13 +944,12 @@ namespace WheelEventInit
                prim__deltaY
                prim__setDeltaY
                0.0
-               (v :> WheelEventInit)
+               (cast {to = WheelEventInit} v)
 
-
+  
   export
   deltaZ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WheelEventInit (Types t)}
+       {auto _ : Cast t WheelEventInit}
     -> t
     -> Attribute True Optional Double
   deltaZ v = fromUndefOrPrim
@@ -1077,4 +957,7 @@ namespace WheelEventInit
                prim__deltaZ
                prim__setDeltaZ
                0.0
-               (v :> WheelEventInit)
+               (cast {to = WheelEventInit} v)
+
+
+

--- a/src/Web/Raw/Url.idr
+++ b/src/Web/Raw/Url.idr
@@ -12,91 +12,91 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace URL
-
+  
   export
   new' : (url : String) -> (base : Optional String) -> JSIO URL
   new' a b = primJS $ URL.prim__new a (toFFI b)
-
+  
   export
   new : (url : String) -> JSIO URL
   new a = primJS $ URL.prim__new a undef
 
-
+  
   export
   createObjectURL : (obj : HSum [Blob, MediaSource]) -> JSIO String
   createObjectURL a = primJS $ URL.prim__createObjectURL (toFFI a)
 
-
+  
   export
   createObjectURL1 : (mediaSource : MediaSource) -> JSIO String
   createObjectURL1 a = primJS $ URL.prim__createObjectURL1 a
 
-
+  
   export
   revokeObjectURL : (url : String) -> JSIO ()
   revokeObjectURL a = primJS $ URL.prim__revokeObjectURL a
 
-
+  
   export
   hash : URL -> Attribute True Prelude.id String
   hash v = fromPrim "URL.gethash" prim__hash prim__setHash v
 
-
+  
   export
   host : URL -> Attribute True Prelude.id String
   host v = fromPrim "URL.gethost" prim__host prim__setHost v
 
-
+  
   export
   hostname : URL -> Attribute True Prelude.id String
   hostname v = fromPrim "URL.gethostname" prim__hostname prim__setHostname v
 
-
+  
   export
   href : URL -> Attribute True Prelude.id String
   href v = fromPrim "URL.gethref" prim__href prim__setHref v
 
-
+  
   export
   origin : (obj : URL) -> JSIO String
   origin a = primJS $ URL.prim__origin a
 
-
+  
   export
   password : URL -> Attribute True Prelude.id String
   password v = fromPrim "URL.getpassword" prim__password prim__setPassword v
 
-
+  
   export
   pathname : URL -> Attribute True Prelude.id String
   pathname v = fromPrim "URL.getpathname" prim__pathname prim__setPathname v
 
-
+  
   export
   port : URL -> Attribute True Prelude.id String
   port v = fromPrim "URL.getport" prim__port prim__setPort v
 
-
+  
   export
   protocol : URL -> Attribute True Prelude.id String
   protocol v = fromPrim "URL.getprotocol" prim__protocol prim__setProtocol v
 
-
+  
   export
   search : URL -> Attribute True Prelude.id String
   search v = fromPrim "URL.getsearch" prim__search prim__setSearch v
 
-
+  
   export
   searchParams : (obj : URL) -> JSIO URLSearchParams
   searchParams a = primJS $ URL.prim__searchParams a
 
-
+  
   export
   username : URL -> Attribute True Prelude.id String
   username v = fromPrim "URL.getusername" prim__username prim__setUsername v
 
-
+  
   export
   toJSON : (obj : URL) -> JSIO String
   toJSON a = primJS $ URL.prim__toJSON a
@@ -104,19 +104,19 @@ namespace URL
 
 
 namespace URLSearchParams
-
+  
   export
   new' :
        (init : Optional
                  (HSum [Array (Array String), Record String String, String]))
     -> JSIO URLSearchParams
   new' a = primJS $ URLSearchParams.prim__new (toFFI a)
-
+  
   export
   new : JSIO URLSearchParams
   new = primJS $ URLSearchParams.prim__new undef
 
-
+  
   export
   append :
        (obj : URLSearchParams)
@@ -125,27 +125,27 @@ namespace URLSearchParams
     -> JSIO ()
   append a b c = primJS $ URLSearchParams.prim__append a b c
 
-
+  
   export
   delete : (obj : URLSearchParams) -> (name : String) -> JSIO ()
   delete a b = primJS $ URLSearchParams.prim__delete a b
 
-
+  
   export
   getAll : (obj : URLSearchParams) -> (name : String) -> JSIO (Array String)
   getAll a b = primJS $ URLSearchParams.prim__getAll a b
 
-
+  
   export
   get : (obj : URLSearchParams) -> (name : String) -> JSIO (Maybe String)
   get a b = tryJS "URLSearchParams.get" $ URLSearchParams.prim__get a b
 
-
+  
   export
   has : (obj : URLSearchParams) -> (name : String) -> JSIO Bool
   has a b = tryJS "URLSearchParams.has" $ URLSearchParams.prim__has a b
 
-
+  
   export
   set :
        (obj : URLSearchParams)
@@ -154,12 +154,17 @@ namespace URLSearchParams
     -> JSIO ()
   set a b c = primJS $ URLSearchParams.prim__set a b c
 
-
+  
   export
   sort : (obj : URLSearchParams) -> JSIO ()
   sort a = primJS $ URLSearchParams.prim__sort a
 
-
+  
   export
   toString : (obj : URLSearchParams) -> JSIO String
   toString a = primJS $ URLSearchParams.prim__toString a
+
+
+
+
+

--- a/src/Web/Raw/Visibility.idr
+++ b/src/Web/Raw/Visibility.idr
@@ -5,3 +5,7 @@ import Web.Internal.VisibilityPrim
 import Web.Internal.Types
 
 %default total
+
+
+
+

--- a/src/Web/Raw/Webgl.idr
+++ b/src/Web/Raw/Webgl.idr
@@ -13,17 +13,17 @@ import Web.Internal.Types
 
 
 namespace WebGLActiveInfo
-
+  
   export
   name : (obj : WebGLActiveInfo) -> JSIO String
   name a = primJS $ WebGLActiveInfo.prim__name a
 
-
+  
   export
   size : (obj : WebGLActiveInfo) -> JSIO Int32
   size a = primJS $ WebGLActiveInfo.prim__size a
 
-
+  
   export
   type : (obj : WebGLActiveInfo) -> JSIO Bits32
   type a = primJS $ WebGLActiveInfo.prim__type a
@@ -40,17 +40,17 @@ namespace WebGLActiveInfo
 
 
 namespace WebGLShaderPrecisionFormat
-
+  
   export
   precision : (obj : WebGLShaderPrecisionFormat) -> JSIO Int32
   precision a = primJS $ WebGLShaderPrecisionFormat.prim__precision a
 
-
+  
   export
   rangeMax : (obj : WebGLShaderPrecisionFormat) -> JSIO Int32
   rangeMax a = primJS $ WebGLShaderPrecisionFormat.prim__rangeMax a
 
-
+  
   export
   rangeMin : (obj : WebGLShaderPrecisionFormat) -> JSIO Int32
   rangeMin a = primJS $ WebGLShaderPrecisionFormat.prim__rangeMin a
@@ -68,1362 +68,1358 @@ namespace WebGLShaderPrecisionFormat
 --------------------------------------------------------------------------------
 
 namespace WebGL2RenderingContextBase
-
-  public export
+  
+  export
   ACTIVE_UNIFORM_BLOCKS : Bits32
   ACTIVE_UNIFORM_BLOCKS = 0x8a36
 
-
-  public export
+  
+  export
   ALREADY_SIGNALED : Bits32
   ALREADY_SIGNALED = 0x911a
 
-
-  public export
+  
+  export
   ANY_SAMPLES_PASSED : Bits32
   ANY_SAMPLES_PASSED = 0x8c2f
 
-
-  public export
+  
+  export
   ANY_SAMPLES_PASSED_CONSERVATIVE : Bits32
   ANY_SAMPLES_PASSED_CONSERVATIVE = 0x8d6a
 
-
-  public export
+  
+  export
   COLOR : Bits32
   COLOR = 0x1800
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT1 : Bits32
   COLOR_ATTACHMENT1 = 0x8ce1
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT10 : Bits32
   COLOR_ATTACHMENT10 = 0x8cea
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT11 : Bits32
   COLOR_ATTACHMENT11 = 0x8ceb
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT12 : Bits32
   COLOR_ATTACHMENT12 = 0x8cec
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT13 : Bits32
   COLOR_ATTACHMENT13 = 0x8ced
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT14 : Bits32
   COLOR_ATTACHMENT14 = 0x8cee
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT15 : Bits32
   COLOR_ATTACHMENT15 = 0x8cef
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT2 : Bits32
   COLOR_ATTACHMENT2 = 0x8ce2
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT3 : Bits32
   COLOR_ATTACHMENT3 = 0x8ce3
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT4 : Bits32
   COLOR_ATTACHMENT4 = 0x8ce4
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT5 : Bits32
   COLOR_ATTACHMENT5 = 0x8ce5
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT6 : Bits32
   COLOR_ATTACHMENT6 = 0x8ce6
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT7 : Bits32
   COLOR_ATTACHMENT7 = 0x8ce7
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT8 : Bits32
   COLOR_ATTACHMENT8 = 0x8ce8
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT9 : Bits32
   COLOR_ATTACHMENT9 = 0x8ce9
 
-
-  public export
+  
+  export
   COMPARE_REF_TO_TEXTURE : Bits32
   COMPARE_REF_TO_TEXTURE = 0x884e
 
-
-  public export
+  
+  export
   CONDITION_SATISFIED : Bits32
   CONDITION_SATISFIED = 0x911c
 
-
-  public export
+  
+  export
   COPY_READ_BUFFER : Bits32
   COPY_READ_BUFFER = 0x8f36
 
-
-  public export
+  
+  export
   COPY_READ_BUFFER_BINDING : Bits32
   COPY_READ_BUFFER_BINDING = 0x8f36
 
-
-  public export
+  
+  export
   COPY_WRITE_BUFFER : Bits32
   COPY_WRITE_BUFFER = 0x8f37
 
-
-  public export
+  
+  export
   COPY_WRITE_BUFFER_BINDING : Bits32
   COPY_WRITE_BUFFER_BINDING = 0x8f37
 
-
-  public export
+  
+  export
   CURRENT_QUERY : Bits32
   CURRENT_QUERY = 0x8865
 
-
-  public export
+  
+  export
   DEPTH : Bits32
   DEPTH = 0x1801
 
-
-  public export
+  
+  export
   DEPTH24_STENCIL8 : Bits32
   DEPTH24_STENCIL8 = 0x88f0
 
-
-  public export
+  
+  export
   DEPTH32F_STENCIL8 : Bits32
   DEPTH32F_STENCIL8 = 0x8cad
 
-
-  public export
+  
+  export
   DEPTH_COMPONENT24 : Bits32
   DEPTH_COMPONENT24 = 0x81a6
 
-
-  public export
+  
+  export
   DEPTH_COMPONENT32F : Bits32
   DEPTH_COMPONENT32F = 0x8cac
 
-
-  public export
+  
+  export
   DRAW_BUFFER0 : Bits32
   DRAW_BUFFER0 = 0x8825
 
-
-  public export
+  
+  export
   DRAW_BUFFER1 : Bits32
   DRAW_BUFFER1 = 0x8826
 
-
-  public export
+  
+  export
   DRAW_BUFFER10 : Bits32
   DRAW_BUFFER10 = 0x882f
 
-
-  public export
+  
+  export
   DRAW_BUFFER11 : Bits32
   DRAW_BUFFER11 = 0x8830
 
-
-  public export
+  
+  export
   DRAW_BUFFER12 : Bits32
   DRAW_BUFFER12 = 0x8831
 
-
-  public export
+  
+  export
   DRAW_BUFFER13 : Bits32
   DRAW_BUFFER13 = 0x8832
 
-
-  public export
+  
+  export
   DRAW_BUFFER14 : Bits32
   DRAW_BUFFER14 = 0x8833
 
-
-  public export
+  
+  export
   DRAW_BUFFER15 : Bits32
   DRAW_BUFFER15 = 0x8834
 
-
-  public export
+  
+  export
   DRAW_BUFFER2 : Bits32
   DRAW_BUFFER2 = 0x8827
 
-
-  public export
+  
+  export
   DRAW_BUFFER3 : Bits32
   DRAW_BUFFER3 = 0x8828
 
-
-  public export
+  
+  export
   DRAW_BUFFER4 : Bits32
   DRAW_BUFFER4 = 0x8829
 
-
-  public export
+  
+  export
   DRAW_BUFFER5 : Bits32
   DRAW_BUFFER5 = 0x882a
 
-
-  public export
+  
+  export
   DRAW_BUFFER6 : Bits32
   DRAW_BUFFER6 = 0x882b
 
-
-  public export
+  
+  export
   DRAW_BUFFER7 : Bits32
   DRAW_BUFFER7 = 0x882c
 
-
-  public export
+  
+  export
   DRAW_BUFFER8 : Bits32
   DRAW_BUFFER8 = 0x882d
 
-
-  public export
+  
+  export
   DRAW_BUFFER9 : Bits32
   DRAW_BUFFER9 = 0x882e
 
-
-  public export
+  
+  export
   DRAW_FRAMEBUFFER : Bits32
   DRAW_FRAMEBUFFER = 0x8ca9
 
-
-  public export
+  
+  export
   DRAW_FRAMEBUFFER_BINDING : Bits32
   DRAW_FRAMEBUFFER_BINDING = 0x8ca6
 
-
-  public export
+  
+  export
   DYNAMIC_COPY : Bits32
   DYNAMIC_COPY = 0x88ea
 
-
-  public export
+  
+  export
   DYNAMIC_READ : Bits32
   DYNAMIC_READ = 0x88e9
 
-
-  public export
+  
+  export
   FLOAT_32_UNSIGNED_INT_24_8_REV : Bits32
   FLOAT_32_UNSIGNED_INT_24_8_REV = 0x8dad
 
-
-  public export
+  
+  export
   FLOAT_MAT2x3 : Bits32
   FLOAT_MAT2x3 = 0x8b65
 
-
-  public export
+  
+  export
   FLOAT_MAT2x4 : Bits32
   FLOAT_MAT2x4 = 0x8b66
 
-
-  public export
+  
+  export
   FLOAT_MAT3x2 : Bits32
   FLOAT_MAT3x2 = 0x8b67
 
-
-  public export
+  
+  export
   FLOAT_MAT3x4 : Bits32
   FLOAT_MAT3x4 = 0x8b68
 
-
-  public export
+  
+  export
   FLOAT_MAT4x2 : Bits32
   FLOAT_MAT4x2 = 0x8b69
 
-
-  public export
+  
+  export
   FLOAT_MAT4x3 : Bits32
   FLOAT_MAT4x3 = 0x8b6a
 
-
-  public export
+  
+  export
   FRAGMENT_SHADER_DERIVATIVE_HINT : Bits32
   FRAGMENT_SHADER_DERIVATIVE_HINT = 0x8b8b
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE = 0x8215
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_BLUE_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_BLUE_SIZE = 0x8214
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING : Bits32
   FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING = 0x8210
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE : Bits32
   FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE = 0x8211
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE = 0x8216
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_GREEN_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_GREEN_SIZE = 0x8213
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_RED_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_RED_SIZE = 0x8212
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE : Bits32
   FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE = 0x8217
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER : Bits32
   FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER = 0x8cd4
 
-
-  public export
+  
+  export
   FRAMEBUFFER_DEFAULT : Bits32
   FRAMEBUFFER_DEFAULT = 0x8218
 
-
-  public export
+  
+  export
   FRAMEBUFFER_INCOMPLETE_MULTISAMPLE : Bits32
   FRAMEBUFFER_INCOMPLETE_MULTISAMPLE = 0x8d56
 
-
-  public export
+  
+  export
   HALF_FLOAT : Bits32
   HALF_FLOAT = 0x140b
 
-
-  public export
+  
+  export
   INTERLEAVED_ATTRIBS : Bits32
   INTERLEAVED_ATTRIBS = 0x8c8c
 
-
-  public export
+  
+  export
   INT_2_10_10_10_REV : Bits32
   INT_2_10_10_10_REV = 0x8d9f
 
-
-  public export
+  
+  export
   INT_SAMPLER_2D : Bits32
   INT_SAMPLER_2D = 0x8dca
 
-
-  public export
+  
+  export
   INT_SAMPLER_2D_ARRAY : Bits32
   INT_SAMPLER_2D_ARRAY = 0x8dcf
 
-
-  public export
+  
+  export
   INT_SAMPLER_3D : Bits32
   INT_SAMPLER_3D = 0x8dcb
 
-
-  public export
+  
+  export
   INT_SAMPLER_CUBE : Bits32
   INT_SAMPLER_CUBE = 0x8dcc
 
-
-  public export
+  
+  export
   INVALID_INDEX : Bits32
   INVALID_INDEX = 0xffffffff
 
-
-  public export
+  
+  export
   MAX : Bits32
   MAX = 0x8008
 
-
-  public export
+  
+  export
   MAX_3D_TEXTURE_SIZE : Bits32
   MAX_3D_TEXTURE_SIZE = 0x8073
 
-
-  public export
+  
+  export
   MAX_ARRAY_TEXTURE_LAYERS : Bits32
   MAX_ARRAY_TEXTURE_LAYERS = 0x88ff
 
-
-  public export
+  
+  export
   MAX_CLIENT_WAIT_TIMEOUT_WEBGL : Bits32
   MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247
 
-
-  public export
+  
+  export
   MAX_COLOR_ATTACHMENTS : Bits32
   MAX_COLOR_ATTACHMENTS = 0x8cdf
 
-
-  public export
+  
+  export
   MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS : Bits32
   MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS = 0x8a33
 
-
-  public export
+  
+  export
   MAX_COMBINED_UNIFORM_BLOCKS : Bits32
   MAX_COMBINED_UNIFORM_BLOCKS = 0x8a2e
 
-
-  public export
+  
+  export
   MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS : Bits32
   MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS = 0x8a31
 
-
-  public export
+  
+  export
   MAX_DRAW_BUFFERS : Bits32
   MAX_DRAW_BUFFERS = 0x8824
 
-
-  public export
+  
+  export
   MAX_ELEMENTS_INDICES : Bits32
   MAX_ELEMENTS_INDICES = 0x80e9
 
-
-  public export
+  
+  export
   MAX_ELEMENTS_VERTICES : Bits32
   MAX_ELEMENTS_VERTICES = 0x80e8
 
-
-  public export
+  
+  export
   MAX_ELEMENT_INDEX : Bits32
   MAX_ELEMENT_INDEX = 0x8d6b
 
-
-  public export
+  
+  export
   MAX_FRAGMENT_INPUT_COMPONENTS : Bits32
   MAX_FRAGMENT_INPUT_COMPONENTS = 0x9125
 
-
-  public export
+  
+  export
   MAX_FRAGMENT_UNIFORM_BLOCKS : Bits32
   MAX_FRAGMENT_UNIFORM_BLOCKS = 0x8a2d
 
-
-  public export
+  
+  export
   MAX_FRAGMENT_UNIFORM_COMPONENTS : Bits32
   MAX_FRAGMENT_UNIFORM_COMPONENTS = 0x8b49
 
-
-  public export
+  
+  export
   MAX_PROGRAM_TEXEL_OFFSET : Bits32
   MAX_PROGRAM_TEXEL_OFFSET = 0x8905
 
-
-  public export
+  
+  export
   MAX_SAMPLES : Bits32
   MAX_SAMPLES = 0x8d57
 
-
-  public export
+  
+  export
   MAX_SERVER_WAIT_TIMEOUT : Bits32
   MAX_SERVER_WAIT_TIMEOUT = 0x9111
 
-
-  public export
+  
+  export
   MAX_TEXTURE_LOD_BIAS : Bits32
   MAX_TEXTURE_LOD_BIAS = 0x84fd
 
-
-  public export
+  
+  export
   MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS : Bits32
   MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 0x8c8a
 
-
-  public export
+  
+  export
   MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS : Bits32
   MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 0x8c8b
 
-
-  public export
+  
+  export
   MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS : Bits32
   MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS = 0x8c80
 
-
-  public export
+  
+  export
   MAX_UNIFORM_BLOCK_SIZE : Bits32
   MAX_UNIFORM_BLOCK_SIZE = 0x8a30
 
-
-  public export
+  
+  export
   MAX_UNIFORM_BUFFER_BINDINGS : Bits32
   MAX_UNIFORM_BUFFER_BINDINGS = 0x8a2f
 
-
-  public export
+  
+  export
   MAX_VARYING_COMPONENTS : Bits32
   MAX_VARYING_COMPONENTS = 0x8b4b
 
-
-  public export
+  
+  export
   MAX_VERTEX_OUTPUT_COMPONENTS : Bits32
   MAX_VERTEX_OUTPUT_COMPONENTS = 0x9122
 
-
-  public export
+  
+  export
   MAX_VERTEX_UNIFORM_BLOCKS : Bits32
   MAX_VERTEX_UNIFORM_BLOCKS = 0x8a2b
 
-
-  public export
+  
+  export
   MAX_VERTEX_UNIFORM_COMPONENTS : Bits32
   MAX_VERTEX_UNIFORM_COMPONENTS = 0x8b4a
 
-
-  public export
+  
+  export
   MIN : Bits32
   MIN = 0x8007
 
-
-  public export
+  
+  export
   MIN_PROGRAM_TEXEL_OFFSET : Bits32
   MIN_PROGRAM_TEXEL_OFFSET = 0x8904
 
-
-  public export
+  
+  export
   OBJECT_TYPE : Bits32
   OBJECT_TYPE = 0x9112
 
-
-  public export
+  
+  export
   PACK_ROW_LENGTH : Bits32
   PACK_ROW_LENGTH = 0xd02
 
-
-  public export
+  
+  export
   PACK_SKIP_PIXELS : Bits32
   PACK_SKIP_PIXELS = 0xd04
 
-
-  public export
+  
+  export
   PACK_SKIP_ROWS : Bits32
   PACK_SKIP_ROWS = 0xd03
 
-
-  public export
+  
+  export
   PIXEL_PACK_BUFFER : Bits32
   PIXEL_PACK_BUFFER = 0x88eb
 
-
-  public export
+  
+  export
   PIXEL_PACK_BUFFER_BINDING : Bits32
   PIXEL_PACK_BUFFER_BINDING = 0x88ed
 
-
-  public export
+  
+  export
   PIXEL_UNPACK_BUFFER : Bits32
   PIXEL_UNPACK_BUFFER = 0x88ec
 
-
-  public export
+  
+  export
   PIXEL_UNPACK_BUFFER_BINDING : Bits32
   PIXEL_UNPACK_BUFFER_BINDING = 0x88ef
 
-
-  public export
+  
+  export
   QUERY_RESULT : Bits32
   QUERY_RESULT = 0x8866
 
-
-  public export
+  
+  export
   QUERY_RESULT_AVAILABLE : Bits32
   QUERY_RESULT_AVAILABLE = 0x8867
 
-
-  public export
+  
+  export
   R11F_G11F_B10F : Bits32
   R11F_G11F_B10F = 0x8c3a
 
-
-  public export
+  
+  export
   R16F : Bits32
   R16F = 0x822d
 
-
-  public export
+  
+  export
   R16I : Bits32
   R16I = 0x8233
 
-
-  public export
+  
+  export
   R16UI : Bits32
   R16UI = 0x8234
 
-
-  public export
+  
+  export
   R32F : Bits32
   R32F = 0x822e
 
-
-  public export
+  
+  export
   R32I : Bits32
   R32I = 0x8235
 
-
-  public export
+  
+  export
   R32UI : Bits32
   R32UI = 0x8236
 
-
-  public export
+  
+  export
   R8 : Bits32
   R8 = 0x8229
 
-
-  public export
+  
+  export
   R8I : Bits32
   R8I = 0x8231
 
-
-  public export
+  
+  export
   R8UI : Bits32
   R8UI = 0x8232
 
-
-  public export
+  
+  export
   R8_SNORM : Bits32
   R8_SNORM = 0x8f94
 
-
-  public export
+  
+  export
   RASTERIZER_DISCARD : Bits32
   RASTERIZER_DISCARD = 0x8c89
 
-
-  public export
+  
+  export
   READ_BUFFER : Bits32
   READ_BUFFER = 0xc02
 
-
-  public export
+  
+  export
   READ_FRAMEBUFFER : Bits32
   READ_FRAMEBUFFER = 0x8ca8
 
-
-  public export
+  
+  export
   READ_FRAMEBUFFER_BINDING : Bits32
   READ_FRAMEBUFFER_BINDING = 0x8caa
 
-
-  public export
+  
+  export
   RED : Bits32
   RED = 0x1903
 
-
-  public export
+  
+  export
   RED_INTEGER : Bits32
   RED_INTEGER = 0x8d94
 
-
-  public export
+  
+  export
   RENDERBUFFER_SAMPLES : Bits32
   RENDERBUFFER_SAMPLES = 0x8cab
 
-
-  public export
+  
+  export
   RG : Bits32
   RG = 0x8227
 
-
-  public export
+  
+  export
   RG16F : Bits32
   RG16F = 0x822f
 
-
-  public export
+  
+  export
   RG16I : Bits32
   RG16I = 0x8239
 
-
-  public export
+  
+  export
   RG16UI : Bits32
   RG16UI = 0x823a
 
-
-  public export
+  
+  export
   RG32F : Bits32
   RG32F = 0x8230
 
-
-  public export
+  
+  export
   RG32I : Bits32
   RG32I = 0x823b
 
-
-  public export
+  
+  export
   RG32UI : Bits32
   RG32UI = 0x823c
 
-
-  public export
+  
+  export
   RG8 : Bits32
   RG8 = 0x822b
 
-
-  public export
+  
+  export
   RG8I : Bits32
   RG8I = 0x8237
 
-
-  public export
+  
+  export
   RG8UI : Bits32
   RG8UI = 0x8238
 
-
-  public export
+  
+  export
   RG8_SNORM : Bits32
   RG8_SNORM = 0x8f95
 
-
-  public export
+  
+  export
   RGB10_A2 : Bits32
   RGB10_A2 = 0x8059
 
-
-  public export
+  
+  export
   RGB10_A2UI : Bits32
   RGB10_A2UI = 0x906f
 
-
-  public export
+  
+  export
   RGB16F : Bits32
   RGB16F = 0x881b
 
-
-  public export
+  
+  export
   RGB16I : Bits32
   RGB16I = 0x8d89
 
-
-  public export
+  
+  export
   RGB16UI : Bits32
   RGB16UI = 0x8d77
 
-
-  public export
+  
+  export
   RGB32F : Bits32
   RGB32F = 0x8815
 
-
-  public export
+  
+  export
   RGB32I : Bits32
   RGB32I = 0x8d83
 
-
-  public export
+  
+  export
   RGB32UI : Bits32
   RGB32UI = 0x8d71
 
-
-  public export
+  
+  export
   RGB8 : Bits32
   RGB8 = 0x8051
 
-
-  public export
+  
+  export
   RGB8I : Bits32
   RGB8I = 0x8d8f
 
-
-  public export
+  
+  export
   RGB8UI : Bits32
   RGB8UI = 0x8d7d
 
-
-  public export
+  
+  export
   RGB8_SNORM : Bits32
   RGB8_SNORM = 0x8f96
 
-
-  public export
+  
+  export
   RGB9_E5 : Bits32
   RGB9_E5 = 0x8c3d
 
-
-  public export
+  
+  export
   RGBA16F : Bits32
   RGBA16F = 0x881a
 
-
-  public export
+  
+  export
   RGBA16I : Bits32
   RGBA16I = 0x8d88
 
-
-  public export
+  
+  export
   RGBA16UI : Bits32
   RGBA16UI = 0x8d76
 
-
-  public export
+  
+  export
   RGBA32F : Bits32
   RGBA32F = 0x8814
 
-
-  public export
+  
+  export
   RGBA32I : Bits32
   RGBA32I = 0x8d82
 
-
-  public export
+  
+  export
   RGBA32UI : Bits32
   RGBA32UI = 0x8d70
 
-
-  public export
+  
+  export
   RGBA8 : Bits32
   RGBA8 = 0x8058
 
-
-  public export
+  
+  export
   RGBA8I : Bits32
   RGBA8I = 0x8d8e
 
-
-  public export
+  
+  export
   RGBA8UI : Bits32
   RGBA8UI = 0x8d7c
 
-
-  public export
+  
+  export
   RGBA8_SNORM : Bits32
   RGBA8_SNORM = 0x8f97
 
-
-  public export
+  
+  export
   RGBA_INTEGER : Bits32
   RGBA_INTEGER = 0x8d99
 
-
-  public export
+  
+  export
   RGB_INTEGER : Bits32
   RGB_INTEGER = 0x8d98
 
-
-  public export
+  
+  export
   RG_INTEGER : Bits32
   RG_INTEGER = 0x8228
 
-
-  public export
+  
+  export
   SAMPLER_2D_ARRAY : Bits32
   SAMPLER_2D_ARRAY = 0x8dc1
 
-
-  public export
+  
+  export
   SAMPLER_2D_ARRAY_SHADOW : Bits32
   SAMPLER_2D_ARRAY_SHADOW = 0x8dc4
 
-
-  public export
+  
+  export
   SAMPLER_2D_SHADOW : Bits32
   SAMPLER_2D_SHADOW = 0x8b62
 
-
-  public export
+  
+  export
   SAMPLER_3D : Bits32
   SAMPLER_3D = 0x8b5f
 
-
-  public export
+  
+  export
   SAMPLER_BINDING : Bits32
   SAMPLER_BINDING = 0x8919
 
-
-  public export
+  
+  export
   SAMPLER_CUBE_SHADOW : Bits32
   SAMPLER_CUBE_SHADOW = 0x8dc5
 
-
-  public export
+  
+  export
   SEPARATE_ATTRIBS : Bits32
   SEPARATE_ATTRIBS = 0x8c8d
 
-
-  public export
+  
+  export
   SIGNALED : Bits32
   SIGNALED = 0x9119
 
-
-  public export
+  
+  export
   SIGNED_NORMALIZED : Bits32
   SIGNED_NORMALIZED = 0x8f9c
 
-
-  public export
+  
+  export
   SRGB : Bits32
   SRGB = 0x8c40
 
-
-  public export
+  
+  export
   SRGB8 : Bits32
   SRGB8 = 0x8c41
 
-
-  public export
+  
+  export
   SRGB8_ALPHA8 : Bits32
   SRGB8_ALPHA8 = 0x8c43
 
-
-  public export
+  
+  export
   STATIC_COPY : Bits32
   STATIC_COPY = 0x88e6
 
-
-  public export
+  
+  export
   STATIC_READ : Bits32
   STATIC_READ = 0x88e5
 
-
-  public export
+  
+  export
   STENCIL : Bits32
   STENCIL = 0x1802
 
-
-  public export
+  
+  export
   STREAM_COPY : Bits32
   STREAM_COPY = 0x88e2
 
-
-  public export
+  
+  export
   STREAM_READ : Bits32
   STREAM_READ = 0x88e1
 
-
-  public export
+  
+  export
   SYNC_CONDITION : Bits32
   SYNC_CONDITION = 0x9113
 
-
-  public export
+  
+  export
   SYNC_FENCE : Bits32
   SYNC_FENCE = 0x9116
 
-
-  public export
+  
+  export
   SYNC_FLAGS : Bits32
   SYNC_FLAGS = 0x9115
 
-
-  public export
+  
+  export
   SYNC_FLUSH_COMMANDS_BIT : Bits32
   SYNC_FLUSH_COMMANDS_BIT = 0x1
 
-
-  public export
+  
+  export
   SYNC_GPU_COMMANDS_COMPLETE : Bits32
   SYNC_GPU_COMMANDS_COMPLETE = 0x9117
 
-
-  public export
+  
+  export
   SYNC_STATUS : Bits32
   SYNC_STATUS = 0x9114
 
-
-  public export
+  
+  export
   TEXTURE_2D_ARRAY : Bits32
   TEXTURE_2D_ARRAY = 0x8c1a
 
-
-  public export
+  
+  export
   TEXTURE_3D : Bits32
   TEXTURE_3D = 0x806f
 
-
-  public export
+  
+  export
   TEXTURE_BASE_LEVEL : Bits32
   TEXTURE_BASE_LEVEL = 0x813c
 
-
-  public export
+  
+  export
   TEXTURE_BINDING_2D_ARRAY : Bits32
   TEXTURE_BINDING_2D_ARRAY = 0x8c1d
 
-
-  public export
+  
+  export
   TEXTURE_BINDING_3D : Bits32
   TEXTURE_BINDING_3D = 0x806a
 
-
-  public export
+  
+  export
   TEXTURE_COMPARE_FUNC : Bits32
   TEXTURE_COMPARE_FUNC = 0x884d
 
-
-  public export
+  
+  export
   TEXTURE_COMPARE_MODE : Bits32
   TEXTURE_COMPARE_MODE = 0x884c
 
-
-  public export
+  
+  export
   TEXTURE_IMMUTABLE_FORMAT : Bits32
   TEXTURE_IMMUTABLE_FORMAT = 0x912f
 
-
-  public export
+  
+  export
   TEXTURE_IMMUTABLE_LEVELS : Bits32
   TEXTURE_IMMUTABLE_LEVELS = 0x82df
 
-
-  public export
+  
+  export
   TEXTURE_MAX_LEVEL : Bits32
   TEXTURE_MAX_LEVEL = 0x813d
 
-
-  public export
+  
+  export
   TEXTURE_MAX_LOD : Bits32
   TEXTURE_MAX_LOD = 0x813b
 
-
-  public export
+  
+  export
   TEXTURE_MIN_LOD : Bits32
   TEXTURE_MIN_LOD = 0x813a
 
-
-  public export
+  
+  export
   TEXTURE_WRAP_R : Bits32
   TEXTURE_WRAP_R = 0x8072
 
-
-  public export
+  
+  export
   TIMEOUT_EXPIRED : Bits32
   TIMEOUT_EXPIRED = 0x911b
 
-
-  public export
+  
+  export
   TIMEOUT_IGNORED : JSInt64
   TIMEOUT_IGNORED = -1
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK : Bits32
   TRANSFORM_FEEDBACK = 0x8e22
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_ACTIVE : Bits32
   TRANSFORM_FEEDBACK_ACTIVE = 0x8e24
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BINDING : Bits32
   TRANSFORM_FEEDBACK_BINDING = 0x8e25
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BUFFER : Bits32
   TRANSFORM_FEEDBACK_BUFFER = 0x8c8e
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BUFFER_BINDING : Bits32
   TRANSFORM_FEEDBACK_BUFFER_BINDING = 0x8c8f
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BUFFER_MODE : Bits32
   TRANSFORM_FEEDBACK_BUFFER_MODE = 0x8c7f
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BUFFER_SIZE : Bits32
   TRANSFORM_FEEDBACK_BUFFER_SIZE = 0x8c85
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_BUFFER_START : Bits32
   TRANSFORM_FEEDBACK_BUFFER_START = 0x8c84
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_PAUSED : Bits32
   TRANSFORM_FEEDBACK_PAUSED = 0x8e23
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN : Bits32
   TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = 0x8c88
 
-
-  public export
+  
+  export
   TRANSFORM_FEEDBACK_VARYINGS : Bits32
   TRANSFORM_FEEDBACK_VARYINGS = 0x8c83
 
-
-  public export
+  
+  export
   UNIFORM_ARRAY_STRIDE : Bits32
   UNIFORM_ARRAY_STRIDE = 0x8a3c
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_ACTIVE_UNIFORMS : Bits32
   UNIFORM_BLOCK_ACTIVE_UNIFORMS = 0x8a42
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES : Bits32
   UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES = 0x8a43
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_BINDING : Bits32
   UNIFORM_BLOCK_BINDING = 0x8a3f
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_DATA_SIZE : Bits32
   UNIFORM_BLOCK_DATA_SIZE = 0x8a40
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_INDEX : Bits32
   UNIFORM_BLOCK_INDEX = 0x8a3a
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER : Bits32
   UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER = 0x8a46
 
-
-  public export
+  
+  export
   UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER : Bits32
   UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER = 0x8a44
 
-
-  public export
+  
+  export
   UNIFORM_BUFFER : Bits32
   UNIFORM_BUFFER = 0x8a11
 
-
-  public export
+  
+  export
   UNIFORM_BUFFER_BINDING : Bits32
   UNIFORM_BUFFER_BINDING = 0x8a28
 
-
-  public export
+  
+  export
   UNIFORM_BUFFER_OFFSET_ALIGNMENT : Bits32
   UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8a34
 
-
-  public export
+  
+  export
   UNIFORM_BUFFER_SIZE : Bits32
   UNIFORM_BUFFER_SIZE = 0x8a2a
 
-
-  public export
+  
+  export
   UNIFORM_BUFFER_START : Bits32
   UNIFORM_BUFFER_START = 0x8a29
 
-
-  public export
+  
+  export
   UNIFORM_IS_ROW_MAJOR : Bits32
   UNIFORM_IS_ROW_MAJOR = 0x8a3e
 
-
-  public export
+  
+  export
   UNIFORM_MATRIX_STRIDE : Bits32
   UNIFORM_MATRIX_STRIDE = 0x8a3d
 
-
-  public export
+  
+  export
   UNIFORM_OFFSET : Bits32
   UNIFORM_OFFSET = 0x8a3b
 
-
-  public export
+  
+  export
   UNIFORM_SIZE : Bits32
   UNIFORM_SIZE = 0x8a38
 
-
-  public export
+  
+  export
   UNIFORM_TYPE : Bits32
   UNIFORM_TYPE = 0x8a37
 
-
-  public export
+  
+  export
   UNPACK_IMAGE_HEIGHT : Bits32
   UNPACK_IMAGE_HEIGHT = 0x806e
 
-
-  public export
+  
+  export
   UNPACK_ROW_LENGTH : Bits32
   UNPACK_ROW_LENGTH = 0xcf2
 
-
-  public export
+  
+  export
   UNPACK_SKIP_IMAGES : Bits32
   UNPACK_SKIP_IMAGES = 0x806d
 
-
-  public export
+  
+  export
   UNPACK_SKIP_PIXELS : Bits32
   UNPACK_SKIP_PIXELS = 0xcf4
 
-
-  public export
+  
+  export
   UNPACK_SKIP_ROWS : Bits32
   UNPACK_SKIP_ROWS = 0xcf3
 
-
-  public export
+  
+  export
   UNSIGNALED : Bits32
   UNSIGNALED = 0x9118
 
-
-  public export
+  
+  export
   UNSIGNED_INT_10F_11F_11F_REV : Bits32
   UNSIGNED_INT_10F_11F_11F_REV = 0x8c3b
 
-
-  public export
+  
+  export
   UNSIGNED_INT_24_8 : Bits32
   UNSIGNED_INT_24_8 = 0x84fa
 
-
-  public export
+  
+  export
   UNSIGNED_INT_2_10_10_10_REV : Bits32
   UNSIGNED_INT_2_10_10_10_REV = 0x8368
 
-
-  public export
+  
+  export
   UNSIGNED_INT_5_9_9_9_REV : Bits32
   UNSIGNED_INT_5_9_9_9_REV = 0x8c3e
 
-
-  public export
+  
+  export
   UNSIGNED_INT_SAMPLER_2D : Bits32
   UNSIGNED_INT_SAMPLER_2D = 0x8dd2
 
-
-  public export
+  
+  export
   UNSIGNED_INT_SAMPLER_2D_ARRAY : Bits32
   UNSIGNED_INT_SAMPLER_2D_ARRAY = 0x8dd7
 
-
-  public export
+  
+  export
   UNSIGNED_INT_SAMPLER_3D : Bits32
   UNSIGNED_INT_SAMPLER_3D = 0x8dd3
 
-
-  public export
+  
+  export
   UNSIGNED_INT_SAMPLER_CUBE : Bits32
   UNSIGNED_INT_SAMPLER_CUBE = 0x8dd4
 
-
-  public export
+  
+  export
   UNSIGNED_INT_VEC2 : Bits32
   UNSIGNED_INT_VEC2 = 0x8dc6
 
-
-  public export
+  
+  export
   UNSIGNED_INT_VEC3 : Bits32
   UNSIGNED_INT_VEC3 = 0x8dc7
 
-
-  public export
+  
+  export
   UNSIGNED_INT_VEC4 : Bits32
   UNSIGNED_INT_VEC4 = 0x8dc8
 
-
-  public export
+  
+  export
   UNSIGNED_NORMALIZED : Bits32
   UNSIGNED_NORMALIZED = 0x8c17
 
-
-  public export
+  
+  export
   VERTEX_ARRAY_BINDING : Bits32
   VERTEX_ARRAY_BINDING = 0x85b5
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_DIVISOR : Bits32
   VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88fe
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_INTEGER : Bits32
   VERTEX_ATTRIB_ARRAY_INTEGER = 0x88fd
 
-
-  public export
+  
+  export
   WAIT_FAILED : Bits32
   WAIT_FAILED = 0x911d
 
-
+  
   export
   beginQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (query : WebGLQuery)
     -> JSIO ()
   beginQuery a b c = primJS $
-    WebGL2RenderingContextBase.prim__beginQuery (up a) b c
+    WebGL2RenderingContextBase.prim__beginQuery (cast a) b c
 
-
+  
   export
   beginTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (primitiveMode : Bits32)
     -> JSIO ()
   beginTransformFeedback a b = primJS $
-    WebGL2RenderingContextBase.prim__beginTransformFeedback (up a) b
+    WebGL2RenderingContextBase.prim__beginTransformFeedback (cast a) b
 
-
+  
   export
   bindBufferBase :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (index : Bits32)
     -> (buffer : Maybe WebGLBuffer)
     -> JSIO ()
   bindBufferBase a b c d = primJS $
-    WebGL2RenderingContextBase.prim__bindBufferBase (up a) b c (toFFI d)
+    WebGL2RenderingContextBase.prim__bindBufferBase (cast a) b c (toFFI d)
 
-
+  
   export
   bindBufferRange :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (index : Bits32)
@@ -1432,48 +1428,44 @@ namespace WebGL2RenderingContextBase
     -> (size : JSInt64)
     -> JSIO ()
   bindBufferRange a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__bindBufferRange (up a) b c (toFFI d) e f
+    WebGL2RenderingContextBase.prim__bindBufferRange (cast a) b c (toFFI d) e f
 
-
+  
   export
   bindSampler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (unit : Bits32)
     -> (sampler : Maybe WebGLSampler)
     -> JSIO ()
   bindSampler a b c = primJS $
-    WebGL2RenderingContextBase.prim__bindSampler (up a) b (toFFI c)
+    WebGL2RenderingContextBase.prim__bindSampler (cast a) b (toFFI c)
 
-
+  
   export
   bindTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (tf : Maybe WebGLTransformFeedback)
     -> JSIO ()
   bindTransformFeedback a b c = primJS $
-    WebGL2RenderingContextBase.prim__bindTransformFeedback (up a) b (toFFI c)
+    WebGL2RenderingContextBase.prim__bindTransformFeedback (cast a) b (toFFI c)
 
-
+  
   export
   bindVertexArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (array : Maybe WebGLVertexArrayObject)
     -> JSIO ()
   bindVertexArray a b = primJS $
-    WebGL2RenderingContextBase.prim__bindVertexArray (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__bindVertexArray (cast a) (toFFI b)
 
-
+  
   export
   blitFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (srcX0 : Int32)
     -> (srcY0 : Int32)
@@ -1487,13 +1479,23 @@ namespace WebGL2RenderingContextBase
     -> (filter : Bits32)
     -> JSIO ()
   blitFramebuffer a b c d e f g h i j k = primJS $
-    WebGL2RenderingContextBase.prim__blitFramebuffer (up a) b c d e f g h i j k
+    WebGL2RenderingContextBase.prim__blitFramebuffer
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      g
+      h
+      i
+      j
+      k
 
-
+  
   export
   clearBufferfi :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
@@ -1501,13 +1503,12 @@ namespace WebGL2RenderingContextBase
     -> (stencil : Int32)
     -> JSIO ()
   clearBufferfi a b c d e = primJS $
-    WebGL2RenderingContextBase.prim__clearBufferfi (up a) b c d e
+    WebGL2RenderingContextBase.prim__clearBufferfi (cast a) b c d e
 
-
+  
   export
   clearBufferfv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
@@ -1516,29 +1517,27 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   clearBufferfv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__clearBufferfv
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       (toFFI e)
-
+  
   export
   clearBufferfv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
     -> (values : HSum [Float32Array, Array Double])
     -> JSIO ()
   clearBufferfv a b c d = primJS $
-    WebGL2RenderingContextBase.prim__clearBufferfv (up a) b c (toFFI d) undef
+    WebGL2RenderingContextBase.prim__clearBufferfv (cast a) b c (toFFI d) undef
 
-
+  
   export
   clearBufferiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
@@ -1547,29 +1546,27 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   clearBufferiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__clearBufferiv
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       (toFFI e)
-
+  
   export
   clearBufferiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
     -> (values : HSum [Int32Array, Array Int32])
     -> JSIO ()
   clearBufferiv a b c d = primJS $
-    WebGL2RenderingContextBase.prim__clearBufferiv (up a) b c (toFFI d) undef
+    WebGL2RenderingContextBase.prim__clearBufferiv (cast a) b c (toFFI d) undef
 
-
+  
   export
   clearBufferuiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
@@ -1578,42 +1575,39 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   clearBufferuiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__clearBufferuiv
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       (toFFI e)
-
+  
   export
   clearBufferuiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffer : Bits32)
     -> (drawbuffer : Int32)
     -> (values : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   clearBufferuiv a b c d = primJS $
-    WebGL2RenderingContextBase.prim__clearBufferuiv (up a) b c (toFFI d) undef
+    WebGL2RenderingContextBase.prim__clearBufferuiv (cast a) b c (toFFI d) undef
 
-
+  
   export
   clientWaitSync :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sync : WebGLSync)
     -> (flags : Bits32)
     -> (timeout : JSBits64)
     -> JSIO Bits32
   clientWaitSync a b c d = primJS $
-    WebGL2RenderingContextBase.prim__clientWaitSync (up a) b c d
+    WebGL2RenderingContextBase.prim__clientWaitSync (cast a) b c d
 
-
+  
   export
   compressedTexImage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1627,7 +1621,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexImage3D a b c d e f g h i j = primJS $
     WebGL2RenderingContextBase.prim__compressedTexImage3D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1638,11 +1632,10 @@ namespace WebGL2RenderingContextBase
       i
       j
 
-
+  
   export
   compressedTexImage3D1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1668,7 +1661,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexImage3D1' a b c d e f g h i j k = primJS $
     WebGL2RenderingContextBase.prim__compressedTexImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1679,11 +1672,10 @@ namespace WebGL2RenderingContextBase
       (toFFI i)
       (toFFI j)
       (toFFI k)
-
+  
   export
   compressedTexImage3D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1707,7 +1699,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexImage3D1 a b c d e f g h i = primJS $
     WebGL2RenderingContextBase.prim__compressedTexImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1719,11 +1711,10 @@ namespace WebGL2RenderingContextBase
       undef
       undef
 
-
+  
   export
   compressedTexSubImage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1739,7 +1730,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexSubImage3D a b c d e f g h i j k l = primJS $
     WebGL2RenderingContextBase.prim__compressedTexSubImage3D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1752,11 +1743,10 @@ namespace WebGL2RenderingContextBase
       k
       l
 
-
+  
   export
   compressedTexSubImage3D1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1784,7 +1774,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexSubImage3D1' a b c d e f g h i j k l m = primJS $
     WebGL2RenderingContextBase.prim__compressedTexSubImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1797,11 +1787,10 @@ namespace WebGL2RenderingContextBase
       (toFFI k)
       (toFFI l)
       (toFFI m)
-
+  
   export
   compressedTexSubImage3D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1827,7 +1816,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   compressedTexSubImage3D1 a b c d e f g h i j k = primJS $
     WebGL2RenderingContextBase.prim__compressedTexSubImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -1841,11 +1830,10 @@ namespace WebGL2RenderingContextBase
       undef
       undef
 
-
+  
   export
   copyBufferSubData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (readTarget : Bits32)
     -> (writeTarget : Bits32)
@@ -1854,13 +1842,12 @@ namespace WebGL2RenderingContextBase
     -> (size : JSInt64)
     -> JSIO ()
   copyBufferSubData a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__copyBufferSubData (up a) b c d e f
+    WebGL2RenderingContextBase.prim__copyBufferSubData (cast a) b c d e f
 
-
+  
   export
   copyTexSubImage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -1873,108 +1860,108 @@ namespace WebGL2RenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   copyTexSubImage3D a b c d e f g h i j = primJS $
-    WebGL2RenderingContextBase.prim__copyTexSubImage3D (up a) b c d e f g h i j
+    WebGL2RenderingContextBase.prim__copyTexSubImage3D
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      g
+      h
+      i
+      j
 
-
+  
   export
   createQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLQuery)
   createQuery a = tryJS "WebGL2RenderingContextBase.createQuery" $
-    WebGL2RenderingContextBase.prim__createQuery (up a)
+    WebGL2RenderingContextBase.prim__createQuery (cast a)
 
-
+  
   export
   createSampler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLSampler)
   createSampler a = tryJS "WebGL2RenderingContextBase.createSampler" $
-    WebGL2RenderingContextBase.prim__createSampler (up a)
+    WebGL2RenderingContextBase.prim__createSampler (cast a)
 
-
+  
   export
   createTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLTransformFeedback)
   createTransformFeedback a = tryJS "WebGL2RenderingContextBase.createTransformFeedback" $
-    WebGL2RenderingContextBase.prim__createTransformFeedback (up a)
+    WebGL2RenderingContextBase.prim__createTransformFeedback (cast a)
 
-
+  
   export
   createVertexArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLVertexArrayObject)
   createVertexArray a = tryJS "WebGL2RenderingContextBase.createVertexArray" $
-    WebGL2RenderingContextBase.prim__createVertexArray (up a)
+    WebGL2RenderingContextBase.prim__createVertexArray (cast a)
 
-
+  
   export
   deleteQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (query : Maybe WebGLQuery)
     -> JSIO ()
   deleteQuery a b = primJS $
-    WebGL2RenderingContextBase.prim__deleteQuery (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__deleteQuery (cast a) (toFFI b)
 
-
+  
   export
   deleteSampler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sampler : Maybe WebGLSampler)
     -> JSIO ()
   deleteSampler a b = primJS $
-    WebGL2RenderingContextBase.prim__deleteSampler (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__deleteSampler (cast a) (toFFI b)
 
-
+  
   export
   deleteSync :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sync : Maybe WebGLSync)
     -> JSIO ()
   deleteSync a b = primJS $
-    WebGL2RenderingContextBase.prim__deleteSync (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__deleteSync (cast a) (toFFI b)
 
-
+  
   export
   deleteTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (tf : Maybe WebGLTransformFeedback)
     -> JSIO ()
   deleteTransformFeedback a b = primJS $
-    WebGL2RenderingContextBase.prim__deleteTransformFeedback (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__deleteTransformFeedback (cast a) (toFFI b)
 
-
+  
   export
   deleteVertexArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (vertexArray : Maybe WebGLVertexArrayObject)
     -> JSIO ()
   deleteVertexArray a b = primJS $
-    WebGL2RenderingContextBase.prim__deleteVertexArray (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__deleteVertexArray (cast a) (toFFI b)
 
-
+  
   export
   drawArraysInstanced :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> (first : Int32)
@@ -1982,24 +1969,22 @@ namespace WebGL2RenderingContextBase
     -> (instanceCount : Int32)
     -> JSIO ()
   drawArraysInstanced a b c d e = primJS $
-    WebGL2RenderingContextBase.prim__drawArraysInstanced (up a) b c d e
+    WebGL2RenderingContextBase.prim__drawArraysInstanced (cast a) b c d e
 
-
+  
   export
   drawBuffers :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (buffers : Array Bits32)
     -> JSIO ()
   drawBuffers a b = primJS $
-    WebGL2RenderingContextBase.prim__drawBuffers (up a) b
+    WebGL2RenderingContextBase.prim__drawBuffers (cast a) b
 
-
+  
   export
   drawElementsInstanced :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> (count : Int32)
@@ -2008,13 +1993,12 @@ namespace WebGL2RenderingContextBase
     -> (instanceCount : Int32)
     -> JSIO ()
   drawElementsInstanced a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__drawElementsInstanced (up a) b c d e f
+    WebGL2RenderingContextBase.prim__drawElementsInstanced (cast a) b c d e f
 
-
+  
   export
   drawRangeElements :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> (start : Bits32)
@@ -2024,45 +2008,41 @@ namespace WebGL2RenderingContextBase
     -> (offset : JSInt64)
     -> JSIO ()
   drawRangeElements a b c d e f g = primJS $
-    WebGL2RenderingContextBase.prim__drawRangeElements (up a) b c d e f g
+    WebGL2RenderingContextBase.prim__drawRangeElements (cast a) b c d e f g
 
-
+  
   export
   endQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> JSIO ()
-  endQuery a b = primJS $ WebGL2RenderingContextBase.prim__endQuery (up a) b
+  endQuery a b = primJS $ WebGL2RenderingContextBase.prim__endQuery (cast a) b
 
-
+  
   export
   endTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO ()
   endTransformFeedback a = primJS $
-    WebGL2RenderingContextBase.prim__endTransformFeedback (up a)
+    WebGL2RenderingContextBase.prim__endTransformFeedback (cast a)
 
-
+  
   export
   fenceSync :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (condition : Bits32)
     -> (flags : Bits32)
     -> JSIO (Maybe WebGLSync)
   fenceSync a b c = tryJS "WebGL2RenderingContextBase.fenceSync" $
-    WebGL2RenderingContextBase.prim__fenceSync (up a) b c
+    WebGL2RenderingContextBase.prim__fenceSync (cast a) b c
 
-
+  
   export
   framebufferTextureLayer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachment : Bits32)
@@ -2072,56 +2052,52 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   framebufferTextureLayer a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__framebufferTextureLayer
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       e
       f
 
-
+  
   export
   getActiveUniformBlockName :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformBlockIndex : Bits32)
     -> JSIO (Maybe String)
   getActiveUniformBlockName a b c = tryJS "WebGL2RenderingContextBase.getActiveUniformBlockName" $
-    WebGL2RenderingContextBase.prim__getActiveUniformBlockName (up a) b c
+    WebGL2RenderingContextBase.prim__getActiveUniformBlockName (cast a) b c
 
-
+  
   export
   getActiveUniformBlockParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformBlockIndex : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getActiveUniformBlockParameter a b c d = tryJS "WebGL2RenderingContextBase.getActiveUniformBlockParameter" $
-    WebGL2RenderingContextBase.prim__getActiveUniformBlockParameter (up a) b c d
+    WebGL2RenderingContextBase.prim__getActiveUniformBlockParameter (cast a) b c d
 
-
+  
   export
   getActiveUniforms :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformIndices : Array Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getActiveUniforms a b c d = tryJS "WebGL2RenderingContextBase.getActiveUniforms" $
-    WebGL2RenderingContextBase.prim__getActiveUniforms (up a) b c d
+    WebGL2RenderingContextBase.prim__getActiveUniforms (cast a) b c d
 
-
+  
   export
   getBufferSubData' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (srcByteOffset : JSInt64)
@@ -2142,17 +2118,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   getBufferSubData' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__getBufferSubData
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   getBufferSubData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (srcByteOffset : JSInt64)
@@ -2171,151 +2146,139 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   getBufferSubData a b c d = primJS $
     WebGL2RenderingContextBase.prim__getBufferSubData
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       undef
       undef
 
-
+  
   export
   getFragDataLocation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (name : String)
     -> JSIO Int32
   getFragDataLocation a b c = primJS $
-    WebGL2RenderingContextBase.prim__getFragDataLocation (up a) b c
+    WebGL2RenderingContextBase.prim__getFragDataLocation (cast a) b c
 
-
+  
   export
   getIndexedParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (index : Bits32)
     -> JSIO Any
   getIndexedParameter a b c = tryJS "WebGL2RenderingContextBase.getIndexedParameter" $
-    WebGL2RenderingContextBase.prim__getIndexedParameter (up a) b c
+    WebGL2RenderingContextBase.prim__getIndexedParameter (cast a) b c
 
-
+  
   export
   getInternalformatParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (internalformat : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getInternalformatParameter a b c d = tryJS "WebGL2RenderingContextBase.getInternalformatParameter" $
-    WebGL2RenderingContextBase.prim__getInternalformatParameter (up a) b c d
+    WebGL2RenderingContextBase.prim__getInternalformatParameter (cast a) b c d
 
-
+  
   export
   getQueryParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (query : WebGLQuery)
     -> (pname : Bits32)
     -> JSIO Any
   getQueryParameter a b c = tryJS "WebGL2RenderingContextBase.getQueryParameter" $
-    WebGL2RenderingContextBase.prim__getQueryParameter (up a) b c
+    WebGL2RenderingContextBase.prim__getQueryParameter (cast a) b c
 
-
+  
   export
   getQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> JSIO (Maybe WebGLQuery)
   getQuery a b c = tryJS "WebGL2RenderingContextBase.getQuery" $
-    WebGL2RenderingContextBase.prim__getQuery (up a) b c
+    WebGL2RenderingContextBase.prim__getQuery (cast a) b c
 
-
+  
   export
   getSamplerParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sampler : WebGLSampler)
     -> (pname : Bits32)
     -> JSIO Any
   getSamplerParameter a b c = tryJS "WebGL2RenderingContextBase.getSamplerParameter" $
-    WebGL2RenderingContextBase.prim__getSamplerParameter (up a) b c
+    WebGL2RenderingContextBase.prim__getSamplerParameter (cast a) b c
 
-
+  
   export
   getSyncParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sync : WebGLSync)
     -> (pname : Bits32)
     -> JSIO Any
   getSyncParameter a b c = tryJS "WebGL2RenderingContextBase.getSyncParameter" $
-    WebGL2RenderingContextBase.prim__getSyncParameter (up a) b c
+    WebGL2RenderingContextBase.prim__getSyncParameter (cast a) b c
 
-
+  
   export
   getTransformFeedbackVarying :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (index : Bits32)
     -> JSIO (Maybe WebGLActiveInfo)
   getTransformFeedbackVarying a b c = tryJS "WebGL2RenderingContextBase.getTransformFeedbackVarying" $
-    WebGL2RenderingContextBase.prim__getTransformFeedbackVarying (up a) b c
+    WebGL2RenderingContextBase.prim__getTransformFeedbackVarying (cast a) b c
 
-
+  
   export
   getUniformBlockIndex :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformBlockName : String)
     -> JSIO Bits32
   getUniformBlockIndex a b c = primJS $
-    WebGL2RenderingContextBase.prim__getUniformBlockIndex (up a) b c
+    WebGL2RenderingContextBase.prim__getUniformBlockIndex (cast a) b c
 
-
+  
   export
   getUniformIndices :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformNames : Array String)
     -> JSIO (Maybe (Array Bits32))
   getUniformIndices a b c = tryJS "WebGL2RenderingContextBase.getUniformIndices" $
-    WebGL2RenderingContextBase.prim__getUniformIndices (up a) b c
+    WebGL2RenderingContextBase.prim__getUniformIndices (cast a) b c
 
-
+  
   export
   invalidateFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachments : Array Bits32)
     -> JSIO ()
   invalidateFramebuffer a b c = primJS $
-    WebGL2RenderingContextBase.prim__invalidateFramebuffer (up a) b c
+    WebGL2RenderingContextBase.prim__invalidateFramebuffer (cast a) b c
 
-
+  
   export
   invalidateSubFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachments : Array Bits32)
@@ -2325,88 +2288,88 @@ namespace WebGL2RenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   invalidateSubFramebuffer a b c d e f g = primJS $
-    WebGL2RenderingContextBase.prim__invalidateSubFramebuffer (up a) b c d e f g
+    WebGL2RenderingContextBase.prim__invalidateSubFramebuffer
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      g
 
-
+  
   export
   isQuery :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (query : Maybe WebGLQuery)
     -> JSIO Bool
   isQuery a b = tryJS "WebGL2RenderingContextBase.isQuery" $
-    WebGL2RenderingContextBase.prim__isQuery (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__isQuery (cast a) (toFFI b)
 
-
+  
   export
   isSampler :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sampler : Maybe WebGLSampler)
     -> JSIO Bool
   isSampler a b = tryJS "WebGL2RenderingContextBase.isSampler" $
-    WebGL2RenderingContextBase.prim__isSampler (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__isSampler (cast a) (toFFI b)
 
-
+  
   export
   isSync :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sync : Maybe WebGLSync)
     -> JSIO Bool
   isSync a b = tryJS "WebGL2RenderingContextBase.isSync" $
-    WebGL2RenderingContextBase.prim__isSync (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__isSync (cast a) (toFFI b)
 
-
+  
   export
   isTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (tf : Maybe WebGLTransformFeedback)
     -> JSIO Bool
   isTransformFeedback a b = tryJS "WebGL2RenderingContextBase.isTransformFeedback" $
-    WebGL2RenderingContextBase.prim__isTransformFeedback (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__isTransformFeedback (cast a) (toFFI b)
 
-
+  
   export
   isVertexArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (vertexArray : Maybe WebGLVertexArrayObject)
     -> JSIO Bool
   isVertexArray a b = tryJS "WebGL2RenderingContextBase.isVertexArray" $
-    WebGL2RenderingContextBase.prim__isVertexArray (up a) (toFFI b)
+    WebGL2RenderingContextBase.prim__isVertexArray (cast a) (toFFI b)
 
-
+  
   export
   pauseTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO ()
   pauseTransformFeedback a = primJS $
-    WebGL2RenderingContextBase.prim__pauseTransformFeedback (up a)
+    WebGL2RenderingContextBase.prim__pauseTransformFeedback (cast a)
 
-
+  
   export
   readBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (src : Bits32)
     -> JSIO ()
-  readBuffer a b = primJS $ WebGL2RenderingContextBase.prim__readBuffer (up a) b
+  readBuffer a b = primJS $
+    WebGL2RenderingContextBase.prim__readBuffer (cast a) b
 
-
+  
   export
   renderbufferStorageMultisample :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (samples : Int32)
@@ -2416,54 +2379,50 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   renderbufferStorageMultisample a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__renderbufferStorageMultisample
-      (up a)
+      (cast a)
       b
       c
       d
       e
       f
 
-
+  
   export
   resumeTransformFeedback :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> JSIO ()
   resumeTransformFeedback a = primJS $
-    WebGL2RenderingContextBase.prim__resumeTransformFeedback (up a)
+    WebGL2RenderingContextBase.prim__resumeTransformFeedback (cast a)
 
-
+  
   export
   samplerParameterf :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sampler : WebGLSampler)
     -> (pname : Bits32)
     -> (param : Double)
     -> JSIO ()
   samplerParameterf a b c d = primJS $
-    WebGL2RenderingContextBase.prim__samplerParameterf (up a) b c d
+    WebGL2RenderingContextBase.prim__samplerParameterf (cast a) b c d
 
-
+  
   export
   samplerParameteri :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sampler : WebGLSampler)
     -> (pname : Bits32)
     -> (param : Int32)
     -> JSIO ()
   samplerParameteri a b c d = primJS $
-    WebGL2RenderingContextBase.prim__samplerParameteri (up a) b c d
+    WebGL2RenderingContextBase.prim__samplerParameteri (cast a) b c d
 
-
+  
   export
   texImage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2477,13 +2436,12 @@ namespace WebGL2RenderingContextBase
     -> (pboOffset : JSInt64)
     -> JSIO ()
   texImage3D a b c d e f g h i j k = primJS $
-    WebGL2RenderingContextBase.prim__texImage3D (up a) b c d e f g h i j k
+    WebGL2RenderingContextBase.prim__texImage3D (cast a) b c d e f g h i j k
 
-
+  
   export
   texImage3D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2505,7 +2463,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texImage3D1 a b c d e f g h i j k = primJS $
     WebGL2RenderingContextBase.prim__texImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2517,11 +2475,10 @@ namespace WebGL2RenderingContextBase
       j
       (toFFI k)
 
-
+  
   export
   texImage3D2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2548,7 +2505,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texImage3D2 a b c d e f g h i j k = primJS $
     WebGL2RenderingContextBase.prim__texImage3D2
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2560,11 +2517,10 @@ namespace WebGL2RenderingContextBase
       j
       (toFFI k)
 
-
+  
   export
   texImage3D3 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2591,7 +2547,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texImage3D3 a b c d e f g h i j k l = primJS $
     WebGL2RenderingContextBase.prim__texImage3D3
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2604,11 +2560,10 @@ namespace WebGL2RenderingContextBase
       (toFFI k)
       l
 
-
+  
   export
   texStorage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (levels : Int32)
@@ -2617,13 +2572,12 @@ namespace WebGL2RenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   texStorage2D a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__texStorage2D (up a) b c d e f
+    WebGL2RenderingContextBase.prim__texStorage2D (cast a) b c d e f
 
-
+  
   export
   texStorage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (levels : Int32)
@@ -2633,13 +2587,12 @@ namespace WebGL2RenderingContextBase
     -> (depth : Int32)
     -> JSIO ()
   texStorage3D a b c d e f g = primJS $
-    WebGL2RenderingContextBase.prim__texStorage3D (up a) b c d e f g
+    WebGL2RenderingContextBase.prim__texStorage3D (cast a) b c d e f g
 
-
+  
   export
   texSubImage3D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2654,13 +2607,24 @@ namespace WebGL2RenderingContextBase
     -> (pboOffset : JSInt64)
     -> JSIO ()
   texSubImage3D a b c d e f g h i j k l = primJS $
-    WebGL2RenderingContextBase.prim__texSubImage3D (up a) b c d e f g h i j k l
+    WebGL2RenderingContextBase.prim__texSubImage3D
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      g
+      h
+      i
+      j
+      k
+      l
 
-
+  
   export
   texSubImage3D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2683,7 +2647,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texSubImage3D1 a b c d e f g h i j k l = primJS $
     WebGL2RenderingContextBase.prim__texSubImage3D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2696,11 +2660,10 @@ namespace WebGL2RenderingContextBase
       k
       (toFFI l)
 
-
+  
   export
   texSubImage3D2' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2729,7 +2692,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texSubImage3D2' a b c d e f g h i j k l m = primJS $
     WebGL2RenderingContextBase.prim__texSubImage3D2
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2742,11 +2705,10 @@ namespace WebGL2RenderingContextBase
       k
       (toFFI l)
       (toFFI m)
-
+  
   export
   texSubImage3D2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -2774,7 +2736,7 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   texSubImage3D2 a b c d e f g h i j k l = primJS $
     WebGL2RenderingContextBase.prim__texSubImage3D2
-      (up a)
+      (cast a)
       b
       c
       d
@@ -2788,36 +2750,33 @@ namespace WebGL2RenderingContextBase
       (toFFI l)
       undef
 
-
+  
   export
   transformFeedbackVaryings :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (varyings : Array String)
     -> (bufferMode : Bits32)
     -> JSIO ()
   transformFeedbackVaryings a b c d = primJS $
-    WebGL2RenderingContextBase.prim__transformFeedbackVaryings (up a) b c d
+    WebGL2RenderingContextBase.prim__transformFeedbackVaryings (cast a) b c d
 
-
+  
   export
   uniform1ui :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v0 : Bits32)
     -> JSIO ()
   uniform1ui a b c = primJS $
-    WebGL2RenderingContextBase.prim__uniform1ui (up a) (toFFI b) c
+    WebGL2RenderingContextBase.prim__uniform1ui (cast a) (toFFI b) c
 
-
+  
   export
   uniform1uiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
@@ -2826,46 +2785,43 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniform1uiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__uniform1uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform1uiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   uniform1uiv a b c = primJS $
     WebGL2RenderingContextBase.prim__uniform1uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform2ui :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v0 : Bits32)
     -> (v1 : Bits32)
     -> JSIO ()
   uniform2ui a b c d = primJS $
-    WebGL2RenderingContextBase.prim__uniform2ui (up a) (toFFI b) c d
+    WebGL2RenderingContextBase.prim__uniform2ui (cast a) (toFFI b) c d
 
-
+  
   export
   uniform2uiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
@@ -2874,33 +2830,31 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniform2uiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__uniform2uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform2uiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   uniform2uiv a b c = primJS $
     WebGL2RenderingContextBase.prim__uniform2uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform3ui :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v0 : Bits32)
@@ -2908,13 +2862,12 @@ namespace WebGL2RenderingContextBase
     -> (v2 : Bits32)
     -> JSIO ()
   uniform3ui a b c d e = primJS $
-    WebGL2RenderingContextBase.prim__uniform3ui (up a) (toFFI b) c d e
+    WebGL2RenderingContextBase.prim__uniform3ui (cast a) (toFFI b) c d e
 
-
+  
   export
   uniform3uiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
@@ -2923,33 +2876,31 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniform3uiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__uniform3uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform3uiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   uniform3uiv a b c = primJS $
     WebGL2RenderingContextBase.prim__uniform3uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform4ui :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v0 : Bits32)
@@ -2958,13 +2909,12 @@ namespace WebGL2RenderingContextBase
     -> (v3 : Bits32)
     -> JSIO ()
   uniform4ui a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__uniform4ui (up a) (toFFI b) c d e f
+    WebGL2RenderingContextBase.prim__uniform4ui (cast a) (toFFI b) c d e f
 
-
+  
   export
   uniform4uiv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
@@ -2973,46 +2923,43 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniform4uiv' a b c d e = primJS $
     WebGL2RenderingContextBase.prim__uniform4uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform4uiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   uniform4uiv a b c = primJS $
     WebGL2RenderingContextBase.prim__uniform4uiv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniformBlockBinding :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (uniformBlockIndex : Bits32)
     -> (uniformBlockBinding : Bits32)
     -> JSIO ()
   uniformBlockBinding a b c d = primJS $
-    WebGL2RenderingContextBase.prim__uniformBlockBinding (up a) b c d
+    WebGL2RenderingContextBase.prim__uniformBlockBinding (cast a) b c d
 
-
+  
   export
   uniformMatrix2x3fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3022,17 +2969,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix2x3fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix2x3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix2x3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3040,18 +2986,17 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix2x3fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix2x3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix2x4fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3061,17 +3006,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix2x4fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix2x4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix2x4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3079,18 +3023,17 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix2x4fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix2x4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix3x2fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3100,17 +3043,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix3x2fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix3x2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix3x2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3118,18 +3060,17 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix3x2fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix3x2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix3x4fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3139,17 +3080,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix3x4fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix3x4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix3x4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3157,18 +3097,17 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix3x4fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix3x4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix4x2fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3178,17 +3117,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix4x2fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix4x2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix4x2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3196,18 +3134,17 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix4x2fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix4x2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix4x3fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3217,17 +3154,16 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix4x3fv' a b c d e f = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix4x3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix4x3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -3235,30 +3171,28 @@ namespace WebGL2RenderingContextBase
     -> JSIO ()
   uniformMatrix4x3fv a b c d = primJS $
     WebGL2RenderingContextBase.prim__uniformMatrix4x3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   vertexAttribDivisor :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (divisor : Bits32)
     -> JSIO ()
   vertexAttribDivisor a b c = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribDivisor (up a) b c
+    WebGL2RenderingContextBase.prim__vertexAttribDivisor (cast a) b c
 
-
+  
   export
   vertexAttribI4i :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Int32)
@@ -3267,25 +3201,23 @@ namespace WebGL2RenderingContextBase
     -> (w : Int32)
     -> JSIO ()
   vertexAttribI4i a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribI4i (up a) b c d e f
+    WebGL2RenderingContextBase.prim__vertexAttribI4i (cast a) b c d e f
 
-
+  
   export
   vertexAttribI4iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [Int32Array, Array Int32])
     -> JSIO ()
   vertexAttribI4iv a b c = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribI4iv (up a) b (toFFI c)
+    WebGL2RenderingContextBase.prim__vertexAttribI4iv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttribI4ui :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Bits32)
@@ -3294,25 +3226,23 @@ namespace WebGL2RenderingContextBase
     -> (w : Bits32)
     -> JSIO ()
   vertexAttribI4ui a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribI4ui (up a) b c d e f
+    WebGL2RenderingContextBase.prim__vertexAttribI4ui (cast a) b c d e f
 
-
+  
   export
   vertexAttribI4uiv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [UInt8Array, Array Bits32])
     -> JSIO ()
   vertexAttribI4uiv a b c = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribI4uiv (up a) b (toFFI c)
+    WebGL2RenderingContextBase.prim__vertexAttribI4uiv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttribIPointer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (size : Int32)
@@ -3321,42 +3251,39 @@ namespace WebGL2RenderingContextBase
     -> (offset : JSInt64)
     -> JSIO ()
   vertexAttribIPointer a b c d e f = primJS $
-    WebGL2RenderingContextBase.prim__vertexAttribIPointer (up a) b c d e f
+    WebGL2RenderingContextBase.prim__vertexAttribIPointer (cast a) b c d e f
 
-
+  
   export
   waitSync :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextBase}
     -> (obj : t1)
     -> (sync : WebGLSync)
     -> (flags : Bits32)
     -> (timeout : JSInt64)
     -> JSIO ()
   waitSync a b c d = primJS $
-    WebGL2RenderingContextBase.prim__waitSync (up a) b c d
+    WebGL2RenderingContextBase.prim__waitSync (cast a) b c d
 
 
 
 namespace WebGL2RenderingContextOverloads
-
+  
   export
   bufferData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (size : JSInt64)
     -> (usage : Bits32)
     -> JSIO ()
   bufferData a b c d = primJS $
-    WebGL2RenderingContextOverloads.prim__bufferData (up a) b c d
+    WebGL2RenderingContextOverloads.prim__bufferData (cast a) b c d
 
-
+  
   export
   bufferData1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (srcData : Maybe
@@ -3376,13 +3303,12 @@ namespace WebGL2RenderingContextOverloads
     -> (usage : Bits32)
     -> JSIO ()
   bufferData1 a b c d = primJS $
-    WebGL2RenderingContextOverloads.prim__bufferData1 (up a) b (toFFI c) d
+    WebGL2RenderingContextOverloads.prim__bufferData1 (cast a) b (toFFI c) d
 
-
+  
   export
   bufferData2' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (srcData : HSum
@@ -3403,17 +3329,16 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   bufferData2' a b c d e f = primJS $
     WebGL2RenderingContextOverloads.prim__bufferData2
-      (up a)
+      (cast a)
       b
       (toFFI c)
       d
       e
       (toFFI f)
-
+  
   export
   bufferData2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (srcData : HSum
@@ -3433,18 +3358,17 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   bufferData2 a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__bufferData2
-      (up a)
+      (cast a)
       b
       (toFFI c)
       d
       e
       undef
 
-
+  
   export
   bufferSubData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (dstByteOffset : JSInt64)
@@ -3463,13 +3387,12 @@ namespace WebGL2RenderingContextOverloads
                     ])
     -> JSIO ()
   bufferSubData a b c d = primJS $
-    WebGL2RenderingContextOverloads.prim__bufferSubData (up a) b c (toFFI d)
+    WebGL2RenderingContextOverloads.prim__bufferSubData (cast a) b c (toFFI d)
 
-
+  
   export
   bufferSubData1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (dstByteOffset : JSInt64)
@@ -3490,17 +3413,16 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   bufferSubData1' a b c d e f = primJS $
     WebGL2RenderingContextOverloads.prim__bufferSubData1
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       e
       (toFFI f)
-
+  
   export
   bufferSubData1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (dstByteOffset : JSInt64)
@@ -3520,18 +3442,17 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   bufferSubData1 a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__bufferSubData1
-      (up a)
+      (cast a)
       b
       c
       (toFFI d)
       e
       undef
 
-
+  
   export
   compressedTexImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3544,7 +3465,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexImage2D a b c d e f g h i = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3554,11 +3475,10 @@ namespace WebGL2RenderingContextOverloads
       h
       i
 
-
+  
   export
   compressedTexImage2D1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3583,7 +3503,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexImage2D1' a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3593,11 +3513,10 @@ namespace WebGL2RenderingContextOverloads
       (toFFI h)
       (toFFI i)
       (toFFI j)
-
+  
   export
   compressedTexImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3620,7 +3539,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexImage2D1 a b c d e f g h = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3631,11 +3550,10 @@ namespace WebGL2RenderingContextOverloads
       undef
       undef
 
-
+  
   export
   compressedTexSubImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3649,7 +3567,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexSubImage2D a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexSubImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3660,11 +3578,10 @@ namespace WebGL2RenderingContextOverloads
       i
       j
 
-
+  
   export
   compressedTexSubImage2D1' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3690,7 +3607,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexSubImage2D1' a b c d e f g h i j k = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexSubImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3701,11 +3618,10 @@ namespace WebGL2RenderingContextOverloads
       (toFFI i)
       (toFFI j)
       (toFFI k)
-
+  
   export
   compressedTexSubImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3729,7 +3645,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   compressedTexSubImage2D1 a b c d e f g h i = primJS $
     WebGL2RenderingContextOverloads.prim__compressedTexSubImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3741,11 +3657,10 @@ namespace WebGL2RenderingContextOverloads
       undef
       undef
 
-
+  
   export
   readPixels :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -3769,7 +3684,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   readPixels a b c d e f g h = primJS $
     WebGL2RenderingContextOverloads.prim__readPixels
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3778,11 +3693,10 @@ namespace WebGL2RenderingContextOverloads
       g
       (toFFI h)
 
-
+  
   export
   readPixels1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -3793,13 +3707,12 @@ namespace WebGL2RenderingContextOverloads
     -> (offset : JSInt64)
     -> JSIO ()
   readPixels1 a b c d e f g h = primJS $
-    WebGL2RenderingContextOverloads.prim__readPixels1 (up a) b c d e f g h
+    WebGL2RenderingContextOverloads.prim__readPixels1 (cast a) b c d e f g h
 
-
+  
   export
   readPixels2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -3823,7 +3736,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   readPixels2 a b c d e f g h i = primJS $
     WebGL2RenderingContextOverloads.prim__readPixels2
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3833,11 +3746,10 @@ namespace WebGL2RenderingContextOverloads
       (toFFI h)
       i
 
-
+  
   export
   texImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3863,7 +3775,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texImage2D a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__texImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3874,11 +3786,10 @@ namespace WebGL2RenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3895,13 +3806,19 @@ namespace WebGL2RenderingContextOverloads
                    ])
     -> JSIO ()
   texImage2D1 a b c d e f g = primJS $
-    WebGL2RenderingContextOverloads.prim__texImage2D1 (up a) b c d e f (toFFI g)
+    WebGL2RenderingContextOverloads.prim__texImage2D1
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      (toFFI g)
 
-
+  
   export
   texImage2D2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3914,13 +3831,12 @@ namespace WebGL2RenderingContextOverloads
     -> (pboOffset : JSInt64)
     -> JSIO ()
   texImage2D2 a b c d e f g h i j = primJS $
-    WebGL2RenderingContextOverloads.prim__texImage2D2 (up a) b c d e f g h i j
+    WebGL2RenderingContextOverloads.prim__texImage2D2 (cast a) b c d e f g h i j
 
-
+  
   export
   texImage2D3 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3941,7 +3857,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texImage2D3 a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__texImage2D3
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3952,11 +3868,10 @@ namespace WebGL2RenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texImage2D4 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -3982,7 +3897,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texImage2D4 a b c d e f g h i j k = primJS $
     WebGL2RenderingContextOverloads.prim__texImage2D4
-      (up a)
+      (cast a)
       b
       c
       d
@@ -3994,11 +3909,10 @@ namespace WebGL2RenderingContextOverloads
       (toFFI j)
       k
 
-
+  
   export
   texSubImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -4024,7 +3938,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texSubImage2D a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__texSubImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -4035,11 +3949,10 @@ namespace WebGL2RenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texSubImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -4058,7 +3971,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texSubImage2D1 a b c d e f g h = primJS $
     WebGL2RenderingContextOverloads.prim__texSubImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -4067,11 +3980,10 @@ namespace WebGL2RenderingContextOverloads
       g
       (toFFI h)
 
-
+  
   export
   texSubImage2D2 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -4085,7 +3997,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texSubImage2D2 a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__texSubImage2D2
-      (up a)
+      (cast a)
       b
       c
       d
@@ -4096,11 +4008,10 @@ namespace WebGL2RenderingContextOverloads
       i
       j
 
-
+  
   export
   texSubImage2D3 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -4121,7 +4032,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texSubImage2D3 a b c d e f g h i j = primJS $
     WebGL2RenderingContextOverloads.prim__texSubImage2D3
-      (up a)
+      (cast a)
       b
       c
       d
@@ -4132,11 +4043,10 @@ namespace WebGL2RenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texSubImage2D4 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -4162,7 +4072,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   texSubImage2D4 a b c d e f g h i j k = primJS $
     WebGL2RenderingContextOverloads.prim__texSubImage2D4
-      (up a)
+      (cast a)
       b
       c
       d
@@ -4174,11 +4084,10 @@ namespace WebGL2RenderingContextOverloads
       (toFFI j)
       k
 
-
+  
   export
   uniform1fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
@@ -4187,33 +4096,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform1fv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform1fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform1fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform1fv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform1fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform1iv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
@@ -4222,33 +4129,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform1iv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform1iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform1iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform1iv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform1iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform2fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
@@ -4257,33 +4162,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform2fv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform2fv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform2iv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
@@ -4292,33 +4195,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform2iv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform2iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform2iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform2iv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform2iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform3fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
@@ -4327,33 +4228,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform3fv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform3fv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform3iv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
@@ -4362,33 +4261,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform3iv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform3iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform3iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform3iv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform3iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform4fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
@@ -4397,33 +4294,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform4fv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform4fv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniform4iv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
@@ -4432,33 +4327,31 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniform4iv' a b c d e = primJS $
     WebGL2RenderingContextOverloads.prim__uniform4iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
-
+  
   export
   uniform4iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (data_ : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform4iv a b c = primJS $
     WebGL2RenderingContextOverloads.prim__uniform4iv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       undef
       undef
 
-
+  
   export
   uniformMatrix2fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4468,17 +4361,16 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix2fv' a b c d e f = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4486,18 +4378,17 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix2fv a b c d = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix3fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4507,17 +4398,16 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix3fv' a b c d e f = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4525,18 +4415,17 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix3fv a b c d = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       undef
       undef
 
-
+  
   export
   uniformMatrix4fv' :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4546,17 +4435,16 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix4fv' a b c d e f = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
       (toFFI f)
-
+  
   export
   uniformMatrix4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGL2RenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGL2RenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -4564,7 +4452,7 @@ namespace WebGL2RenderingContextOverloads
     -> JSIO ()
   uniformMatrix4fv a b c d = primJS $
     WebGL2RenderingContextOverloads.prim__uniformMatrix4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
@@ -4574,1605 +4462,1594 @@ namespace WebGL2RenderingContextOverloads
 
 
 namespace WebGLRenderingContextBase
-
-  public export
+  
+  export
   ACTIVE_ATTRIBUTES : Bits32
   ACTIVE_ATTRIBUTES = 0x8b89
 
-
-  public export
+  
+  export
   ACTIVE_TEXTURE : Bits32
   ACTIVE_TEXTURE = 0x84e0
 
-
-  public export
+  
+  export
   ACTIVE_UNIFORMS : Bits32
   ACTIVE_UNIFORMS = 0x8b86
 
-
-  public export
+  
+  export
   ALIASED_LINE_WIDTH_RANGE : Bits32
   ALIASED_LINE_WIDTH_RANGE = 0x846e
 
-
-  public export
+  
+  export
   ALIASED_POINT_SIZE_RANGE : Bits32
   ALIASED_POINT_SIZE_RANGE = 0x846d
 
-
-  public export
+  
+  export
   ALPHA : Bits32
   ALPHA = 0x1906
 
-
-  public export
+  
+  export
   ALPHA_BITS : Bits32
   ALPHA_BITS = 0xd55
 
-
-  public export
+  
+  export
   ALWAYS : Bits32
   ALWAYS = 0x207
 
-
-  public export
+  
+  export
   ARRAY_BUFFER : Bits32
   ARRAY_BUFFER = 0x8892
 
-
-  public export
+  
+  export
   ARRAY_BUFFER_BINDING : Bits32
   ARRAY_BUFFER_BINDING = 0x8894
 
-
-  public export
+  
+  export
   ATTACHED_SHADERS : Bits32
   ATTACHED_SHADERS = 0x8b85
 
-
-  public export
+  
+  export
   BACK : Bits32
   BACK = 0x405
 
-
-  public export
+  
+  export
   BLEND : Bits32
   BLEND = 0xbe2
 
-
-  public export
+  
+  export
   BLEND_COLOR : Bits32
   BLEND_COLOR = 0x8005
 
-
-  public export
+  
+  export
   BLEND_DST_ALPHA : Bits32
   BLEND_DST_ALPHA = 0x80ca
 
-
-  public export
+  
+  export
   BLEND_DST_RGB : Bits32
   BLEND_DST_RGB = 0x80c8
 
-
-  public export
+  
+  export
   BLEND_EQUATION : Bits32
   BLEND_EQUATION = 0x8009
 
-
-  public export
+  
+  export
   BLEND_EQUATION_ALPHA : Bits32
   BLEND_EQUATION_ALPHA = 0x883d
 
-
-  public export
+  
+  export
   BLEND_EQUATION_RGB : Bits32
   BLEND_EQUATION_RGB = 0x8009
 
-
-  public export
+  
+  export
   BLEND_SRC_ALPHA : Bits32
   BLEND_SRC_ALPHA = 0x80cb
 
-
-  public export
+  
+  export
   BLEND_SRC_RGB : Bits32
   BLEND_SRC_RGB = 0x80c9
 
-
-  public export
+  
+  export
   BLUE_BITS : Bits32
   BLUE_BITS = 0xd54
 
-
-  public export
+  
+  export
   BOOL : Bits32
   BOOL = 0x8b56
 
-
-  public export
+  
+  export
   BOOL_VEC2 : Bits32
   BOOL_VEC2 = 0x8b57
 
-
-  public export
+  
+  export
   BOOL_VEC3 : Bits32
   BOOL_VEC3 = 0x8b58
 
-
-  public export
+  
+  export
   BOOL_VEC4 : Bits32
   BOOL_VEC4 = 0x8b59
 
-
-  public export
+  
+  export
   BROWSER_DEFAULT_WEBGL : Bits32
   BROWSER_DEFAULT_WEBGL = 0x9244
 
-
-  public export
+  
+  export
   BUFFER_SIZE : Bits32
   BUFFER_SIZE = 0x8764
 
-
-  public export
+  
+  export
   BUFFER_USAGE : Bits32
   BUFFER_USAGE = 0x8765
 
-
-  public export
+  
+  export
   BYTE : Bits32
   BYTE = 0x1400
 
-
-  public export
+  
+  export
   CCW : Bits32
   CCW = 0x901
 
-
-  public export
+  
+  export
   CLAMP_TO_EDGE : Bits32
   CLAMP_TO_EDGE = 0x812f
 
-
-  public export
+  
+  export
   COLOR_ATTACHMENT0 : Bits32
   COLOR_ATTACHMENT0 = 0x8ce0
 
-
-  public export
+  
+  export
   COLOR_BUFFER_BIT : Bits32
   COLOR_BUFFER_BIT = 0x4000
 
-
-  public export
+  
+  export
   COLOR_CLEAR_VALUE : Bits32
   COLOR_CLEAR_VALUE = 0xc22
 
-
-  public export
+  
+  export
   COLOR_WRITEMASK : Bits32
   COLOR_WRITEMASK = 0xc23
 
-
-  public export
+  
+  export
   COMPILE_STATUS : Bits32
   COMPILE_STATUS = 0x8b81
 
-
-  public export
+  
+  export
   COMPRESSED_TEXTURE_FORMATS : Bits32
   COMPRESSED_TEXTURE_FORMATS = 0x86a3
 
-
-  public export
+  
+  export
   CONSTANT_ALPHA : Bits32
   CONSTANT_ALPHA = 0x8003
 
-
-  public export
+  
+  export
   CONSTANT_COLOR : Bits32
   CONSTANT_COLOR = 0x8001
 
-
-  public export
+  
+  export
   CONTEXT_LOST_WEBGL : Bits32
   CONTEXT_LOST_WEBGL = 0x9242
 
-
-  public export
+  
+  export
   CULL_FACE : Bits32
   CULL_FACE = 0xb44
 
-
-  public export
+  
+  export
   CULL_FACE_MODE : Bits32
   CULL_FACE_MODE = 0xb45
 
-
-  public export
+  
+  export
   CURRENT_PROGRAM : Bits32
   CURRENT_PROGRAM = 0x8b8d
 
-
-  public export
+  
+  export
   CURRENT_VERTEX_ATTRIB : Bits32
   CURRENT_VERTEX_ATTRIB = 0x8626
 
-
-  public export
+  
+  export
   CW : Bits32
   CW = 0x900
 
-
-  public export
+  
+  export
   DECR : Bits32
   DECR = 0x1e03
 
-
-  public export
+  
+  export
   DECR_WRAP : Bits32
   DECR_WRAP = 0x8508
 
-
-  public export
+  
+  export
   DELETE_STATUS : Bits32
   DELETE_STATUS = 0x8b80
 
-
-  public export
+  
+  export
   DEPTH_ATTACHMENT : Bits32
   DEPTH_ATTACHMENT = 0x8d00
 
-
-  public export
+  
+  export
   DEPTH_BITS : Bits32
   DEPTH_BITS = 0xd56
 
-
-  public export
+  
+  export
   DEPTH_BUFFER_BIT : Bits32
   DEPTH_BUFFER_BIT = 0x100
 
-
-  public export
+  
+  export
   DEPTH_CLEAR_VALUE : Bits32
   DEPTH_CLEAR_VALUE = 0xb73
 
-
-  public export
+  
+  export
   DEPTH_COMPONENT : Bits32
   DEPTH_COMPONENT = 0x1902
 
-
-  public export
+  
+  export
   DEPTH_COMPONENT16 : Bits32
   DEPTH_COMPONENT16 = 0x81a5
 
-
-  public export
+  
+  export
   DEPTH_FUNC : Bits32
   DEPTH_FUNC = 0xb74
 
-
-  public export
+  
+  export
   DEPTH_RANGE : Bits32
   DEPTH_RANGE = 0xb70
 
-
-  public export
+  
+  export
   DEPTH_STENCIL : Bits32
   DEPTH_STENCIL = 0x84f9
 
-
-  public export
+  
+  export
   DEPTH_STENCIL_ATTACHMENT : Bits32
   DEPTH_STENCIL_ATTACHMENT = 0x821a
 
-
-  public export
+  
+  export
   DEPTH_TEST : Bits32
   DEPTH_TEST = 0xb71
 
-
-  public export
+  
+  export
   DEPTH_WRITEMASK : Bits32
   DEPTH_WRITEMASK = 0xb72
 
-
-  public export
+  
+  export
   DITHER : Bits32
   DITHER = 0xbd0
 
-
-  public export
+  
+  export
   DONT_CARE : Bits32
   DONT_CARE = 0x1100
 
-
-  public export
+  
+  export
   DST_ALPHA : Bits32
   DST_ALPHA = 0x304
 
-
-  public export
+  
+  export
   DST_COLOR : Bits32
   DST_COLOR = 0x306
 
-
-  public export
+  
+  export
   DYNAMIC_DRAW : Bits32
   DYNAMIC_DRAW = 0x88e8
 
-
-  public export
+  
+  export
   ELEMENT_ARRAY_BUFFER : Bits32
   ELEMENT_ARRAY_BUFFER = 0x8893
 
-
-  public export
+  
+  export
   ELEMENT_ARRAY_BUFFER_BINDING : Bits32
   ELEMENT_ARRAY_BUFFER_BINDING = 0x8895
 
-
-  public export
+  
+  export
   EQUAL : Bits32
   EQUAL = 0x202
 
-
-  public export
+  
+  export
   FASTEST : Bits32
   FASTEST = 0x1101
 
-
-  public export
+  
+  export
   FLOAT : Bits32
   FLOAT = 0x1406
 
-
-  public export
+  
+  export
   FLOAT_MAT2 : Bits32
   FLOAT_MAT2 = 0x8b5a
 
-
-  public export
+  
+  export
   FLOAT_MAT3 : Bits32
   FLOAT_MAT3 = 0x8b5b
 
-
-  public export
+  
+  export
   FLOAT_MAT4 : Bits32
   FLOAT_MAT4 = 0x8b5c
 
-
-  public export
+  
+  export
   FLOAT_VEC2 : Bits32
   FLOAT_VEC2 = 0x8b50
 
-
-  public export
+  
+  export
   FLOAT_VEC3 : Bits32
   FLOAT_VEC3 = 0x8b51
 
-
-  public export
+  
+  export
   FLOAT_VEC4 : Bits32
   FLOAT_VEC4 = 0x8b52
 
-
-  public export
+  
+  export
   FRAGMENT_SHADER : Bits32
   FRAGMENT_SHADER = 0x8b30
 
-
-  public export
+  
+  export
   FRAMEBUFFER : Bits32
   FRAMEBUFFER = 0x8d40
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_OBJECT_NAME : Bits32
   FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8cd1
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE : Bits32
   FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE = 0x8cd0
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE : Bits32
   FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE = 0x8cd3
 
-
-  public export
+  
+  export
   FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL : Bits32
   FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL = 0x8cd2
 
-
-  public export
+  
+  export
   FRAMEBUFFER_BINDING : Bits32
   FRAMEBUFFER_BINDING = 0x8ca6
 
-
-  public export
+  
+  export
   FRAMEBUFFER_COMPLETE : Bits32
   FRAMEBUFFER_COMPLETE = 0x8cd5
 
-
-  public export
+  
+  export
   FRAMEBUFFER_INCOMPLETE_ATTACHMENT : Bits32
   FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8cd6
 
-
-  public export
+  
+  export
   FRAMEBUFFER_INCOMPLETE_DIMENSIONS : Bits32
   FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8cd9
 
-
-  public export
+  
+  export
   FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT : Bits32
   FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8cd7
 
-
-  public export
+  
+  export
   FRAMEBUFFER_UNSUPPORTED : Bits32
   FRAMEBUFFER_UNSUPPORTED = 0x8cdd
 
-
-  public export
+  
+  export
   FRONT : Bits32
   FRONT = 0x404
 
-
-  public export
+  
+  export
   FRONT_AND_BACK : Bits32
   FRONT_AND_BACK = 0x408
 
-
-  public export
+  
+  export
   FRONT_FACE : Bits32
   FRONT_FACE = 0xb46
 
-
-  public export
+  
+  export
   FUNC_ADD : Bits32
   FUNC_ADD = 0x8006
 
-
-  public export
+  
+  export
   FUNC_REVERSE_SUBTRACT : Bits32
   FUNC_REVERSE_SUBTRACT = 0x800b
 
-
-  public export
+  
+  export
   FUNC_SUBTRACT : Bits32
   FUNC_SUBTRACT = 0x800a
 
-
-  public export
+  
+  export
   GENERATE_MIPMAP_HINT : Bits32
   GENERATE_MIPMAP_HINT = 0x8192
 
-
-  public export
+  
+  export
   GEQUAL : Bits32
   GEQUAL = 0x206
 
-
-  public export
+  
+  export
   GREATER : Bits32
   GREATER = 0x204
 
-
-  public export
+  
+  export
   GREEN_BITS : Bits32
   GREEN_BITS = 0xd53
 
-
-  public export
+  
+  export
   HIGH_FLOAT : Bits32
   HIGH_FLOAT = 0x8df2
 
-
-  public export
+  
+  export
   HIGH_INT : Bits32
   HIGH_INT = 0x8df5
 
-
-  public export
+  
+  export
   IMPLEMENTATION_COLOR_READ_FORMAT : Bits32
   IMPLEMENTATION_COLOR_READ_FORMAT = 0x8b9b
 
-
-  public export
+  
+  export
   IMPLEMENTATION_COLOR_READ_TYPE : Bits32
   IMPLEMENTATION_COLOR_READ_TYPE = 0x8b9a
 
-
-  public export
+  
+  export
   INCR : Bits32
   INCR = 0x1e02
 
-
-  public export
+  
+  export
   INCR_WRAP : Bits32
   INCR_WRAP = 0x8507
 
-
-  public export
+  
+  export
   INT : Bits32
   INT = 0x1404
 
-
-  public export
+  
+  export
   INT_VEC2 : Bits32
   INT_VEC2 = 0x8b53
 
-
-  public export
+  
+  export
   INT_VEC3 : Bits32
   INT_VEC3 = 0x8b54
 
-
-  public export
+  
+  export
   INT_VEC4 : Bits32
   INT_VEC4 = 0x8b55
 
-
-  public export
+  
+  export
   INVALID_ENUM : Bits32
   INVALID_ENUM = 0x500
 
-
-  public export
+  
+  export
   INVALID_FRAMEBUFFER_OPERATION : Bits32
   INVALID_FRAMEBUFFER_OPERATION = 0x506
 
-
-  public export
+  
+  export
   INVALID_OPERATION : Bits32
   INVALID_OPERATION = 0x502
 
-
-  public export
+  
+  export
   INVALID_VALUE : Bits32
   INVALID_VALUE = 0x501
 
-
-  public export
+  
+  export
   INVERT : Bits32
   INVERT = 0x150a
 
-
-  public export
+  
+  export
   KEEP : Bits32
   KEEP = 0x1e00
 
-
-  public export
+  
+  export
   LEQUAL : Bits32
   LEQUAL = 0x203
 
-
-  public export
+  
+  export
   LESS : Bits32
   LESS = 0x201
 
-
-  public export
+  
+  export
   LINEAR : Bits32
   LINEAR = 0x2601
 
-
-  public export
+  
+  export
   LINEAR_MIPMAP_LINEAR : Bits32
   LINEAR_MIPMAP_LINEAR = 0x2703
 
-
-  public export
+  
+  export
   LINEAR_MIPMAP_NEAREST : Bits32
   LINEAR_MIPMAP_NEAREST = 0x2701
 
-
-  public export
+  
+  export
   LINES : Bits32
   LINES = 0x1
 
-
-  public export
+  
+  export
   LINE_LOOP : Bits32
   LINE_LOOP = 0x2
 
-
-  public export
+  
+  export
   LINE_STRIP : Bits32
   LINE_STRIP = 0x3
 
-
-  public export
+  
+  export
   LINE_WIDTH : Bits32
   LINE_WIDTH = 0xb21
 
-
-  public export
+  
+  export
   LINK_STATUS : Bits32
   LINK_STATUS = 0x8b82
 
-
-  public export
+  
+  export
   LOW_FLOAT : Bits32
   LOW_FLOAT = 0x8df0
 
-
-  public export
+  
+  export
   LOW_INT : Bits32
   LOW_INT = 0x8df3
 
-
-  public export
+  
+  export
   LUMINANCE : Bits32
   LUMINANCE = 0x1909
 
-
-  public export
+  
+  export
   LUMINANCE_ALPHA : Bits32
   LUMINANCE_ALPHA = 0x190a
 
-
-  public export
+  
+  export
   MAX_COMBINED_TEXTURE_IMAGE_UNITS : Bits32
   MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8b4d
 
-
-  public export
+  
+  export
   MAX_CUBE_MAP_TEXTURE_SIZE : Bits32
   MAX_CUBE_MAP_TEXTURE_SIZE = 0x851c
 
-
-  public export
+  
+  export
   MAX_FRAGMENT_UNIFORM_VECTORS : Bits32
   MAX_FRAGMENT_UNIFORM_VECTORS = 0x8dfd
 
-
-  public export
+  
+  export
   MAX_RENDERBUFFER_SIZE : Bits32
   MAX_RENDERBUFFER_SIZE = 0x84e8
 
-
-  public export
+  
+  export
   MAX_TEXTURE_IMAGE_UNITS : Bits32
   MAX_TEXTURE_IMAGE_UNITS = 0x8872
 
-
-  public export
+  
+  export
   MAX_TEXTURE_SIZE : Bits32
   MAX_TEXTURE_SIZE = 0xd33
 
-
-  public export
+  
+  export
   MAX_VARYING_VECTORS : Bits32
   MAX_VARYING_VECTORS = 0x8dfc
 
-
-  public export
+  
+  export
   MAX_VERTEX_ATTRIBS : Bits32
   MAX_VERTEX_ATTRIBS = 0x8869
 
-
-  public export
+  
+  export
   MAX_VERTEX_TEXTURE_IMAGE_UNITS : Bits32
   MAX_VERTEX_TEXTURE_IMAGE_UNITS = 0x8b4c
 
-
-  public export
+  
+  export
   MAX_VERTEX_UNIFORM_VECTORS : Bits32
   MAX_VERTEX_UNIFORM_VECTORS = 0x8dfb
 
-
-  public export
+  
+  export
   MAX_VIEWPORT_DIMS : Bits32
   MAX_VIEWPORT_DIMS = 0xd3a
 
-
-  public export
+  
+  export
   MEDIUM_FLOAT : Bits32
   MEDIUM_FLOAT = 0x8df1
 
-
-  public export
+  
+  export
   MEDIUM_INT : Bits32
   MEDIUM_INT = 0x8df4
 
-
-  public export
+  
+  export
   MIRRORED_REPEAT : Bits32
   MIRRORED_REPEAT = 0x8370
 
-
-  public export
+  
+  export
   NEAREST : Bits32
   NEAREST = 0x2600
 
-
-  public export
+  
+  export
   NEAREST_MIPMAP_LINEAR : Bits32
   NEAREST_MIPMAP_LINEAR = 0x2702
 
-
-  public export
+  
+  export
   NEAREST_MIPMAP_NEAREST : Bits32
   NEAREST_MIPMAP_NEAREST = 0x2700
 
-
-  public export
+  
+  export
   NEVER : Bits32
   NEVER = 0x200
 
-
-  public export
+  
+  export
   NICEST : Bits32
   NICEST = 0x1102
 
-
-  public export
+  
+  export
   NONE : Bits32
   NONE = 0
 
-
-  public export
+  
+  export
   NOTEQUAL : Bits32
   NOTEQUAL = 0x205
 
-
-  public export
+  
+  export
   NO_ERROR : Bits32
   NO_ERROR = 0
 
-
-  public export
+  
+  export
   ONE : Bits32
   ONE = 1
 
-
-  public export
+  
+  export
   ONE_MINUS_CONSTANT_ALPHA : Bits32
   ONE_MINUS_CONSTANT_ALPHA = 0x8004
 
-
-  public export
+  
+  export
   ONE_MINUS_CONSTANT_COLOR : Bits32
   ONE_MINUS_CONSTANT_COLOR = 0x8002
 
-
-  public export
+  
+  export
   ONE_MINUS_DST_ALPHA : Bits32
   ONE_MINUS_DST_ALPHA = 0x305
 
-
-  public export
+  
+  export
   ONE_MINUS_DST_COLOR : Bits32
   ONE_MINUS_DST_COLOR = 0x307
 
-
-  public export
+  
+  export
   ONE_MINUS_SRC_ALPHA : Bits32
   ONE_MINUS_SRC_ALPHA = 0x303
 
-
-  public export
+  
+  export
   ONE_MINUS_SRC_COLOR : Bits32
   ONE_MINUS_SRC_COLOR = 0x301
 
-
-  public export
+  
+  export
   OUT_OF_MEMORY : Bits32
   OUT_OF_MEMORY = 0x505
 
-
-  public export
+  
+  export
   PACK_ALIGNMENT : Bits32
   PACK_ALIGNMENT = 0xd05
 
-
-  public export
+  
+  export
   POINTS : Bits32
   POINTS = 0x0
 
-
-  public export
+  
+  export
   POLYGON_OFFSET_FACTOR : Bits32
   POLYGON_OFFSET_FACTOR = 0x8038
 
-
-  public export
+  
+  export
   POLYGON_OFFSET_FILL : Bits32
   POLYGON_OFFSET_FILL = 0x8037
 
-
-  public export
+  
+  export
   POLYGON_OFFSET_UNITS : Bits32
   POLYGON_OFFSET_UNITS = 0x2a00
 
-
-  public export
+  
+  export
   RED_BITS : Bits32
   RED_BITS = 0xd52
 
-
-  public export
+  
+  export
   RENDERBUFFER : Bits32
   RENDERBUFFER = 0x8d41
 
-
-  public export
+  
+  export
   RENDERBUFFER_ALPHA_SIZE : Bits32
   RENDERBUFFER_ALPHA_SIZE = 0x8d53
 
-
-  public export
+  
+  export
   RENDERBUFFER_BINDING : Bits32
   RENDERBUFFER_BINDING = 0x8ca7
 
-
-  public export
+  
+  export
   RENDERBUFFER_BLUE_SIZE : Bits32
   RENDERBUFFER_BLUE_SIZE = 0x8d52
 
-
-  public export
+  
+  export
   RENDERBUFFER_DEPTH_SIZE : Bits32
   RENDERBUFFER_DEPTH_SIZE = 0x8d54
 
-
-  public export
+  
+  export
   RENDERBUFFER_GREEN_SIZE : Bits32
   RENDERBUFFER_GREEN_SIZE = 0x8d51
 
-
-  public export
+  
+  export
   RENDERBUFFER_HEIGHT : Bits32
   RENDERBUFFER_HEIGHT = 0x8d43
 
-
-  public export
+  
+  export
   RENDERBUFFER_INTERNAL_FORMAT : Bits32
   RENDERBUFFER_INTERNAL_FORMAT = 0x8d44
 
-
-  public export
+  
+  export
   RENDERBUFFER_RED_SIZE : Bits32
   RENDERBUFFER_RED_SIZE = 0x8d50
 
-
-  public export
+  
+  export
   RENDERBUFFER_STENCIL_SIZE : Bits32
   RENDERBUFFER_STENCIL_SIZE = 0x8d55
 
-
-  public export
+  
+  export
   RENDERBUFFER_WIDTH : Bits32
   RENDERBUFFER_WIDTH = 0x8d42
 
-
-  public export
+  
+  export
   RENDERER : Bits32
   RENDERER = 0x1f01
 
-
-  public export
+  
+  export
   REPEAT : Bits32
   REPEAT = 0x2901
 
-
-  public export
+  
+  export
   REPLACE : Bits32
   REPLACE = 0x1e01
 
-
-  public export
+  
+  export
   RGB : Bits32
   RGB = 0x1907
 
-
-  public export
+  
+  export
   RGB565 : Bits32
   RGB565 = 0x8d62
 
-
-  public export
+  
+  export
   RGB5_A1 : Bits32
   RGB5_A1 = 0x8057
 
-
-  public export
+  
+  export
   RGBA : Bits32
   RGBA = 0x1908
 
-
-  public export
+  
+  export
   RGBA4 : Bits32
   RGBA4 = 0x8056
 
-
-  public export
+  
+  export
   SAMPLER_2D : Bits32
   SAMPLER_2D = 0x8b5e
 
-
-  public export
+  
+  export
   SAMPLER_CUBE : Bits32
   SAMPLER_CUBE = 0x8b60
 
-
-  public export
+  
+  export
   SAMPLES : Bits32
   SAMPLES = 0x80a9
 
-
-  public export
+  
+  export
   SAMPLE_ALPHA_TO_COVERAGE : Bits32
   SAMPLE_ALPHA_TO_COVERAGE = 0x809e
 
-
-  public export
+  
+  export
   SAMPLE_BUFFERS : Bits32
   SAMPLE_BUFFERS = 0x80a8
 
-
-  public export
+  
+  export
   SAMPLE_COVERAGE : Bits32
   SAMPLE_COVERAGE = 0x80a0
 
-
-  public export
+  
+  export
   SAMPLE_COVERAGE_INVERT : Bits32
   SAMPLE_COVERAGE_INVERT = 0x80ab
 
-
-  public export
+  
+  export
   SAMPLE_COVERAGE_VALUE : Bits32
   SAMPLE_COVERAGE_VALUE = 0x80aa
 
-
-  public export
+  
+  export
   SCISSOR_BOX : Bits32
   SCISSOR_BOX = 0xc10
 
-
-  public export
+  
+  export
   SCISSOR_TEST : Bits32
   SCISSOR_TEST = 0xc11
 
-
-  public export
+  
+  export
   SHADER_TYPE : Bits32
   SHADER_TYPE = 0x8b4f
 
-
-  public export
+  
+  export
   SHADING_LANGUAGE_VERSION : Bits32
   SHADING_LANGUAGE_VERSION = 0x8b8c
 
-
-  public export
+  
+  export
   SHORT : Bits32
   SHORT = 0x1402
 
-
-  public export
+  
+  export
   SRC_ALPHA : Bits32
   SRC_ALPHA = 0x302
 
-
-  public export
+  
+  export
   SRC_ALPHA_SATURATE : Bits32
   SRC_ALPHA_SATURATE = 0x308
 
-
-  public export
+  
+  export
   SRC_COLOR : Bits32
   SRC_COLOR = 0x300
 
-
-  public export
+  
+  export
   STATIC_DRAW : Bits32
   STATIC_DRAW = 0x88e4
 
-
-  public export
+  
+  export
   STENCIL_ATTACHMENT : Bits32
   STENCIL_ATTACHMENT = 0x8d20
 
-
-  public export
+  
+  export
   STENCIL_BACK_FAIL : Bits32
   STENCIL_BACK_FAIL = 0x8801
 
-
-  public export
+  
+  export
   STENCIL_BACK_FUNC : Bits32
   STENCIL_BACK_FUNC = 0x8800
 
-
-  public export
+  
+  export
   STENCIL_BACK_PASS_DEPTH_FAIL : Bits32
   STENCIL_BACK_PASS_DEPTH_FAIL = 0x8802
 
-
-  public export
+  
+  export
   STENCIL_BACK_PASS_DEPTH_PASS : Bits32
   STENCIL_BACK_PASS_DEPTH_PASS = 0x8803
 
-
-  public export
+  
+  export
   STENCIL_BACK_REF : Bits32
   STENCIL_BACK_REF = 0x8ca3
 
-
-  public export
+  
+  export
   STENCIL_BACK_VALUE_MASK : Bits32
   STENCIL_BACK_VALUE_MASK = 0x8ca4
 
-
-  public export
+  
+  export
   STENCIL_BACK_WRITEMASK : Bits32
   STENCIL_BACK_WRITEMASK = 0x8ca5
 
-
-  public export
+  
+  export
   STENCIL_BITS : Bits32
   STENCIL_BITS = 0xd57
 
-
-  public export
+  
+  export
   STENCIL_BUFFER_BIT : Bits32
   STENCIL_BUFFER_BIT = 0x400
 
-
-  public export
+  
+  export
   STENCIL_CLEAR_VALUE : Bits32
   STENCIL_CLEAR_VALUE = 0xb91
 
-
-  public export
+  
+  export
   STENCIL_FAIL : Bits32
   STENCIL_FAIL = 0xb94
 
-
-  public export
+  
+  export
   STENCIL_FUNC : Bits32
   STENCIL_FUNC = 0xb92
 
-
-  public export
+  
+  export
   STENCIL_INDEX8 : Bits32
   STENCIL_INDEX8 = 0x8d48
 
-
-  public export
+  
+  export
   STENCIL_PASS_DEPTH_FAIL : Bits32
   STENCIL_PASS_DEPTH_FAIL = 0xb95
 
-
-  public export
+  
+  export
   STENCIL_PASS_DEPTH_PASS : Bits32
   STENCIL_PASS_DEPTH_PASS = 0xb96
 
-
-  public export
+  
+  export
   STENCIL_REF : Bits32
   STENCIL_REF = 0xb97
 
-
-  public export
+  
+  export
   STENCIL_TEST : Bits32
   STENCIL_TEST = 0xb90
 
-
-  public export
+  
+  export
   STENCIL_VALUE_MASK : Bits32
   STENCIL_VALUE_MASK = 0xb93
 
-
-  public export
+  
+  export
   STENCIL_WRITEMASK : Bits32
   STENCIL_WRITEMASK = 0xb98
 
-
-  public export
+  
+  export
   STREAM_DRAW : Bits32
   STREAM_DRAW = 0x88e0
 
-
-  public export
+  
+  export
   SUBPIXEL_BITS : Bits32
   SUBPIXEL_BITS = 0xd50
 
-
-  public export
+  
+  export
   TEXTURE : Bits32
   TEXTURE = 0x1702
 
-
-  public export
+  
+  export
   TEXTURE0 : Bits32
   TEXTURE0 = 0x84c0
 
-
-  public export
+  
+  export
   TEXTURE1 : Bits32
   TEXTURE1 = 0x84c1
 
-
-  public export
+  
+  export
   TEXTURE10 : Bits32
   TEXTURE10 = 0x84ca
 
-
-  public export
+  
+  export
   TEXTURE11 : Bits32
   TEXTURE11 = 0x84cb
 
-
-  public export
+  
+  export
   TEXTURE12 : Bits32
   TEXTURE12 = 0x84cc
 
-
-  public export
+  
+  export
   TEXTURE13 : Bits32
   TEXTURE13 = 0x84cd
 
-
-  public export
+  
+  export
   TEXTURE14 : Bits32
   TEXTURE14 = 0x84ce
 
-
-  public export
+  
+  export
   TEXTURE15 : Bits32
   TEXTURE15 = 0x84cf
 
-
-  public export
+  
+  export
   TEXTURE16 : Bits32
   TEXTURE16 = 0x84d0
 
-
-  public export
+  
+  export
   TEXTURE17 : Bits32
   TEXTURE17 = 0x84d1
 
-
-  public export
+  
+  export
   TEXTURE18 : Bits32
   TEXTURE18 = 0x84d2
 
-
-  public export
+  
+  export
   TEXTURE19 : Bits32
   TEXTURE19 = 0x84d3
 
-
-  public export
+  
+  export
   TEXTURE2 : Bits32
   TEXTURE2 = 0x84c2
 
-
-  public export
+  
+  export
   TEXTURE20 : Bits32
   TEXTURE20 = 0x84d4
 
-
-  public export
+  
+  export
   TEXTURE21 : Bits32
   TEXTURE21 = 0x84d5
 
-
-  public export
+  
+  export
   TEXTURE22 : Bits32
   TEXTURE22 = 0x84d6
 
-
-  public export
+  
+  export
   TEXTURE23 : Bits32
   TEXTURE23 = 0x84d7
 
-
-  public export
+  
+  export
   TEXTURE24 : Bits32
   TEXTURE24 = 0x84d8
 
-
-  public export
+  
+  export
   TEXTURE25 : Bits32
   TEXTURE25 = 0x84d9
 
-
-  public export
+  
+  export
   TEXTURE26 : Bits32
   TEXTURE26 = 0x84da
 
-
-  public export
+  
+  export
   TEXTURE27 : Bits32
   TEXTURE27 = 0x84db
 
-
-  public export
+  
+  export
   TEXTURE28 : Bits32
   TEXTURE28 = 0x84dc
 
-
-  public export
+  
+  export
   TEXTURE29 : Bits32
   TEXTURE29 = 0x84dd
 
-
-  public export
+  
+  export
   TEXTURE3 : Bits32
   TEXTURE3 = 0x84c3
 
-
-  public export
+  
+  export
   TEXTURE30 : Bits32
   TEXTURE30 = 0x84de
 
-
-  public export
+  
+  export
   TEXTURE31 : Bits32
   TEXTURE31 = 0x84df
 
-
-  public export
+  
+  export
   TEXTURE4 : Bits32
   TEXTURE4 = 0x84c4
 
-
-  public export
+  
+  export
   TEXTURE5 : Bits32
   TEXTURE5 = 0x84c5
 
-
-  public export
+  
+  export
   TEXTURE6 : Bits32
   TEXTURE6 = 0x84c6
 
-
-  public export
+  
+  export
   TEXTURE7 : Bits32
   TEXTURE7 = 0x84c7
 
-
-  public export
+  
+  export
   TEXTURE8 : Bits32
   TEXTURE8 = 0x84c8
 
-
-  public export
+  
+  export
   TEXTURE9 : Bits32
   TEXTURE9 = 0x84c9
 
-
-  public export
+  
+  export
   TEXTURE_2D : Bits32
   TEXTURE_2D = 0xde1
 
-
-  public export
+  
+  export
   TEXTURE_BINDING_2D : Bits32
   TEXTURE_BINDING_2D = 0x8069
 
-
-  public export
+  
+  export
   TEXTURE_BINDING_CUBE_MAP : Bits32
   TEXTURE_BINDING_CUBE_MAP = 0x8514
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP : Bits32
   TEXTURE_CUBE_MAP = 0x8513
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_NEGATIVE_X : Bits32
   TEXTURE_CUBE_MAP_NEGATIVE_X = 0x8516
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_NEGATIVE_Y : Bits32
   TEXTURE_CUBE_MAP_NEGATIVE_Y = 0x8518
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_NEGATIVE_Z : Bits32
   TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851a
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_POSITIVE_X : Bits32
   TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_POSITIVE_Y : Bits32
   TEXTURE_CUBE_MAP_POSITIVE_Y = 0x8517
 
-
-  public export
+  
+  export
   TEXTURE_CUBE_MAP_POSITIVE_Z : Bits32
   TEXTURE_CUBE_MAP_POSITIVE_Z = 0x8519
 
-
-  public export
+  
+  export
   TEXTURE_MAG_FILTER : Bits32
   TEXTURE_MAG_FILTER = 0x2800
 
-
-  public export
+  
+  export
   TEXTURE_MIN_FILTER : Bits32
   TEXTURE_MIN_FILTER = 0x2801
 
-
-  public export
+  
+  export
   TEXTURE_WRAP_S : Bits32
   TEXTURE_WRAP_S = 0x2802
 
-
-  public export
+  
+  export
   TEXTURE_WRAP_T : Bits32
   TEXTURE_WRAP_T = 0x2803
 
-
-  public export
+  
+  export
   TRIANGLES : Bits32
   TRIANGLES = 0x4
 
-
-  public export
+  
+  export
   TRIANGLE_FAN : Bits32
   TRIANGLE_FAN = 0x6
 
-
-  public export
+  
+  export
   TRIANGLE_STRIP : Bits32
   TRIANGLE_STRIP = 0x5
 
-
-  public export
+  
+  export
   UNPACK_ALIGNMENT : Bits32
   UNPACK_ALIGNMENT = 0xcf5
 
-
-  public export
+  
+  export
   UNPACK_COLORSPACE_CONVERSION_WEBGL : Bits32
   UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243
 
-
-  public export
+  
+  export
   UNPACK_FLIP_Y_WEBGL : Bits32
   UNPACK_FLIP_Y_WEBGL = 0x9240
 
-
-  public export
+  
+  export
   UNPACK_PREMULTIPLY_ALPHA_WEBGL : Bits32
   UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241
 
-
-  public export
+  
+  export
   UNSIGNED_BYTE : Bits32
   UNSIGNED_BYTE = 0x1401
 
-
-  public export
+  
+  export
   UNSIGNED_INT : Bits32
   UNSIGNED_INT = 0x1405
 
-
-  public export
+  
+  export
   UNSIGNED_SHORT : Bits32
   UNSIGNED_SHORT = 0x1403
 
-
-  public export
+  
+  export
   UNSIGNED_SHORT_4_4_4_4 : Bits32
   UNSIGNED_SHORT_4_4_4_4 = 0x8033
 
-
-  public export
+  
+  export
   UNSIGNED_SHORT_5_5_5_1 : Bits32
   UNSIGNED_SHORT_5_5_5_1 = 0x8034
 
-
-  public export
+  
+  export
   UNSIGNED_SHORT_5_6_5 : Bits32
   UNSIGNED_SHORT_5_6_5 = 0x8363
 
-
-  public export
+  
+  export
   VALIDATE_STATUS : Bits32
   VALIDATE_STATUS = 0x8b83
 
-
-  public export
+  
+  export
   VENDOR : Bits32
   VENDOR = 0x1f00
 
-
-  public export
+  
+  export
   VERSION : Bits32
   VERSION = 0x1f02
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_BUFFER_BINDING : Bits32
   VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889f
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_ENABLED : Bits32
   VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_NORMALIZED : Bits32
   VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886a
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_POINTER : Bits32
   VERTEX_ATTRIB_ARRAY_POINTER = 0x8645
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_SIZE : Bits32
   VERTEX_ATTRIB_ARRAY_SIZE = 0x8623
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_STRIDE : Bits32
   VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624
 
-
-  public export
+  
+  export
   VERTEX_ATTRIB_ARRAY_TYPE : Bits32
   VERTEX_ATTRIB_ARRAY_TYPE = 0x8625
 
-
-  public export
+  
+  export
   VERTEX_SHADER : Bits32
   VERTEX_SHADER = 0x8b31
 
-
-  public export
+  
+  export
   VIEWPORT : Bits32
   VIEWPORT = 0xba2
 
-
-  public export
+  
+  export
   ZERO : Bits32
   ZERO = 0
 
-
+  
   export
   canvas :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (HSum [HTMLCanvasElement, OffscreenCanvas])
   canvas a = tryJS "WebGLRenderingContextBase.canvas" $
-    WebGLRenderingContextBase.prim__canvas (up a)
+    WebGLRenderingContextBase.prim__canvas (cast a)
 
-
+  
   export
   drawingBufferHeight :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO Int32
   drawingBufferHeight a = primJS $
-    WebGLRenderingContextBase.prim__drawingBufferHeight (up a)
+    WebGLRenderingContextBase.prim__drawingBufferHeight (cast a)
 
-
+  
   export
   drawingBufferWidth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO Int32
   drawingBufferWidth a = primJS $
-    WebGLRenderingContextBase.prim__drawingBufferWidth (up a)
+    WebGLRenderingContextBase.prim__drawingBufferWidth (cast a)
 
-
+  
   export
   activeTexture :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (texture : Bits32)
     -> JSIO ()
   activeTexture a b = primJS $
-    WebGLRenderingContextBase.prim__activeTexture (up a) b
+    WebGLRenderingContextBase.prim__activeTexture (cast a) b
 
-
+  
   export
   attachShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (shader : WebGLShader)
     -> JSIO ()
   attachShader a b c = primJS $
-    WebGLRenderingContextBase.prim__attachShader (up a) b c
+    WebGLRenderingContextBase.prim__attachShader (cast a) b c
 
-
+  
   export
   bindAttribLocation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (index : Bits32)
     -> (name : String)
     -> JSIO ()
   bindAttribLocation a b c d = primJS $
-    WebGLRenderingContextBase.prim__bindAttribLocation (up a) b c d
+    WebGLRenderingContextBase.prim__bindAttribLocation (cast a) b c d
 
-
+  
   export
   bindBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (buffer : Maybe WebGLBuffer)
     -> JSIO ()
   bindBuffer a b c = primJS $
-    WebGLRenderingContextBase.prim__bindBuffer (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__bindBuffer (cast a) b (toFFI c)
 
-
+  
   export
   bindFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (framebuffer : Maybe WebGLFramebuffer)
     -> JSIO ()
   bindFramebuffer a b c = primJS $
-    WebGLRenderingContextBase.prim__bindFramebuffer (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__bindFramebuffer (cast a) b (toFFI c)
 
-
+  
   export
   bindRenderbuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (renderbuffer : Maybe WebGLRenderbuffer)
     -> JSIO ()
   bindRenderbuffer a b c = primJS $
-    WebGLRenderingContextBase.prim__bindRenderbuffer (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__bindRenderbuffer (cast a) b (toFFI c)
 
-
+  
   export
   bindTexture :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (texture : Maybe WebGLTexture)
     -> JSIO ()
   bindTexture a b c = primJS $
-    WebGLRenderingContextBase.prim__bindTexture (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__bindTexture (cast a) b (toFFI c)
 
-
+  
   export
   blendColor :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (red : Double)
     -> (green : Double)
@@ -6180,36 +6057,33 @@ namespace WebGLRenderingContextBase
     -> (alpha : Double)
     -> JSIO ()
   blendColor a b c d e = primJS $
-    WebGLRenderingContextBase.prim__blendColor (up a) b c d e
+    WebGLRenderingContextBase.prim__blendColor (cast a) b c d e
 
-
+  
   export
   blendEquationSeparate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (modeRGB : Bits32)
     -> (modeAlpha : Bits32)
     -> JSIO ()
   blendEquationSeparate a b c = primJS $
-    WebGLRenderingContextBase.prim__blendEquationSeparate (up a) b c
+    WebGLRenderingContextBase.prim__blendEquationSeparate (cast a) b c
 
-
+  
   export
   blendEquation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> JSIO ()
   blendEquation a b = primJS $
-    WebGLRenderingContextBase.prim__blendEquation (up a) b
+    WebGLRenderingContextBase.prim__blendEquation (cast a) b
 
-
+  
   export
   blendFuncSeparate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (srcRGB : Bits32)
     -> (dstRGB : Bits32)
@@ -6217,36 +6091,33 @@ namespace WebGLRenderingContextBase
     -> (dstAlpha : Bits32)
     -> JSIO ()
   blendFuncSeparate a b c d e = primJS $
-    WebGLRenderingContextBase.prim__blendFuncSeparate (up a) b c d e
+    WebGLRenderingContextBase.prim__blendFuncSeparate (cast a) b c d e
 
-
+  
   export
   blendFunc :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (sfactor : Bits32)
     -> (dfactor : Bits32)
     -> JSIO ()
   blendFunc a b c = primJS $
-    WebGLRenderingContextBase.prim__blendFunc (up a) b c
+    WebGLRenderingContextBase.prim__blendFunc (cast a) b c
 
-
+  
   export
   checkFramebufferStatus :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> JSIO Bits32
   checkFramebufferStatus a b = primJS $
-    WebGLRenderingContextBase.prim__checkFramebufferStatus (up a) b
+    WebGLRenderingContextBase.prim__checkFramebufferStatus (cast a) b
 
-
+  
   export
   clearColor :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (red : Double)
     -> (green : Double)
@@ -6254,44 +6125,41 @@ namespace WebGLRenderingContextBase
     -> (alpha : Double)
     -> JSIO ()
   clearColor a b c d e = primJS $
-    WebGLRenderingContextBase.prim__clearColor (up a) b c d e
+    WebGLRenderingContextBase.prim__clearColor (cast a) b c d e
 
-
+  
   export
   clearDepth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (depth : Double)
     -> JSIO ()
-  clearDepth a b = primJS $ WebGLRenderingContextBase.prim__clearDepth (up a) b
+  clearDepth a b = primJS $
+    WebGLRenderingContextBase.prim__clearDepth (cast a) b
 
-
+  
   export
   clearStencil :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (s : Int32)
     -> JSIO ()
   clearStencil a b = primJS $
-    WebGLRenderingContextBase.prim__clearStencil (up a) b
+    WebGLRenderingContextBase.prim__clearStencil (cast a) b
 
-
+  
   export
   clear :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mask : Bits32)
     -> JSIO ()
-  clear a b = primJS $ WebGLRenderingContextBase.prim__clear (up a) b
+  clear a b = primJS $ WebGLRenderingContextBase.prim__clear (cast a) b
 
-
+  
   export
   colorMask :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (red : Bool)
     -> (green : Bool)
@@ -6300,28 +6168,26 @@ namespace WebGLRenderingContextBase
     -> JSIO ()
   colorMask a b c d e = primJS $
     WebGLRenderingContextBase.prim__colorMask
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
       (toFFI e)
 
-
+  
   export
   compileShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : WebGLShader)
     -> JSIO ()
   compileShader a b = primJS $
-    WebGLRenderingContextBase.prim__compileShader (up a) b
+    WebGLRenderingContextBase.prim__compileShader (cast a) b
 
-
+  
   export
   copyTexImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -6333,13 +6199,12 @@ namespace WebGLRenderingContextBase
     -> (border : Int32)
     -> JSIO ()
   copyTexImage2D a b c d e f g h i = primJS $
-    WebGLRenderingContextBase.prim__copyTexImage2D (up a) b c d e f g h i
+    WebGLRenderingContextBase.prim__copyTexImage2D (cast a) b c d e f g h i
 
-
+  
   export
   copyTexSubImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -6351,229 +6216,208 @@ namespace WebGLRenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   copyTexSubImage2D a b c d e f g h i = primJS $
-    WebGLRenderingContextBase.prim__copyTexSubImage2D (up a) b c d e f g h i
+    WebGLRenderingContextBase.prim__copyTexSubImage2D (cast a) b c d e f g h i
 
-
+  
   export
   createBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLBuffer)
   createBuffer a = tryJS "WebGLRenderingContextBase.createBuffer" $
-    WebGLRenderingContextBase.prim__createBuffer (up a)
+    WebGLRenderingContextBase.prim__createBuffer (cast a)
 
-
+  
   export
   createFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLFramebuffer)
   createFramebuffer a = tryJS "WebGLRenderingContextBase.createFramebuffer" $
-    WebGLRenderingContextBase.prim__createFramebuffer (up a)
+    WebGLRenderingContextBase.prim__createFramebuffer (cast a)
 
-
+  
   export
   createProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLProgram)
   createProgram a = tryJS "WebGLRenderingContextBase.createProgram" $
-    WebGLRenderingContextBase.prim__createProgram (up a)
+    WebGLRenderingContextBase.prim__createProgram (cast a)
 
-
+  
   export
   createRenderbuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLRenderbuffer)
   createRenderbuffer a = tryJS "WebGLRenderingContextBase.createRenderbuffer" $
-    WebGLRenderingContextBase.prim__createRenderbuffer (up a)
+    WebGLRenderingContextBase.prim__createRenderbuffer (cast a)
 
-
+  
   export
   createShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (type : Bits32)
     -> JSIO (Maybe WebGLShader)
   createShader a b = tryJS "WebGLRenderingContextBase.createShader" $
-    WebGLRenderingContextBase.prim__createShader (up a) b
+    WebGLRenderingContextBase.prim__createShader (cast a) b
 
-
+  
   export
   createTexture :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLTexture)
   createTexture a = tryJS "WebGLRenderingContextBase.createTexture" $
-    WebGLRenderingContextBase.prim__createTexture (up a)
+    WebGLRenderingContextBase.prim__createTexture (cast a)
 
-
+  
   export
   cullFace :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> JSIO ()
-  cullFace a b = primJS $ WebGLRenderingContextBase.prim__cullFace (up a) b
+  cullFace a b = primJS $ WebGLRenderingContextBase.prim__cullFace (cast a) b
 
-
+  
   export
   deleteBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (buffer : Maybe WebGLBuffer)
     -> JSIO ()
   deleteBuffer a b = primJS $
-    WebGLRenderingContextBase.prim__deleteBuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteBuffer (cast a) (toFFI b)
 
-
+  
   export
   deleteFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (framebuffer : Maybe WebGLFramebuffer)
     -> JSIO ()
   deleteFramebuffer a b = primJS $
-    WebGLRenderingContextBase.prim__deleteFramebuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteFramebuffer (cast a) (toFFI b)
 
-
+  
   export
   deleteProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : Maybe WebGLProgram)
     -> JSIO ()
   deleteProgram a b = primJS $
-    WebGLRenderingContextBase.prim__deleteProgram (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteProgram (cast a) (toFFI b)
 
-
+  
   export
   deleteRenderbuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (renderbuffer : Maybe WebGLRenderbuffer)
     -> JSIO ()
   deleteRenderbuffer a b = primJS $
-    WebGLRenderingContextBase.prim__deleteRenderbuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteRenderbuffer (cast a) (toFFI b)
 
-
+  
   export
   deleteShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : Maybe WebGLShader)
     -> JSIO ()
   deleteShader a b = primJS $
-    WebGLRenderingContextBase.prim__deleteShader (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteShader (cast a) (toFFI b)
 
-
+  
   export
   deleteTexture :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (texture : Maybe WebGLTexture)
     -> JSIO ()
   deleteTexture a b = primJS $
-    WebGLRenderingContextBase.prim__deleteTexture (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__deleteTexture (cast a) (toFFI b)
 
-
+  
   export
   depthFunc :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (func : Bits32)
     -> JSIO ()
-  depthFunc a b = primJS $ WebGLRenderingContextBase.prim__depthFunc (up a) b
+  depthFunc a b = primJS $ WebGLRenderingContextBase.prim__depthFunc (cast a) b
 
-
+  
   export
   depthMask :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (flag : Bool)
     -> JSIO ()
   depthMask a b = primJS $
-    WebGLRenderingContextBase.prim__depthMask (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__depthMask (cast a) (toFFI b)
 
-
+  
   export
   depthRange :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (zNear : Double)
     -> (zFar : Double)
     -> JSIO ()
   depthRange a b c = primJS $
-    WebGLRenderingContextBase.prim__depthRange (up a) b c
+    WebGLRenderingContextBase.prim__depthRange (cast a) b c
 
-
+  
   export
   detachShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (shader : WebGLShader)
     -> JSIO ()
   detachShader a b c = primJS $
-    WebGLRenderingContextBase.prim__detachShader (up a) b c
+    WebGLRenderingContextBase.prim__detachShader (cast a) b c
 
-
+  
   export
   disableVertexAttribArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> JSIO ()
   disableVertexAttribArray a b = primJS $
-    WebGLRenderingContextBase.prim__disableVertexAttribArray (up a) b
+    WebGLRenderingContextBase.prim__disableVertexAttribArray (cast a) b
 
-
+  
   export
   disable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (cap : Bits32)
     -> JSIO ()
-  disable a b = primJS $ WebGLRenderingContextBase.prim__disable (up a) b
+  disable a b = primJS $ WebGLRenderingContextBase.prim__disable (cast a) b
 
-
+  
   export
   drawArrays :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> (first : Int32)
     -> (count : Int32)
     -> JSIO ()
   drawArrays a b c d = primJS $
-    WebGLRenderingContextBase.prim__drawArrays (up a) b c d
+    WebGLRenderingContextBase.prim__drawArrays (cast a) b c d
 
-
+  
   export
   drawElements :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> (count : Int32)
@@ -6581,52 +6425,41 @@ namespace WebGLRenderingContextBase
     -> (offset : JSInt64)
     -> JSIO ()
   drawElements a b c d e = primJS $
-    WebGLRenderingContextBase.prim__drawElements (up a) b c d e
+    WebGLRenderingContextBase.prim__drawElements (cast a) b c d e
 
-
+  
   export
   enableVertexAttribArray :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> JSIO ()
   enableVertexAttribArray a b = primJS $
-    WebGLRenderingContextBase.prim__enableVertexAttribArray (up a) b
+    WebGLRenderingContextBase.prim__enableVertexAttribArray (cast a) b
 
-
+  
   export
   enable :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (cap : Bits32)
     -> JSIO ()
-  enable a b = primJS $ WebGLRenderingContextBase.prim__enable (up a) b
+  enable a b = primJS $ WebGLRenderingContextBase.prim__enable (cast a) b
 
-
+  
   export
-  finish :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  finish a = primJS $ WebGLRenderingContextBase.prim__finish (up a)
+  finish : {auto _ : Cast t1 WebGLRenderingContextBase} -> (obj : t1) -> JSIO ()
+  finish a = primJS $ WebGLRenderingContextBase.prim__finish (cast a)
 
-
+  
   export
-  flush :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
-    -> (obj : t1)
-    -> JSIO ()
-  flush a = primJS $ WebGLRenderingContextBase.prim__flush (up a)
+  flush : {auto _ : Cast t1 WebGLRenderingContextBase} -> (obj : t1) -> JSIO ()
+  flush a = primJS $ WebGLRenderingContextBase.prim__flush (cast a)
 
-
+  
   export
   framebufferRenderbuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachment : Bits32)
@@ -6635,17 +6468,16 @@ namespace WebGLRenderingContextBase
     -> JSIO ()
   framebufferRenderbuffer a b c d e = primJS $
     WebGLRenderingContextBase.prim__framebufferRenderbuffer
-      (up a)
+      (cast a)
       b
       c
       d
       (toFFI e)
 
-
+  
   export
   framebufferTexture2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachment : Bits32)
@@ -6655,446 +6487,411 @@ namespace WebGLRenderingContextBase
     -> JSIO ()
   framebufferTexture2D a b c d e f = primJS $
     WebGLRenderingContextBase.prim__framebufferTexture2D
-      (up a)
+      (cast a)
       b
       c
       d
       (toFFI e)
       f
 
-
+  
   export
   frontFace :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mode : Bits32)
     -> JSIO ()
-  frontFace a b = primJS $ WebGLRenderingContextBase.prim__frontFace (up a) b
+  frontFace a b = primJS $ WebGLRenderingContextBase.prim__frontFace (cast a) b
 
-
+  
   export
   generateMipmap :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> JSIO ()
   generateMipmap a b = primJS $
-    WebGLRenderingContextBase.prim__generateMipmap (up a) b
+    WebGLRenderingContextBase.prim__generateMipmap (cast a) b
 
-
+  
   export
   getActiveAttrib :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (index : Bits32)
     -> JSIO (Maybe WebGLActiveInfo)
   getActiveAttrib a b c = tryJS "WebGLRenderingContextBase.getActiveAttrib" $
-    WebGLRenderingContextBase.prim__getActiveAttrib (up a) b c
+    WebGLRenderingContextBase.prim__getActiveAttrib (cast a) b c
 
-
+  
   export
   getActiveUniform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (index : Bits32)
     -> JSIO (Maybe WebGLActiveInfo)
   getActiveUniform a b c = tryJS "WebGLRenderingContextBase.getActiveUniform" $
-    WebGLRenderingContextBase.prim__getActiveUniform (up a) b c
+    WebGLRenderingContextBase.prim__getActiveUniform (cast a) b c
 
-
+  
   export
   getAttachedShaders :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> JSIO (Maybe (Array WebGLShader))
   getAttachedShaders a b = tryJS "WebGLRenderingContextBase.getAttachedShaders" $
-    WebGLRenderingContextBase.prim__getAttachedShaders (up a) b
+    WebGLRenderingContextBase.prim__getAttachedShaders (cast a) b
 
-
+  
   export
   getAttribLocation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (name : String)
     -> JSIO Int32
   getAttribLocation a b c = primJS $
-    WebGLRenderingContextBase.prim__getAttribLocation (up a) b c
+    WebGLRenderingContextBase.prim__getAttribLocation (cast a) b c
 
-
+  
   export
   getBufferParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getBufferParameter a b c = tryJS "WebGLRenderingContextBase.getBufferParameter" $
-    WebGLRenderingContextBase.prim__getBufferParameter (up a) b c
+    WebGLRenderingContextBase.prim__getBufferParameter (cast a) b c
 
-
+  
   export
   getContextAttributes :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe WebGLContextAttributes)
   getContextAttributes a = tryJS "WebGLRenderingContextBase.getContextAttributes" $
-    WebGLRenderingContextBase.prim__getContextAttributes (up a)
+    WebGLRenderingContextBase.prim__getContextAttributes (cast a)
 
-
+  
   export
   getError :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO Bits32
-  getError a = primJS $ WebGLRenderingContextBase.prim__getError (up a)
+  getError a = primJS $ WebGLRenderingContextBase.prim__getError (cast a)
 
-
+  
   export
   getExtension :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (name : String)
     -> JSIO (Maybe Object)
   getExtension a b = tryJS "WebGLRenderingContextBase.getExtension" $
-    WebGLRenderingContextBase.prim__getExtension (up a) b
+    WebGLRenderingContextBase.prim__getExtension (cast a) b
 
-
+  
   export
   getFramebufferAttachmentParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (attachment : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getFramebufferAttachmentParameter a b c d = tryJS "WebGLRenderingContextBase.getFramebufferAttachmentParameter" $
-    WebGLRenderingContextBase.prim__getFramebufferAttachmentParameter (up a) b c d
+    WebGLRenderingContextBase.prim__getFramebufferAttachmentParameter
+      (cast a)
+      b
+      c
+      d
 
-
+  
   export
   getParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (pname : Bits32)
     -> JSIO Any
   getParameter a b = tryJS "WebGLRenderingContextBase.getParameter" $
-    WebGLRenderingContextBase.prim__getParameter (up a) b
+    WebGLRenderingContextBase.prim__getParameter (cast a) b
 
-
+  
   export
   getProgramInfoLog :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> JSIO (Maybe String)
   getProgramInfoLog a b = tryJS "WebGLRenderingContextBase.getProgramInfoLog" $
-    WebGLRenderingContextBase.prim__getProgramInfoLog (up a) b
+    WebGLRenderingContextBase.prim__getProgramInfoLog (cast a) b
 
-
+  
   export
   getProgramParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (pname : Bits32)
     -> JSIO Any
   getProgramParameter a b c = tryJS "WebGLRenderingContextBase.getProgramParameter" $
-    WebGLRenderingContextBase.prim__getProgramParameter (up a) b c
+    WebGLRenderingContextBase.prim__getProgramParameter (cast a) b c
 
-
+  
   export
   getRenderbufferParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getRenderbufferParameter a b c = tryJS "WebGLRenderingContextBase.getRenderbufferParameter" $
-    WebGLRenderingContextBase.prim__getRenderbufferParameter (up a) b c
+    WebGLRenderingContextBase.prim__getRenderbufferParameter (cast a) b c
 
-
+  
   export
   getShaderInfoLog :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : WebGLShader)
     -> JSIO (Maybe String)
   getShaderInfoLog a b = tryJS "WebGLRenderingContextBase.getShaderInfoLog" $
-    WebGLRenderingContextBase.prim__getShaderInfoLog (up a) b
+    WebGLRenderingContextBase.prim__getShaderInfoLog (cast a) b
 
-
+  
   export
   getShaderParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : WebGLShader)
     -> (pname : Bits32)
     -> JSIO Any
   getShaderParameter a b c = tryJS "WebGLRenderingContextBase.getShaderParameter" $
-    WebGLRenderingContextBase.prim__getShaderParameter (up a) b c
+    WebGLRenderingContextBase.prim__getShaderParameter (cast a) b c
 
-
+  
   export
   getShaderPrecisionFormat :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shadertype : Bits32)
     -> (precisiontype : Bits32)
     -> JSIO (Maybe WebGLShaderPrecisionFormat)
   getShaderPrecisionFormat a b c = tryJS "WebGLRenderingContextBase.getShaderPrecisionFormat" $
-    WebGLRenderingContextBase.prim__getShaderPrecisionFormat (up a) b c
+    WebGLRenderingContextBase.prim__getShaderPrecisionFormat (cast a) b c
 
-
+  
   export
   getShaderSource :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : WebGLShader)
     -> JSIO (Maybe String)
   getShaderSource a b = tryJS "WebGLRenderingContextBase.getShaderSource" $
-    WebGLRenderingContextBase.prim__getShaderSource (up a) b
+    WebGLRenderingContextBase.prim__getShaderSource (cast a) b
 
-
+  
   export
   getSupportedExtensions :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO (Maybe (Array String))
   getSupportedExtensions a = tryJS "WebGLRenderingContextBase.getSupportedExtensions" $
-    WebGLRenderingContextBase.prim__getSupportedExtensions (up a)
+    WebGLRenderingContextBase.prim__getSupportedExtensions (cast a)
 
-
+  
   export
   getTexParameter :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getTexParameter a b c = tryJS "WebGLRenderingContextBase.getTexParameter" $
-    WebGLRenderingContextBase.prim__getTexParameter (up a) b c
+    WebGLRenderingContextBase.prim__getTexParameter (cast a) b c
 
-
+  
   export
   getUniformLocation :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (name : String)
     -> JSIO (Maybe WebGLUniformLocation)
   getUniformLocation a b c = tryJS "WebGLRenderingContextBase.getUniformLocation" $
-    WebGLRenderingContextBase.prim__getUniformLocation (up a) b c
+    WebGLRenderingContextBase.prim__getUniformLocation (cast a) b c
 
-
+  
   export
   getUniform :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> (location : WebGLUniformLocation)
     -> JSIO Any
   getUniform a b c = tryJS "WebGLRenderingContextBase.getUniform" $
-    WebGLRenderingContextBase.prim__getUniform (up a) b c
+    WebGLRenderingContextBase.prim__getUniform (cast a) b c
 
-
+  
   export
   getVertexAttribOffset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (pname : Bits32)
     -> JSIO JSInt64
   getVertexAttribOffset a b c = primJS $
-    WebGLRenderingContextBase.prim__getVertexAttribOffset (up a) b c
+    WebGLRenderingContextBase.prim__getVertexAttribOffset (cast a) b c
 
-
+  
   export
   getVertexAttrib :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (pname : Bits32)
     -> JSIO Any
   getVertexAttrib a b c = tryJS "WebGLRenderingContextBase.getVertexAttrib" $
-    WebGLRenderingContextBase.prim__getVertexAttrib (up a) b c
+    WebGLRenderingContextBase.prim__getVertexAttrib (cast a) b c
 
-
+  
   export
   hint :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (mode : Bits32)
     -> JSIO ()
-  hint a b c = primJS $ WebGLRenderingContextBase.prim__hint (up a) b c
+  hint a b c = primJS $ WebGLRenderingContextBase.prim__hint (cast a) b c
 
-
+  
   export
   isBuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (buffer : Maybe WebGLBuffer)
     -> JSIO Bool
   isBuffer a b = tryJS "WebGLRenderingContextBase.isBuffer" $
-    WebGLRenderingContextBase.prim__isBuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isBuffer (cast a) (toFFI b)
 
-
+  
   export
   isContextLost :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> JSIO Bool
   isContextLost a = tryJS "WebGLRenderingContextBase.isContextLost" $
-    WebGLRenderingContextBase.prim__isContextLost (up a)
+    WebGLRenderingContextBase.prim__isContextLost (cast a)
 
-
+  
   export
   isEnabled :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (cap : Bits32)
     -> JSIO Bool
   isEnabled a b = tryJS "WebGLRenderingContextBase.isEnabled" $
-    WebGLRenderingContextBase.prim__isEnabled (up a) b
+    WebGLRenderingContextBase.prim__isEnabled (cast a) b
 
-
+  
   export
   isFramebuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (framebuffer : Maybe WebGLFramebuffer)
     -> JSIO Bool
   isFramebuffer a b = tryJS "WebGLRenderingContextBase.isFramebuffer" $
-    WebGLRenderingContextBase.prim__isFramebuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isFramebuffer (cast a) (toFFI b)
 
-
+  
   export
   isProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : Maybe WebGLProgram)
     -> JSIO Bool
   isProgram a b = tryJS "WebGLRenderingContextBase.isProgram" $
-    WebGLRenderingContextBase.prim__isProgram (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isProgram (cast a) (toFFI b)
 
-
+  
   export
   isRenderbuffer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (renderbuffer : Maybe WebGLRenderbuffer)
     -> JSIO Bool
   isRenderbuffer a b = tryJS "WebGLRenderingContextBase.isRenderbuffer" $
-    WebGLRenderingContextBase.prim__isRenderbuffer (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isRenderbuffer (cast a) (toFFI b)
 
-
+  
   export
   isShader :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : Maybe WebGLShader)
     -> JSIO Bool
   isShader a b = tryJS "WebGLRenderingContextBase.isShader" $
-    WebGLRenderingContextBase.prim__isShader (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isShader (cast a) (toFFI b)
 
-
+  
   export
   isTexture :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (texture : Maybe WebGLTexture)
     -> JSIO Bool
   isTexture a b = tryJS "WebGLRenderingContextBase.isTexture" $
-    WebGLRenderingContextBase.prim__isTexture (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__isTexture (cast a) (toFFI b)
 
-
+  
   export
   lineWidth :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (width : Double)
     -> JSIO ()
-  lineWidth a b = primJS $ WebGLRenderingContextBase.prim__lineWidth (up a) b
+  lineWidth a b = primJS $ WebGLRenderingContextBase.prim__lineWidth (cast a) b
 
-
+  
   export
   linkProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> JSIO ()
   linkProgram a b = primJS $
-    WebGLRenderingContextBase.prim__linkProgram (up a) b
+    WebGLRenderingContextBase.prim__linkProgram (cast a) b
 
-
+  
   export
   pixelStorei :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (pname : Bits32)
     -> (param : Int32)
     -> JSIO ()
   pixelStorei a b c = primJS $
-    WebGLRenderingContextBase.prim__pixelStorei (up a) b c
+    WebGLRenderingContextBase.prim__pixelStorei (cast a) b c
 
-
+  
   export
   polygonOffset :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (factor : Double)
     -> (units : Double)
     -> JSIO ()
   polygonOffset a b c = primJS $
-    WebGLRenderingContextBase.prim__polygonOffset (up a) b c
+    WebGLRenderingContextBase.prim__polygonOffset (cast a) b c
 
-
+  
   export
   renderbufferStorage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (internalformat : Bits32)
@@ -7102,25 +6899,23 @@ namespace WebGLRenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   renderbufferStorage a b c d e = primJS $
-    WebGLRenderingContextBase.prim__renderbufferStorage (up a) b c d e
+    WebGLRenderingContextBase.prim__renderbufferStorage (cast a) b c d e
 
-
+  
   export
   sampleCoverage :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (value : Double)
     -> (invert : Bool)
     -> JSIO ()
   sampleCoverage a b c = primJS $
-    WebGLRenderingContextBase.prim__sampleCoverage (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__sampleCoverage (cast a) b (toFFI c)
 
-
+  
   export
   scissor :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -7128,25 +6923,23 @@ namespace WebGLRenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   scissor a b c d e = primJS $
-    WebGLRenderingContextBase.prim__scissor (up a) b c d e
+    WebGLRenderingContextBase.prim__scissor (cast a) b c d e
 
-
+  
   export
   shaderSource :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (shader : WebGLShader)
     -> (source : String)
     -> JSIO ()
   shaderSource a b c = primJS $
-    WebGLRenderingContextBase.prim__shaderSource (up a) b c
+    WebGLRenderingContextBase.prim__shaderSource (cast a) b c
 
-
+  
   export
   stencilFuncSeparate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (face : Bits32)
     -> (func : Bits32)
@@ -7154,49 +6947,45 @@ namespace WebGLRenderingContextBase
     -> (mask : Bits32)
     -> JSIO ()
   stencilFuncSeparate a b c d e = primJS $
-    WebGLRenderingContextBase.prim__stencilFuncSeparate (up a) b c d e
+    WebGLRenderingContextBase.prim__stencilFuncSeparate (cast a) b c d e
 
-
+  
   export
   stencilFunc :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (func : Bits32)
     -> (ref : Int32)
     -> (mask : Bits32)
     -> JSIO ()
   stencilFunc a b c d = primJS $
-    WebGLRenderingContextBase.prim__stencilFunc (up a) b c d
+    WebGLRenderingContextBase.prim__stencilFunc (cast a) b c d
 
-
+  
   export
   stencilMaskSeparate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (face : Bits32)
     -> (mask : Bits32)
     -> JSIO ()
   stencilMaskSeparate a b c = primJS $
-    WebGLRenderingContextBase.prim__stencilMaskSeparate (up a) b c
+    WebGLRenderingContextBase.prim__stencilMaskSeparate (cast a) b c
 
-
+  
   export
   stencilMask :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (mask : Bits32)
     -> JSIO ()
   stencilMask a b = primJS $
-    WebGLRenderingContextBase.prim__stencilMask (up a) b
+    WebGLRenderingContextBase.prim__stencilMask (cast a) b
 
-
+  
   export
   stencilOpSeparate :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (face : Bits32)
     -> (fail : Bits32)
@@ -7204,102 +6993,94 @@ namespace WebGLRenderingContextBase
     -> (zpass : Bits32)
     -> JSIO ()
   stencilOpSeparate a b c d e = primJS $
-    WebGLRenderingContextBase.prim__stencilOpSeparate (up a) b c d e
+    WebGLRenderingContextBase.prim__stencilOpSeparate (cast a) b c d e
 
-
+  
   export
   stencilOp :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (fail : Bits32)
     -> (zfail : Bits32)
     -> (zpass : Bits32)
     -> JSIO ()
   stencilOp a b c d = primJS $
-    WebGLRenderingContextBase.prim__stencilOp (up a) b c d
+    WebGLRenderingContextBase.prim__stencilOp (cast a) b c d
 
-
+  
   export
   texParameterf :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> (param : Double)
     -> JSIO ()
   texParameterf a b c d = primJS $
-    WebGLRenderingContextBase.prim__texParameterf (up a) b c d
+    WebGLRenderingContextBase.prim__texParameterf (cast a) b c d
 
-
+  
   export
   texParameteri :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (target : Bits32)
     -> (pname : Bits32)
     -> (param : Int32)
     -> JSIO ()
   texParameteri a b c d = primJS $
-    WebGLRenderingContextBase.prim__texParameteri (up a) b c d
+    WebGLRenderingContextBase.prim__texParameteri (cast a) b c d
 
-
+  
   export
   uniform1f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Double)
     -> JSIO ()
   uniform1f a b c = primJS $
-    WebGLRenderingContextBase.prim__uniform1f (up a) (toFFI b) c
+    WebGLRenderingContextBase.prim__uniform1f (cast a) (toFFI b) c
 
-
+  
   export
   uniform1i :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Int32)
     -> JSIO ()
   uniform1i a b c = primJS $
-    WebGLRenderingContextBase.prim__uniform1i (up a) (toFFI b) c
+    WebGLRenderingContextBase.prim__uniform1i (cast a) (toFFI b) c
 
-
+  
   export
   uniform2f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
   uniform2f a b c d = primJS $
-    WebGLRenderingContextBase.prim__uniform2f (up a) (toFFI b) c d
+    WebGLRenderingContextBase.prim__uniform2f (cast a) (toFFI b) c d
 
-
+  
   export
   uniform2i :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Int32)
     -> (y : Int32)
     -> JSIO ()
   uniform2i a b c d = primJS $
-    WebGLRenderingContextBase.prim__uniform2i (up a) (toFFI b) c d
+    WebGLRenderingContextBase.prim__uniform2i (cast a) (toFFI b) c d
 
-
+  
   export
   uniform3f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Double)
@@ -7307,13 +7088,12 @@ namespace WebGLRenderingContextBase
     -> (z : Double)
     -> JSIO ()
   uniform3f a b c d e = primJS $
-    WebGLRenderingContextBase.prim__uniform3f (up a) (toFFI b) c d e
+    WebGLRenderingContextBase.prim__uniform3f (cast a) (toFFI b) c d e
 
-
+  
   export
   uniform3i :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Int32)
@@ -7321,13 +7101,12 @@ namespace WebGLRenderingContextBase
     -> (z : Int32)
     -> JSIO ()
   uniform3i a b c d e = primJS $
-    WebGLRenderingContextBase.prim__uniform3i (up a) (toFFI b) c d e
+    WebGLRenderingContextBase.prim__uniform3i (cast a) (toFFI b) c d e
 
-
+  
   export
   uniform4f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Double)
@@ -7336,13 +7115,12 @@ namespace WebGLRenderingContextBase
     -> (w : Double)
     -> JSIO ()
   uniform4f a b c d e f = primJS $
-    WebGLRenderingContextBase.prim__uniform4f (up a) (toFFI b) c d e f
+    WebGLRenderingContextBase.prim__uniform4f (cast a) (toFFI b) c d e f
 
-
+  
   export
   uniform4i :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (x : Int32)
@@ -7351,84 +7129,77 @@ namespace WebGLRenderingContextBase
     -> (w : Int32)
     -> JSIO ()
   uniform4i a b c d e f = primJS $
-    WebGLRenderingContextBase.prim__uniform4i (up a) (toFFI b) c d e f
+    WebGLRenderingContextBase.prim__uniform4i (cast a) (toFFI b) c d e f
 
-
+  
   export
   useProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : Maybe WebGLProgram)
     -> JSIO ()
   useProgram a b = primJS $
-    WebGLRenderingContextBase.prim__useProgram (up a) (toFFI b)
+    WebGLRenderingContextBase.prim__useProgram (cast a) (toFFI b)
 
-
+  
   export
   validateProgram :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (program : WebGLProgram)
     -> JSIO ()
   validateProgram a b = primJS $
-    WebGLRenderingContextBase.prim__validateProgram (up a) b
+    WebGLRenderingContextBase.prim__validateProgram (cast a) b
 
-
+  
   export
   vertexAttrib1f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Double)
     -> JSIO ()
   vertexAttrib1f a b c = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib1f (up a) b c
+    WebGLRenderingContextBase.prim__vertexAttrib1f (cast a) b c
 
-
+  
   export
   vertexAttrib1fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [Float32Array, Array Double])
     -> JSIO ()
   vertexAttrib1fv a b c = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib1fv (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__vertexAttrib1fv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttrib2f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Double)
     -> (y : Double)
     -> JSIO ()
   vertexAttrib2f a b c d = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib2f (up a) b c d
+    WebGLRenderingContextBase.prim__vertexAttrib2f (cast a) b c d
 
-
+  
   export
   vertexAttrib2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [Float32Array, Array Double])
     -> JSIO ()
   vertexAttrib2fv a b c = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib2fv (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__vertexAttrib2fv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttrib3f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Double)
@@ -7436,25 +7207,23 @@ namespace WebGLRenderingContextBase
     -> (z : Double)
     -> JSIO ()
   vertexAttrib3f a b c d e = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib3f (up a) b c d e
+    WebGLRenderingContextBase.prim__vertexAttrib3f (cast a) b c d e
 
-
+  
   export
   vertexAttrib3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [Float32Array, Array Double])
     -> JSIO ()
   vertexAttrib3fv a b c = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib3fv (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__vertexAttrib3fv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttrib4f :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (x : Double)
@@ -7463,25 +7232,23 @@ namespace WebGLRenderingContextBase
     -> (w : Double)
     -> JSIO ()
   vertexAttrib4f a b c d e f = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib4f (up a) b c d e f
+    WebGLRenderingContextBase.prim__vertexAttrib4f (cast a) b c d e f
 
-
+  
   export
   vertexAttrib4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (values : HSum [Float32Array, Array Double])
     -> JSIO ()
   vertexAttrib4fv a b c = primJS $
-    WebGLRenderingContextBase.prim__vertexAttrib4fv (up a) b (toFFI c)
+    WebGLRenderingContextBase.prim__vertexAttrib4fv (cast a) b (toFFI c)
 
-
+  
   export
   vertexAttribPointer :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (index : Bits32)
     -> (size : Int32)
@@ -7492,7 +7259,7 @@ namespace WebGLRenderingContextBase
     -> JSIO ()
   vertexAttribPointer a b c d e f g = primJS $
     WebGLRenderingContextBase.prim__vertexAttribPointer
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7500,11 +7267,10 @@ namespace WebGLRenderingContextBase
       f
       g
 
-
+  
   export
   viewport :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextBase (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextBase}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -7512,29 +7278,27 @@ namespace WebGLRenderingContextBase
     -> (height : Int32)
     -> JSIO ()
   viewport a b c d e = primJS $
-    WebGLRenderingContextBase.prim__viewport (up a) b c d e
+    WebGLRenderingContextBase.prim__viewport (cast a) b c d e
 
 
 
 namespace WebGLRenderingContextOverloads
-
+  
   export
   bufferData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (size : JSInt64)
     -> (usage : Bits32)
     -> JSIO ()
   bufferData a b c d = primJS $
-    WebGLRenderingContextOverloads.prim__bufferData (up a) b c d
+    WebGLRenderingContextOverloads.prim__bufferData (cast a) b c d
 
-
+  
   export
   bufferData1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (data_ : Maybe
@@ -7554,13 +7318,12 @@ namespace WebGLRenderingContextOverloads
     -> (usage : Bits32)
     -> JSIO ()
   bufferData1 a b c d = primJS $
-    WebGLRenderingContextOverloads.prim__bufferData1 (up a) b (toFFI c) d
+    WebGLRenderingContextOverloads.prim__bufferData1 (cast a) b (toFFI c) d
 
-
+  
   export
   bufferSubData :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (offset : JSInt64)
@@ -7579,13 +7342,12 @@ namespace WebGLRenderingContextOverloads
                   ])
     -> JSIO ()
   bufferSubData a b c d = primJS $
-    WebGLRenderingContextOverloads.prim__bufferSubData (up a) b c (toFFI d)
+    WebGLRenderingContextOverloads.prim__bufferSubData (cast a) b c (toFFI d)
 
-
+  
   export
   compressedTexImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7608,7 +7370,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   compressedTexImage2D a b c d e f g h = primJS $
     WebGLRenderingContextOverloads.prim__compressedTexImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7617,11 +7379,10 @@ namespace WebGLRenderingContextOverloads
       g
       (toFFI h)
 
-
+  
   export
   compressedTexSubImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7645,7 +7406,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   compressedTexSubImage2D a b c d e f g h i = primJS $
     WebGLRenderingContextOverloads.prim__compressedTexSubImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7655,11 +7416,10 @@ namespace WebGLRenderingContextOverloads
       h
       (toFFI i)
 
-
+  
   export
   readPixels :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (x : Int32)
     -> (y : Int32)
@@ -7682,13 +7442,20 @@ namespace WebGLRenderingContextOverloads
                       ]))
     -> JSIO ()
   readPixels a b c d e f g h = primJS $
-    WebGLRenderingContextOverloads.prim__readPixels (up a) b c d e f g (toFFI h)
+    WebGLRenderingContextOverloads.prim__readPixels
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      g
+      (toFFI h)
 
-
+  
   export
   texImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7714,7 +7481,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   texImage2D a b c d e f g h i j = primJS $
     WebGLRenderingContextOverloads.prim__texImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7725,11 +7492,10 @@ namespace WebGLRenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7746,13 +7512,19 @@ namespace WebGLRenderingContextOverloads
                    ])
     -> JSIO ()
   texImage2D1 a b c d e f g = primJS $
-    WebGLRenderingContextOverloads.prim__texImage2D1 (up a) b c d e f (toFFI g)
+    WebGLRenderingContextOverloads.prim__texImage2D1
+      (cast a)
+      b
+      c
+      d
+      e
+      f
+      (toFFI g)
 
-
+  
   export
   texSubImage2D :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7778,7 +7550,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   texSubImage2D a b c d e f g h i j = primJS $
     WebGLRenderingContextOverloads.prim__texSubImage2D
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7789,11 +7561,10 @@ namespace WebGLRenderingContextOverloads
       i
       (toFFI j)
 
-
+  
   export
   texSubImage2D1 :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (target : Bits32)
     -> (level : Int32)
@@ -7812,7 +7583,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   texSubImage2D1 a b c d e f g h = primJS $
     WebGLRenderingContextOverloads.prim__texSubImage2D1
-      (up a)
+      (cast a)
       b
       c
       d
@@ -7821,107 +7592,98 @@ namespace WebGLRenderingContextOverloads
       g
       (toFFI h)
 
-
+  
   export
   uniform1fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform1fv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform1fv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform1fv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform1iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform1iv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform1iv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform1iv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform2fv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform2fv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform2fv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform2iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform2iv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform2iv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform2iv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform3fv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform3fv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform3fv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform3iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform3iv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform3iv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform3iv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Float32Array, Array Double])
     -> JSIO ()
   uniform4fv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform4fv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform4fv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniform4iv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (v : HSum [Int32Array, Array Int32])
     -> JSIO ()
   uniform4iv a b c = primJS $
-    WebGLRenderingContextOverloads.prim__uniform4iv (up a) (toFFI b) (toFFI c)
+    WebGLRenderingContextOverloads.prim__uniform4iv (cast a) (toFFI b) (toFFI c)
 
-
+  
   export
   uniformMatrix2fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -7929,16 +7691,15 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   uniformMatrix2fv a b c d = primJS $
     WebGLRenderingContextOverloads.prim__uniformMatrix2fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
 
-
+  
   export
   uniformMatrix3fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -7946,16 +7707,15 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   uniformMatrix3fv a b c d = primJS $
     WebGLRenderingContextOverloads.prim__uniformMatrix3fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
 
-
+  
   export
   uniformMatrix4fv :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem WebGLRenderingContextOverloads (Types t1)}
+       {auto _ : Cast t1 WebGLRenderingContextOverloads}
     -> (obj : t1)
     -> (location : Maybe WebGLUniformLocation)
     -> (transpose : Bool)
@@ -7963,7 +7723,7 @@ namespace WebGLRenderingContextOverloads
     -> JSIO ()
   uniformMatrix4fv a b c d = primJS $
     WebGLRenderingContextOverloads.prim__uniformMatrix4fv
-      (up a)
+      (cast a)
       (toFFI b)
       (toFFI c)
       (toFFI d)
@@ -7976,7 +7736,7 @@ namespace WebGLRenderingContextOverloads
 --------------------------------------------------------------------------------
 
 namespace WebGLContextAttributes
-
+  
   export
   new' :
        (alpha : Optional Bool)
@@ -8000,7 +7760,7 @@ namespace WebGLContextAttributes
       (toFFI g)
       (toFFI h)
       (toFFI i)
-
+  
   export
   new : JSIO WebGLContextAttributes
   new = primJS $
@@ -8015,11 +7775,10 @@ namespace WebGLContextAttributes
       undef
       undef
 
-
+  
   export
   alpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   alpha v = fromUndefOrPrim
@@ -8027,13 +7786,12 @@ namespace WebGLContextAttributes
               prim__alpha
               prim__setAlpha
               True
-              (v :> WebGLContextAttributes)
+              (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   antialias :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   antialias v = fromUndefOrPrim
@@ -8041,13 +7799,12 @@ namespace WebGLContextAttributes
                   prim__antialias
                   prim__setAntialias
                   True
-                  (v :> WebGLContextAttributes)
+                  (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   depth :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   depth v = fromUndefOrPrim
@@ -8055,13 +7812,12 @@ namespace WebGLContextAttributes
               prim__depth
               prim__setDepth
               True
-              (v :> WebGLContextAttributes)
+              (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   desynchronized :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   desynchronized v = fromUndefOrPrim
@@ -8069,13 +7825,12 @@ namespace WebGLContextAttributes
                        prim__desynchronized
                        prim__setDesynchronized
                        False
-                       (v :> WebGLContextAttributes)
+                       (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   failIfMajorPerformanceCaveat :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   failIfMajorPerformanceCaveat v = fromUndefOrPrim
@@ -8083,26 +7838,24 @@ namespace WebGLContextAttributes
                                      prim__failIfMajorPerformanceCaveat
                                      prim__setFailIfMajorPerformanceCaveat
                                      False
-                                     (v :> WebGLContextAttributes)
+                                     (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   powerPreference :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute False Optional WebGLPowerPreference
   powerPreference v = fromUndefOrPrimNoDefault
                         "WebGLContextAttributes.getpowerPreference"
                         prim__powerPreference
                         prim__setPowerPreference
-                        (v :> WebGLContextAttributes)
+                        (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   premultipliedAlpha :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   premultipliedAlpha v = fromUndefOrPrim
@@ -8110,13 +7863,12 @@ namespace WebGLContextAttributes
                            prim__premultipliedAlpha
                            prim__setPremultipliedAlpha
                            True
-                           (v :> WebGLContextAttributes)
+                           (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   preserveDrawingBuffer :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   preserveDrawingBuffer v = fromUndefOrPrim
@@ -8124,13 +7876,12 @@ namespace WebGLContextAttributes
                               prim__preserveDrawingBuffer
                               prim__setPreserveDrawingBuffer
                               False
-                              (v :> WebGLContextAttributes)
+                              (cast {to = WebGLContextAttributes} v)
 
-
+  
   export
   stencil :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem WebGLContextAttributes (Types t)}
+       {auto _ : Cast t WebGLContextAttributes}
     -> t
     -> Attribute True Optional Bool
   stencil v = fromUndefOrPrim
@@ -8138,4 +7889,7 @@ namespace WebGLContextAttributes
                 prim__stencil
                 prim__setStencil
                 False
-                (v :> WebGLContextAttributes)
+                (cast {to = WebGLContextAttributes} v)
+
+
+

--- a/src/Web/Raw/Webidl.idr
+++ b/src/Web/Raw/Webidl.idr
@@ -12,169 +12,157 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace DOMException
-
-  public export
+  
+  export
   ABORT_ERR : Bits16
   ABORT_ERR = 20
 
-
-  public export
+  
+  export
   DATA_CLONE_ERR : Bits16
   DATA_CLONE_ERR = 25
 
-
-  public export
+  
+  export
   DOMSTRING_SIZE_ERR : Bits16
   DOMSTRING_SIZE_ERR = 2
 
-
-  public export
+  
+  export
   HIERARCHY_REQUEST_ERR : Bits16
   HIERARCHY_REQUEST_ERR = 3
 
-
-  public export
+  
+  export
   INDEX_SIZE_ERR : Bits16
   INDEX_SIZE_ERR = 1
 
-
-  public export
+  
+  export
   INUSE_ATTRIBUTE_ERR : Bits16
   INUSE_ATTRIBUTE_ERR = 10
 
-
-  public export
+  
+  export
   INVALID_ACCESS_ERR : Bits16
   INVALID_ACCESS_ERR = 15
 
-
-  public export
+  
+  export
   INVALID_CHARACTER_ERR : Bits16
   INVALID_CHARACTER_ERR = 5
 
-
-  public export
+  
+  export
   INVALID_MODIFICATION_ERR : Bits16
   INVALID_MODIFICATION_ERR = 13
 
-
-  public export
+  
+  export
   INVALID_NODE_TYPE_ERR : Bits16
   INVALID_NODE_TYPE_ERR = 24
 
-
-  public export
+  
+  export
   INVALID_STATE_ERR : Bits16
   INVALID_STATE_ERR = 11
 
-
-  public export
+  
+  export
   NAMESPACE_ERR : Bits16
   NAMESPACE_ERR = 14
 
-
-  public export
+  
+  export
   NETWORK_ERR : Bits16
   NETWORK_ERR = 19
 
-
-  public export
+  
+  export
   NOT_FOUND_ERR : Bits16
   NOT_FOUND_ERR = 8
 
-
-  public export
+  
+  export
   NOT_SUPPORTED_ERR : Bits16
   NOT_SUPPORTED_ERR = 9
 
-
-  public export
+  
+  export
   NO_DATA_ALLOWED_ERR : Bits16
   NO_DATA_ALLOWED_ERR = 6
 
-
-  public export
+  
+  export
   NO_MODIFICATION_ALLOWED_ERR : Bits16
   NO_MODIFICATION_ALLOWED_ERR = 7
 
-
-  public export
+  
+  export
   QUOTA_EXCEEDED_ERR : Bits16
   QUOTA_EXCEEDED_ERR = 22
 
-
-  public export
+  
+  export
   SECURITY_ERR : Bits16
   SECURITY_ERR = 18
 
-
-  public export
+  
+  export
   SYNTAX_ERR : Bits16
   SYNTAX_ERR = 12
 
-
-  public export
+  
+  export
   TIMEOUT_ERR : Bits16
   TIMEOUT_ERR = 23
 
-
-  public export
+  
+  export
   TYPE_MISMATCH_ERR : Bits16
   TYPE_MISMATCH_ERR = 17
 
-
-  public export
+  
+  export
   URL_MISMATCH_ERR : Bits16
   URL_MISMATCH_ERR = 21
 
-
-  public export
+  
+  export
   VALIDATION_ERR : Bits16
   VALIDATION_ERR = 16
 
-
-  public export
+  
+  export
   WRONG_DOCUMENT_ERR : Bits16
   WRONG_DOCUMENT_ERR = 4
 
-
+  
   export
   new' :
        (message : Optional String)
     -> (name : Optional String)
     -> JSIO DOMException
   new' a b = primJS $ DOMException.prim__new (toFFI a) (toFFI b)
-
+  
   export
   new : JSIO DOMException
   new = primJS $ DOMException.prim__new undef undef
 
-
+  
   export
-  code :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMException (Types t1)}
-    -> (obj : t1)
-    -> JSIO Bits16
-  code a = primJS $ DOMException.prim__code (up a)
+  code : {auto _ : Cast t1 DOMException} -> (obj : t1) -> JSIO Bits16
+  code a = primJS $ DOMException.prim__code (cast a)
 
-
+  
   export
-  message :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMException (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  message a = primJS $ DOMException.prim__message (up a)
+  message : {auto _ : Cast t1 DOMException} -> (obj : t1) -> JSIO String
+  message a = primJS $ DOMException.prim__message (cast a)
 
-
+  
   export
-  name :
-       {auto 0 _ : JSType t1}
-    -> {auto 0 _ : Elem DOMException (Types t1)}
-    -> (obj : t1)
-    -> JSIO String
-  name a = primJS $ DOMException.prim__name (up a)
+  name : {auto _ : Cast t1 DOMException} -> (obj : t1) -> JSIO String
+  name a = primJS $ DOMException.prim__name (cast a)
 
 
 
@@ -186,7 +174,7 @@ namespace DOMException
 --------------------------------------------------------------------------------
 
 namespace Function
-
+  
   export
   toFunction : (IO (Array AnyPtr) -> IO AnyPtr) -> JSIO Function
   toFunction cb = primJS $ prim__toFunction cb
@@ -194,7 +182,9 @@ namespace Function
 
 
 namespace VoidFunction
-
+  
   export
   toVoidFunction : (() -> IO ()) -> JSIO VoidFunction
   toVoidFunction cb = primJS $ prim__toVoidFunction cb
+
+

--- a/src/Web/Raw/Xhr.idr
+++ b/src/Web/Raw/Xhr.idr
@@ -12,48 +12,46 @@ import Web.Internal.Types
 --------------------------------------------------------------------------------
 
 namespace FormData
-
+  
   export
   new' : (form : Optional HTMLFormElement) -> JSIO FormData
   new' a = primJS $ FormData.prim__new (toFFI a)
-
+  
   export
   new : JSIO FormData
   new = primJS $ FormData.prim__new undef
 
-
+  
   export
   append : (obj : FormData) -> (name : String) -> (value : String) -> JSIO ()
   append a b c = primJS $ FormData.prim__append a b c
 
-
+  
   export
   append1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Blob (Types t3)}
+       {auto _ : Cast t3 Blob}
     -> (obj : FormData)
     -> (name : String)
     -> (blobValue : t3)
     -> (filename : Optional String)
     -> JSIO ()
-  append1' a b c d = primJS $ FormData.prim__append1 a b (up c) (toFFI d)
-
+  append1' a b c d = primJS $ FormData.prim__append1 a b (cast c) (toFFI d)
+  
   export
   append1 :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Blob (Types t3)}
+       {auto _ : Cast t3 Blob}
     -> (obj : FormData)
     -> (name : String)
     -> (blobValue : t3)
     -> JSIO ()
-  append1 a b c = primJS $ FormData.prim__append1 a b (up c) undef
+  append1 a b c = primJS $ FormData.prim__append1 a b (cast c) undef
 
-
+  
   export
   delete : (obj : FormData) -> (name : String) -> JSIO ()
   delete a b = primJS $ FormData.prim__delete a b
 
-
+  
   export
   getAll :
        (obj : FormData)
@@ -61,7 +59,7 @@ namespace FormData
     -> JSIO (Array (Union2 File String))
   getAll a b = primJS $ FormData.prim__getAll a b
 
-
+  
   export
   get :
        (obj : FormData)
@@ -69,67 +67,64 @@ namespace FormData
     -> JSIO (Maybe (HSum [File, String]))
   get a b = tryJS "FormData.get" $ FormData.prim__get a b
 
-
+  
   export
   has : (obj : FormData) -> (name : String) -> JSIO Bool
   has a b = tryJS "FormData.has" $ FormData.prim__has a b
 
-
+  
   export
   set : (obj : FormData) -> (name : String) -> (value : String) -> JSIO ()
   set a b c = primJS $ FormData.prim__set a b c
 
-
+  
   export
   set1' :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Blob (Types t3)}
+       {auto _ : Cast t3 Blob}
     -> (obj : FormData)
     -> (name : String)
     -> (blobValue : t3)
     -> (filename : Optional String)
     -> JSIO ()
-  set1' a b c d = primJS $ FormData.prim__set1 a b (up c) (toFFI d)
-
+  set1' a b c d = primJS $ FormData.prim__set1 a b (cast c) (toFFI d)
+  
   export
   set1 :
-       {auto 0 _ : JSType t3}
-    -> {auto 0 _ : Elem Blob (Types t3)}
+       {auto _ : Cast t3 Blob}
     -> (obj : FormData)
     -> (name : String)
     -> (blobValue : t3)
     -> JSIO ()
-  set1 a b c = primJS $ FormData.prim__set1 a b (up c) undef
+  set1 a b c = primJS $ FormData.prim__set1 a b (cast c) undef
 
 
 
 namespace ProgressEvent
-
+  
   export
   new' :
-       {auto 0 _ : JSType t2}
-    -> {auto 0 _ : Elem ProgressEventInit (Types t2)}
+       {auto _ : Cast t2 ProgressEventInit}
     -> (type : String)
     -> (eventInitDict : Optional t2)
     -> JSIO ProgressEvent
   new' a b = primJS $ ProgressEvent.prim__new a (optUp b)
-
+  
   export
   new : (type : String) -> JSIO ProgressEvent
   new a = primJS $ ProgressEvent.prim__new a undef
 
-
+  
   export
   lengthComputable : (obj : ProgressEvent) -> JSIO Bool
   lengthComputable a = tryJS "ProgressEvent.lengthComputable" $
     ProgressEvent.prim__lengthComputable a
 
-
+  
   export
   loaded : (obj : ProgressEvent) -> JSIO JSBits64
   loaded a = primJS $ ProgressEvent.prim__loaded a
 
-
+  
   export
   total_ : (obj : ProgressEvent) -> JSIO JSBits64
   total_ a = primJS $ ProgressEvent.prim__total a
@@ -137,37 +132,37 @@ namespace ProgressEvent
 
 
 namespace XMLHttpRequest
-
-  public export
+  
+  export
   DONE : Bits16
   DONE = 4
 
-
-  public export
+  
+  export
   HEADERS_RECEIVED : Bits16
   HEADERS_RECEIVED = 2
 
-
-  public export
+  
+  export
   LOADING : Bits16
   LOADING = 3
 
-
-  public export
+  
+  export
   OPENED : Bits16
   OPENED = 1
 
-
-  public export
+  
+  export
   UNSENT : Bits16
   UNSENT = 0
 
-
+  
   export
   new : JSIO XMLHttpRequest
   new = primJS $ XMLHttpRequest.prim__new
 
-
+  
   export
   onreadystatechange :
        XMLHttpRequest
@@ -178,22 +173,22 @@ namespace XMLHttpRequest
                            prim__setOnreadystatechange
                            v
 
-
+  
   export
   readyState : (obj : XMLHttpRequest) -> JSIO Bits16
   readyState a = primJS $ XMLHttpRequest.prim__readyState a
 
-
+  
   export
   response : (obj : XMLHttpRequest) -> JSIO Any
   response a = tryJS "XMLHttpRequest.response" $ XMLHttpRequest.prim__response a
 
-
+  
   export
   responseText : (obj : XMLHttpRequest) -> JSIO String
   responseText a = primJS $ XMLHttpRequest.prim__responseText a
 
-
+  
   export
   responseType :
        XMLHttpRequest
@@ -204,28 +199,28 @@ namespace XMLHttpRequest
                      prim__setResponseType
                      v
 
-
+  
   export
   responseURL : (obj : XMLHttpRequest) -> JSIO String
   responseURL a = primJS $ XMLHttpRequest.prim__responseURL a
 
-
+  
   export
   responseXML : (obj : XMLHttpRequest) -> JSIO (Maybe Document)
   responseXML a = tryJS "XMLHttpRequest.responseXML" $
     XMLHttpRequest.prim__responseXML a
 
-
+  
   export
   status : (obj : XMLHttpRequest) -> JSIO Bits16
   status a = primJS $ XMLHttpRequest.prim__status a
 
-
+  
   export
   statusText : (obj : XMLHttpRequest) -> JSIO ByteString
   statusText a = primJS $ XMLHttpRequest.prim__statusText a
 
-
+  
   export
   timeout : XMLHttpRequest -> Attribute True Prelude.id Bits32
   timeout v = fromPrim
@@ -234,12 +229,12 @@ namespace XMLHttpRequest
                 prim__setTimeout
                 v
 
-
+  
   export
   upload : (obj : XMLHttpRequest) -> JSIO XMLHttpRequestUpload
   upload a = primJS $ XMLHttpRequest.prim__upload a
 
-
+  
   export
   withCredentials : XMLHttpRequest -> Attribute True Prelude.id Bool
   withCredentials v = fromPrim
@@ -248,18 +243,18 @@ namespace XMLHttpRequest
                         prim__setWithCredentials
                         v
 
-
+  
   export
   abort : (obj : XMLHttpRequest) -> JSIO ()
   abort a = primJS $ XMLHttpRequest.prim__abort a
 
-
+  
   export
   getAllResponseHeaders : (obj : XMLHttpRequest) -> JSIO ByteString
   getAllResponseHeaders a = primJS $
     XMLHttpRequest.prim__getAllResponseHeaders a
 
-
+  
   export
   getResponseHeader :
        (obj : XMLHttpRequest)
@@ -268,7 +263,7 @@ namespace XMLHttpRequest
   getResponseHeader a b = tryJS "XMLHttpRequest.getResponseHeader" $
     XMLHttpRequest.prim__getResponseHeader a b
 
-
+  
   export
   open_ :
        (obj : XMLHttpRequest)
@@ -277,7 +272,7 @@ namespace XMLHttpRequest
     -> JSIO ()
   open_ a b c = primJS $ XMLHttpRequest.prim__open a b c
 
-
+  
   export
   open1' :
        (obj : XMLHttpRequest)
@@ -289,7 +284,7 @@ namespace XMLHttpRequest
     -> JSIO ()
   open1' a b c d e f = primJS $
     XMLHttpRequest.prim__open1 a b c (toFFI d) (toFFI e) (toFFI f)
-
+  
   export
   open1 :
        (obj : XMLHttpRequest)
@@ -300,12 +295,12 @@ namespace XMLHttpRequest
   open1 a b c d = primJS $
     XMLHttpRequest.prim__open1 a b c (toFFI d) undef undef
 
-
+  
   export
   overrideMimeType : (obj : XMLHttpRequest) -> (mime : String) -> JSIO ()
   overrideMimeType a b = primJS $ XMLHttpRequest.prim__overrideMimeType a b
 
-
+  
   export
   send' :
        (obj : XMLHttpRequest)
@@ -331,12 +326,12 @@ namespace XMLHttpRequest
                        ])))
     -> JSIO ()
   send' a b = primJS $ XMLHttpRequest.prim__send a (toFFI b)
-
+  
   export
   send : (obj : XMLHttpRequest) -> JSIO ()
   send a = primJS $ XMLHttpRequest.prim__send a undef
 
-
+  
   export
   setRequestHeader :
        (obj : XMLHttpRequest)
@@ -348,96 +343,89 @@ namespace XMLHttpRequest
 
 
 namespace XMLHttpRequestEventTarget
-
+  
   export
   onabort :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onabort v = fromNullablePrim
                 "XMLHttpRequestEventTarget.getonabort"
                 prim__onabort
                 prim__setOnabort
-                (v :> XMLHttpRequestEventTarget)
+                (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   onerror :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onerror v = fromNullablePrim
                 "XMLHttpRequestEventTarget.getonerror"
                 prim__onerror
                 prim__setOnerror
-                (v :> XMLHttpRequestEventTarget)
+                (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   onload :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onload v = fromNullablePrim
                "XMLHttpRequestEventTarget.getonload"
                prim__onload
                prim__setOnload
-               (v :> XMLHttpRequestEventTarget)
+               (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   onloadend :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onloadend v = fromNullablePrim
                   "XMLHttpRequestEventTarget.getonloadend"
                   prim__onloadend
                   prim__setOnloadend
-                  (v :> XMLHttpRequestEventTarget)
+                  (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   onloadstart :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onloadstart v = fromNullablePrim
                     "XMLHttpRequestEventTarget.getonloadstart"
                     prim__onloadstart
                     prim__setOnloadstart
-                    (v :> XMLHttpRequestEventTarget)
+                    (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   onprogress :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   onprogress v = fromNullablePrim
                    "XMLHttpRequestEventTarget.getonprogress"
                    prim__onprogress
                    prim__setOnprogress
-                   (v :> XMLHttpRequestEventTarget)
+                   (cast {to = XMLHttpRequestEventTarget} v)
 
-
+  
   export
   ontimeout :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem XMLHttpRequestEventTarget (Types t)}
+       {auto _ : Cast t XMLHttpRequestEventTarget}
     -> t
     -> Attribute False Maybe EventHandlerNonNull
   ontimeout v = fromNullablePrim
                   "XMLHttpRequestEventTarget.getontimeout"
                   prim__ontimeout
                   prim__setOntimeout
-                  (v :> XMLHttpRequestEventTarget)
+                  (cast {to = XMLHttpRequestEventTarget} v)
 
 
 
@@ -449,7 +437,7 @@ namespace XMLHttpRequestEventTarget
 --------------------------------------------------------------------------------
 
 namespace ProgressEventInit
-
+  
   export
   new' :
        (lengthComputable : Optional Bool)
@@ -458,16 +446,15 @@ namespace ProgressEventInit
     -> JSIO ProgressEventInit
   new' a b c = primJS $
     ProgressEventInit.prim__new (toFFI a) (toFFI b) (toFFI c)
-
+  
   export
   new : JSIO ProgressEventInit
   new = primJS $ ProgressEventInit.prim__new undef undef undef
 
-
+  
   export
   lengthComputable :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ProgressEventInit (Types t)}
+       {auto _ : Cast t ProgressEventInit}
     -> t
     -> Attribute True Optional Bool
   lengthComputable v = fromUndefOrPrim
@@ -475,13 +462,12 @@ namespace ProgressEventInit
                          prim__lengthComputable
                          prim__setLengthComputable
                          False
-                         (v :> ProgressEventInit)
+                         (cast {to = ProgressEventInit} v)
 
-
+  
   export
   loaded :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ProgressEventInit (Types t)}
+       {auto _ : Cast t ProgressEventInit}
     -> t
     -> Attribute True Optional JSBits64
   loaded v = fromUndefOrPrim
@@ -489,13 +475,12 @@ namespace ProgressEventInit
                prim__loaded
                prim__setLoaded
                0
-               (v :> ProgressEventInit)
+               (cast {to = ProgressEventInit} v)
 
-
+  
   export
   total_ :
-       {auto 0 _ : JSType t}
-    -> {auto 0 _ : Elem ProgressEventInit (Types t)}
+       {auto _ : Cast t ProgressEventInit}
     -> t
     -> Attribute True Optional JSBits64
   total_ v = fromUndefOrPrim
@@ -503,4 +488,7 @@ namespace ProgressEventInit
                prim__total
                prim__setTotal
                0
-               (v :> ProgressEventInit)
+               (cast {to = ProgressEventInit} v)
+
+
+


### PR DESCRIPTION
I'm experimenting with compile-time slow downs when using idris2-dom, possibly due to too many `public export`s. A considerable amount of those come from the `JSType` implementations, which must be publicly exported, because they operate at the typelevel. With this PR, these are replaced by implementations of `Cast`.