### PR TITLE
[ doc ] fix some typos for tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ These have been moved to a separate library in the `js` directory.
 
 ### Documentation
 The tutorial consists of one or more literal Idris2 files to be
-found at `srd/Doc`. It can be built by running `idris2 --build doc.ipkg`
-and tested afterwards by loading `doc.html` in one's favorite browser.
+found at `docs/src`. It can be built by running `idris2 --build docs.ipkg`
+and tested afterwards by loading `docs.html` in one's favorite browser.
 
 ### Tests
 There is `js/test/test.ipkg` for running several Hedgehog property tests.
@@ -42,7 +42,7 @@ JavaScript utilities working on both JavaScript backends.
 
 ## Dependencies
 
-Packages `dom.ipkg`, `doc.ipkg` and `js.ipkg` depend on the following packages:
+Packages `dom.ipkg`, `docs.ipkg` and `js.ipkg` depend on the following packages:
 
 * [idris2-elab-util](https://github.com/stefan-hoeck/idris2-elab-util)
 * [idris2-sop](https://github.com/stefan-hoeck/idris2-sop)

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -3,6 +3,6 @@
   <meta charset='utf-8'>
  </head>
  <body>
-  <script type='text/javascript' src='build/exec/dom-doc.js'></script>
+  <script type='text/javascript' src='build/exec/dom-docs.js'></script>
  </body>
 </html>

--- a/docs/src/Tutorial.md
+++ b/docs/src/Tutorial.md
@@ -105,8 +105,8 @@ prog = do
 
 You can give this a try in the browser by replacing the
 `main` function in `Main` with `main = runJS Tutorial.prog`
-followed by building the `doc` package: `idris2 --build doc.ipkg`.
-Now, load the `doc.html` file in the project's root folder in your browser.
+followed by building the `docs` package: `idris2 --build docs.ipkg`.
+Now, load the `docs.html` file in the project's root folder in your browser.
 It will not look very nice, but it should behave as described.
 
 ## Step-by-step program walkthrough


### PR DESCRIPTION
With these changes, the tutorial instructions work.

I moved and renamed the `doc.html` file to `docs/docs.html` for consistency with the package name
